### PR TITLE
Add displayText function call for write-only display during voice (NAN-534)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -8,7 +8,7 @@ import { compactMessages } from '@/lib/compact'
 import { useCallSounds } from '@/lib/sounds'
 import { sendVapiChat, syncMessagesToVapi } from '@/lib/vapi-chat'
 import ExpoVapiModule from '@/modules/expo-vapi'
-import type { SpeechEvent, TranscriptEvent } from '@/modules/expo-vapi'
+import type { FunctionCallEvent, SpeechEvent, TranscriptEvent } from '@/modules/expo-vapi'
 import { Stack } from 'expo-router'
 import { MicIcon, MicOffIcon, PhoneOffIcon, PlusIcon, SendIcon } from 'lucide-react-native'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -29,7 +29,39 @@ talking. Acknowledge the request quickly ("On it, generating that now") and let 
 the background work complete asynchronously.
 
 When sharing images or URLs, include them as markdown (e.g. ![description](url)) \
-but never speak the URL aloud — just describe what you created or found.`
+but never speak the URL aloud — just describe what you created or found.
+
+## Display Tool
+
+You have a \`displayText\` function that writes content to the user's screen \
+WITHOUT it being spoken aloud. Use it for:
+- URLs, links, or code snippets
+- Long text the user asked you to write (emails, summaries, lists)
+- Image markdown (![desc](url))
+- Any content better read than heard
+
+After calling displayText, briefly tell the user verbally, e.g. "I've put that \
+on your screen" or "Check your display". Keep the spoken part short — the detail \
+is on screen.`
+
+const DISPLAY_TEXT_FUNCTION = {
+  name: 'displayText',
+  description: 'Write content to the user\'s screen without it being spoken aloud by TTS. Use for URLs, code, long text, images, or anything better read than heard.',
+  parameters: {
+    type: 'object',
+    properties: {
+      text: {
+        type: 'string',
+        description: 'The content to display. Supports markdown including image syntax ![alt](url).',
+      },
+      title: {
+        type: 'string',
+        description: 'Optional short title shown above the content.',
+      },
+    },
+    required: ['text'],
+  },
+}
 
 type ContentPart = { type: 'text', text: string } | { type: 'image', url: string, alt: string }
 
