### PR TITLE
Fix microphone: remove expo-audio audio session conflict

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -126,6 +126,7 @@ export default function ChatScreen() {
   useEffect(() => {
     const subs = [
       ExpoVapiModule.addListener('onCallStart', () => {
+        console.log('[Chat] onCallStart fired')
         setIsCallActive(true)
         setIsConnecting(false)
         wasCallActiveRef.current = true
@@ -133,6 +134,7 @@ export default function ChatScreen() {
         soundsRef.current.playJoin()
       }),
       ExpoVapiModule.addListener('onCallEnd', async () => {
+        console.log('[Chat] onCallEnd fired')
         const wasActive = wasCallActiveRef.current
         const wasUserInitiated = userInitiatedEndRef.current
         setIsCallActive(false)
@@ -156,6 +158,7 @@ export default function ChatScreen() {
         }
       }),
       ExpoVapiModule.addListener('onTranscript', async (event: TranscriptEvent) => {
+        console.log('[Chat] onTranscript:', event.role, event.type, event.text?.substring(0, 50))
         if (event.type === 'final' && conversationId) {
           await addMessage(conversationId, event.role, event.text)
           loadMessages()
@@ -352,8 +355,8 @@ export default function ChatScreen() {
         model,
         messages: modelMessages,
         functions: [DISPLAY_TEXT_FUNCTION],
-        user: `voiceclaw:${conversationId}`,
       },
+      metadata: { conversationId: `voiceclaw:${conversationId}` },
     }
 
     const callOverrides = Object.keys(overrides).length > 0 ? overrides : undefined

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -6,7 +6,7 @@ import { Text } from '@/components/ui/text'
 import { getSetting, setSetting } from '@/db'
 import { EyeIcon, EyeOffIcon } from 'lucide-react-native'
 import { useEffect, useState } from 'react'
-import { Alert, KeyboardAvoidingView, Platform, Pressable, ScrollView, TextInput, View } from 'react-native'
+import { Alert, Keyboard, KeyboardAvoidingView, Platform, Pressable, ScrollView, TextInput, TouchableWithoutFeedback, View } from 'react-native'
 
 function SecretInput({
   value,
@@ -87,7 +87,7 @@ export default function SettingsScreen() {
       className="flex-1 bg-background"
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       keyboardVerticalOffset={90}>
-      <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }}>
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }} keyboardDismissMode="on-drag" keyboardShouldPersistTaps="handled">
         <Card className="gap-4 p-4">
           <Text className="text-lg font-semibold text-foreground">Vapi Configuration</Text>
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,7 +5,6 @@ import { ConversationProvider } from '@/lib/conversation-context'
 import { NAV_THEME } from '@/lib/theme'
 import { ThemeProvider } from '@react-navigation/native'
 import { PortalHost } from '@rn-primitives/portal'
-import { setAudioModeAsync } from 'expo-audio'
 import { Stack } from 'expo-router'
 import * as SplashScreen from 'expo-splash-screen'
 import { StatusBar } from 'expo-status-bar'
@@ -25,11 +24,6 @@ export default function RootLayout() {
   const [dbReady, setDbReady] = useState(false)
 
   useEffect(() => {
-    setAudioModeAsync({
-      playsInSilentMode: true,
-      interruptionMode: 'mixWithOthers',
-    }).catch(console.warn)
-
     runMigrations()
       .then(() => setDbReady(true))
       .then(() => SplashScreen.hideAsync())

--- a/lib/sounds.ts
+++ b/lib/sounds.ts
@@ -1,45 +1,11 @@
-import { useAudioPlayer } from 'expo-audio'
-import { useCallback, useEffect, useRef } from 'react'
-
-const joinSound = require('@/assets/sounds/call-join.wav')
-const endSound = require('@/assets/sounds/call-end.wav')
-const thinkingSound = require('@/assets/sounds/thinking.wav')
+// Sounds temporarily disabled to debug microphone/audio session conflict with Daily.co
+// TODO: Re-enable with expo-audio once the audio session conflict is resolved
 
 export function useCallSounds() {
-  const joinPlayer = useAudioPlayer(joinSound)
-  const endPlayer = useAudioPlayer(endSound)
-  const thinkingPlayer = useAudioPlayer(thinkingSound)
-  const thinkingActive = useRef(false)
-
-  useEffect(() => {
-    joinPlayer.volume = 0.4
-    endPlayer.volume = 0.3
-    thinkingPlayer.volume = 0.15
-    thinkingPlayer.loop = true
-  }, [joinPlayer, endPlayer, thinkingPlayer])
-
-  const playJoin = useCallback(() => {
-    joinPlayer.seekTo(0)
-    joinPlayer.play()
-  }, [joinPlayer])
-
-  const playEnd = useCallback(() => {
-    endPlayer.seekTo(0)
-    endPlayer.play()
-  }, [endPlayer])
-
-  const startThinking = useCallback(() => {
-    if (thinkingActive.current) return
-    thinkingActive.current = true
-    thinkingPlayer.seekTo(0)
-    thinkingPlayer.play()
-  }, [thinkingPlayer])
-
-  const stopThinking = useCallback(() => {
-    if (!thinkingActive.current) return
-    thinkingActive.current = false
-    thinkingPlayer.pause()
-  }, [thinkingPlayer])
-
-  return { playJoin, playEnd, startThinking, stopThinking }
+  return {
+    playJoin: () => {},
+    playEnd: () => {},
+    startThinking: () => {},
+    stopThinking: () => {},
+  }
 }

--- a/modules/expo-vapi/ios/ExpoVapiModule.swift
+++ b/modules/expo-vapi/ios/ExpoVapiModule.swift
@@ -21,8 +21,10 @@ public class ExpoVapiModule: Module {
     )
 
     AsyncFunction("initialize") { (publicKey: String) in
+      print("[ExpoVapi] Initializing with key: \(publicKey.prefix(8))...")
       self.vapi = Vapi(publicKey: publicKey)
       self.subscribeToEvents()
+      print("[ExpoVapi] Initialized and subscribed to events")
     }
 
     AsyncFunction("startCall") { (assistantId: String, overrides: [String: Any]?) -> [String: Any] in
@@ -30,11 +32,15 @@ public class ExpoVapiModule: Module {
         throw Exception(name: "ERR_NOT_INITIALIZED", description: "Call initialize() first")
       }
 
+      print("[ExpoVapi] Starting call with assistantId: \(assistantId)")
+      print("[ExpoVapi] Overrides: \(String(describing: overrides))")
+
       let response = try await vapi.start(
         assistantId: assistantId,
         assistantOverrides: overrides ?? [:]
       )
 
+      print("[ExpoVapi] Call started with id: \(response.id)")
       return ["callId": response.id, "status": "started"]
     }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "expo": "^55.0.0",
-    "expo-audio": "^55.0.9",
     "expo-constants": "~55.0.7",
     "expo-linking": "~55.0.7",
     "expo-router": "~55.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2949,11 +2949,6 @@ expo-asset@~55.0.10:
     "@expo/image-utils" "^0.8.12"
     expo-constants "~55.0.9"
 
-expo-audio@^55.0.9:
-  version "55.0.9"
-  resolved "https://registry.yarnpkg.com/expo-audio/-/expo-audio-55.0.9.tgz#b580e26f5f50c9872fa751b0e4ebd57e135353ef"
-  integrity sha512-3SsyjwrupXRBbOoDjD5rcqgGnQ5RiB8z4KF1eel88q4z8yue7NKik2o9e3QBMDKLX7xnbJo673ah14BKnF9OVA==
-
 expo-constants@~55.0.7, expo-constants@~55.0.8, expo-constants@~55.0.9:
   version "55.0.9"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-55.0.9.tgz#73eda44cdc8198ba1eb83972f14c5aec9bc68e35"


### PR DESCRIPTION
## Summary

- **Root cause**: `expo-audio` was hijacking the iOS audio session from Daily.co's WebRTC stack. It set `AVAudioSessionCategoryPlayback` (playback only), but Daily.co needs `AVAudioSessionCategoryPlayAndRecord` to capture microphone input.
- **Symptom**: All Vapi voice calls ended with `silence-timed-out` — STT received no audio, assistant never responded.
- **Fix**: Remove `expo-audio` entirely and stub out the `useCallSounds` hook. Sounds will be re-enabled once we configure `expo-audio` with `playAndRecord` category.

## Changes

- Remove `expo-audio` dependency
- Stub `useCallSounds` hook (no-op functions)
- Remove `setAudioModeAsync` from app startup (`_layout.tsx`)
- Add debug logging to `ExpoVapiModule.swift` for call lifecycle
- Fix keyboard dismiss on Settings screen (`keyboardDismissMode`)
- Fix Vapi override: move `user` field to `metadata` (Vapi rejects `user` in model overrides)

## Debugging journey

1. Calls connected (got call ID from Vapi API) but no transcripts appeared
2. Vapi dashboard showed all calls ending with `silence-timed-out` — zero audio reaching Deepgram
3. Added JS logging — confirmed `onCallStart` fired but no `onTranscript` events
4. Traced to `expo-audio` (added in NAN-545 call sounds feature) — removing it restored mic functionality
5. iOS only allows one audio session config at a time; `expo-audio`'s playback-only category overrode Daily.co's play-and-record category

## Next steps

Re-enable sounds by configuring `expo-audio` with `AVAudioSessionCategoryPlayAndRecord` instead of the default playback category.

## Test plan

- [ ] Start a voice call — mic should be picked up, transcripts should appear
- [ ] Assistant should respond with voice audio
- [ ] Text chat still works
- [ ] Settings keyboard dismisses on scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)