@@ -96,6 +128,24 @@ export default function ChatScreen() {
         if (event.role === 'user') {
           setIsThinking(true)
           soundsRef.current.startThinking()
+        }
+      }),
+      ExpoVapiModule.addListener('onFunctionCall', async (event: FunctionCallEvent) => {
+        if (event.name === 'displayText' && conversationId) {
+          const text = (event.parameters.text as string) || ''
+          const title = event.parameters.title as string | undefined
+          const displayContent = title ? `**${title}**\n\n${text}` : text
+          await addMessage(conversationId, 'assistant', displayContent)
+          loadMessages()
+
+          try {
+            await ExpoVapiModule.sendFunctionCallResult(
+              'displayText',
+              JSON.stringify({ status: 'displayed', length: text.length })
+            )
+          } catch (e) {
+            console.warn('[DisplayText] Failed to send function call result:', e)
+          }
         }
       }),
       ExpoVapiModule.addListener('onError', async (event) => {
@@ -220,12 +270,22 @@ export default function ChatScreen() {
       server: { timeoutSeconds: 45 },
       silenceTimeoutSeconds: 120,
       endCallPhrases: [],
+      clientMessages: [
+        'transcript',
+        'hang',
+        'function-call',
+        'speech-update',
+        'status-update',
+        'conversation-update',
+        'model-output',
+      ],
       firstMessage: modelMessages.length > 1 ? 'Welcome back :)' : undefined,
       model: {
         url: apiUrl,
         provider: 'custom-llm',
         model,
         messages: modelMessages,
+        functions: [DISPLAY_TEXT_FUNCTION],
       },
     }
 

--- a/modules/expo-vapi/ios/ExpoVapiModule.swift
+++ b/modules/expo-vapi/ios/ExpoVapiModule.swift
@@ -16,6 +16,7 @@ public class ExpoVapiModule: Module {
       "onTranscript",
       "onSpeechStart",
       "onSpeechEnd",
+      "onFunctionCall",
       "onError"
     )
 
@@ -58,6 +59,14 @@ public class ExpoVapiModule: Module {
       let message = VapiMessage(type: "add-message", role: "user", content: content)
       try await self.vapi?.send(message: message)
     }
+
+    AsyncFunction("sendFunctionCallResult") { (name: String, result: String) in
+      guard let vapi = self.vapi else {
+        throw Exception(name: "ERR_NOT_INITIALIZED", description: "Call initialize() first")
+      }
+      let message = VapiFunctionCallResultMessage(name: name, result: result)
+      try await vapi.sendRaw(message: message)
+    }
   }
 
   private func subscribeToEvents() {
@@ -66,56 +75,77 @@ public class ExpoVapiModule: Module {
     vapi.eventPublisher
       .receive(on: DispatchQueue.main)
       .sink { [weak self] event in
-        guard let self = self else { return }
-
-        switch event {
-        case .callDidStart:
-          self.callActive = true
-          self.sendEvent("onCallStart", [:])
-
-        case .callDidEnd:
-          self.callActive = false
-          self.micMuted = false
-          self.sendEvent("onCallEnd", [:])
-
-        case .transcript(let transcript):
-          self.sendEvent("onTranscript", [
-            "role": transcript.role == .user ? "user" : "assistant",
-            "text": transcript.transcript,
-            "type": transcript.transcriptType == .final ? "final" : "partial"
-          ])
-
-        case .speechUpdate(let update):
-          let role = update.role == .user ? "user" : "assistant"
-          if update.status == .started {
-            self.sendEvent("onSpeechStart", ["role": role])
-          } else {
-            self.sendEvent("onSpeechEnd", ["role": role])
-          }
-
-        case .error(let error):
-          print("[Vapi] Error: \(error.localizedDescription)")
-          self.sendEvent("onError", [
-            "message": error.localizedDescription
-          ])
-
-        case .hang:
-          print("[Vapi] Hang event received (not ending call — letting server handle disconnect)")
-
-        case .statusUpdate(let status):
-          print("[Vapi] Status: \(status.status)")
-
-        case .conversationUpdate(let update):
-          print("[Vapi] Conversation updated: \(update.conversation.count) messages")
-
-        case .modelOutput(let output):
-          print("[Vapi] Model output: \(output.output.prefix(100))")
-
-        default:
-          print("[Vapi] Unhandled event: \(event)")
-          break
-        }
+        self?.handleVapiEvent(event)
       }
       .store(in: &cancellables)
+  }
+
+  private func handleVapiEvent(_ event: Vapi.Event) {
+    switch event {
+    case .callDidStart:
+      self.callActive = true
+      self.sendEvent("onCallStart", [:])
+
+    case .callDidEnd:
+      self.callActive = false
+      self.micMuted = false
+      self.sendEvent("onCallEnd", [:])
+
+    case .transcript(let transcript):
+      self.handleTranscript(transcript)
+
+    case .speechUpdate(let update):
+      self.handleSpeechUpdate(update)
+
+    case .functionCall(let functionCall):
+      self.handleFunctionCall(functionCall)
+
+    case .error(let error):
+      print("[Vapi] Error: \(error.localizedDescription)")
+      self.sendEvent("onError", ["message": error.localizedDescription])
+
+    case .hang:
+      print("[Vapi] Hang event received (not ending call — letting server handle disconnect)")
+
+    case .statusUpdate(let status):
+      print("[Vapi] Status: \(status.status)")
+
+    case .conversationUpdate(let update):
+      print("[Vapi] Conversation updated: \(update.conversation.count) messages")
+
+    case .modelOutput(let output):
+      print("[Vapi] Model output: \(output.output.prefix(100))")
+
+    default:
+      print("[Vapi] Unhandled event: \(event)")
+    }
+  }
+
+  private func handleTranscript(_ transcript: Transcript) {
+    self.sendEvent("onTranscript", [
+      "role": transcript.role == .user ? "user" : "assistant",
+      "text": transcript.transcript,
+      "type": transcript.transcriptType == .final ? "final" : "partial"
+    ])
+  }
+
+  private func handleSpeechUpdate(_ update: SpeechUpdate) {
+    let role = update.role == .user ? "user" : "assistant"
+    if update.status == .started {
+      self.sendEvent("onSpeechStart", ["role": role])
+    } else {
+      self.sendEvent("onSpeechEnd", ["role": role])
+    }
+  }
+
+  private func handleFunctionCall(_ functionCall: FunctionCall) {
+    var params: [String: Any] = [:]
+    for (key, value) in functionCall.parameters {
+      params[key] = value
+    }
+    self.sendEvent("onFunctionCall", [
+      "name": functionCall.name,
+      "parameters": params
+    ])
   }
 }

--- a/modules/expo-vapi/ios/Vapi/Vapi.swift
+++ b/modules/expo-vapi/ios/Vapi/Vapi.swift
@@ -19,6 +19,26 @@ public struct VapiMessage: Encodable {
     }
 }
 
+// Function call result message sent back to Vapi when a client-side function call completes
+public struct VapiFunctionCallResultMessage: Encodable {
+    public let type = "function-call-result"
+    public let functionCallResult: FunctionCallResult
+
+    public struct FunctionCallResult: Encodable {
+        public let forwardToClientEnabled: Bool
+        public let result: String
+        public let name: String
+    }
+
+    public init(name: String, result: String) {
+        self.functionCallResult = FunctionCallResult(
+            forwardToClientEnabled: false,
+            result: result,
+            name: name
+        )
+    }
+}
+
 public final class Vapi: CallClientDelegate {
     
     // MARK: - Supporting Types
@@ -162,12 +182,12 @@ public final class Vapi: CallClientDelegate {
         do {
           // Use JSONEncoder to convert the message to JSON Data
           let jsonData = try JSONEncoder().encode(message)
-          
+
           // Debugging: Print the JSON data to verify its format (optional)
           if let jsonString = String(data: jsonData, encoding: .utf8) {
               print(jsonString)
           }
-          
+
           // Send the JSON data to all targets
           try await self.call?.sendAppMessage(json: jsonData, to: .all)
       } catch {
@@ -175,6 +195,19 @@ public final class Vapi: CallClientDelegate {
           print("Error encoding message to JSON: \(error)")
           throw error // Re-throw the error to be handled by the caller
       }
+    }
+
+    public func sendRaw<T: Encodable>(message: T) async throws {
+        do {
+            let jsonData = try JSONEncoder().encode(message)
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                print("[Vapi] Sending raw message: \(jsonString)")
+            }
+            try await self.call?.sendAppMessage(json: jsonData, to: .all)
+        } catch {
+            print("Error encoding raw message to JSON: \(error)")
+            throw error
+        }
     }
 
     public func setMuted(_ muted: Bool) async throws {

--- a/modules/expo-vapi/src/ExpoVapi.types.ts
+++ b/modules/expo-vapi/src/ExpoVapi.types.ts
@@ -8,6 +8,11 @@ export type SpeechEvent = {
   role: 'user' | 'assistant'
 }
 
+export type FunctionCallEvent = {
+  name: string
+  parameters: Record<string, unknown>
+}
+
 export type ErrorEvent = {
   message: string
 }
@@ -23,5 +28,6 @@ export type ExpoVapiModuleEvents = {
   onTranscript: (event: TranscriptEvent) => void
   onSpeechStart: (event: SpeechEvent) => void
   onSpeechEnd: (event: SpeechEvent) => void
+  onFunctionCall: (event: FunctionCallEvent) => void
   onError: (event: ErrorEvent) => void
 }

--- a/modules/expo-vapi/src/ExpoVapiModule.ts
+++ b/modules/expo-vapi/src/ExpoVapiModule.ts
@@ -10,6 +10,7 @@ declare class ExpoVapiModule extends NativeModule<ExpoVapiModuleEvents> {
   isCallActive(): boolean
   isMuted(): boolean
   sendMessage(content: string): Promise<void>
+  sendFunctionCallResult(name: string, result: string): Promise<void>
 }
 
 export default requireNativeModule<ExpoVapiModule>('ExpoVapi')


### PR DESCRIPTION
## Summary
- Implements a `displayText` client-side function that the voice agent can call to write content to the chat screen **without** TTS reading it aloud
- Uses Vapi's `function-call` / `function-call-result` mechanism: the LLM calls `displayText`, Vapi sends a `function-call` event to the client, the app writes to the chat DB and sends a result back
- Updates the voice system prompt to instruct the model when and how to use `displayText` (URLs, code, long text, images)

## Changes
- **`modules/expo-vapi/ios/Vapi/Vapi.swift`** -- Added `VapiFunctionCallResultMessage` struct and `sendRaw<T: Encodable>()` method for sending arbitrary typed messages back to Vapi
- **`modules/expo-vapi/ios/ExpoVapiModule.swift`** -- Added `onFunctionCall` event, `sendFunctionCallResult` async function, and refactored event handling into smaller methods to reduce cyclomatic complexity
- **`modules/expo-vapi/src/ExpoVapi.types.ts`** -- Added `FunctionCallEvent` type and `onFunctionCall` to module events
- **`modules/expo-vapi/src/ExpoVapiModule.ts`** -- Added `sendFunctionCallResult()` method declaration
- **`app/(tabs)/index.tsx`** -- Added `DISPLAY_TEXT_FUNCTION` definition, `onFunctionCall` listener that writes to chat DB and sends result back, `clientMessages` override to enable `function-call` events, and updated `VOICE_SYSTEM_PROMPT` with display tool instructions

## How it works
1. When starting a voice call, the `displayText` function is passed in `model.functions` via assistant overrides
2. The custom LLM (OpenClaw) sees the function definition and can call it when appropriate
3. Vapi intercepts the tool call and sends a `function-call` event to the client SDK
4. The native Swift module forwards it as an `onFunctionCall` event to JavaScript
5. The React chat screen writes the content to the local SQLite DB and displays it as a normal message bubble
6. A `function-call-result` is sent back to Vapi so the model knows the content was displayed
7. The model then speaks a brief verbal acknowledgment (e.g., "Check your screen")

## Test plan
- [ ] Start a voice call and ask the agent to share a URL or write something long
- [ ] Verify the content appears on screen as a chat bubble without being spoken
- [ ] Verify the agent verbally acknowledges the display ("I've put that on your screen")
- [ ] Verify normal transcripts still work alongside function call messages
- [ ] Verify text chat mode is unaffected by the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)