### PR TITLE
Group conversations by date in history list

### DIFF
--- a/app/(tabs)/history.tsx
+++ b/app/(tabs)/history.tsx
@@ -4,13 +4,20 @@ import { Text } from '@/components/ui/text'
 import { deleteAllConversations, deleteConversation, getConversationsWithPreview, type ConversationWithPreview } from '@/db'
 import { useConversationContext } from '@/lib/conversation-context'
 import { useRouter } from 'expo-router'
-import { useCallback, useEffect, useState } from 'react'
-import { Alert, FlatList, Pressable, View } from 'react-native'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Alert, Pressable, SectionList, View } from 'react-native'
+
+type ConversationSection = {
+  title: string
+  data: ConversationWithPreview[]
+}
 
 export default function HistoryScreen() {
   const [conversations, setConversations] = useState<ConversationWithPreview[]>([])
   const { selectConversation } = useConversationContext()
   const router = useRouter()
+
+  const sections = useMemo(() => groupConversationsByDate(conversations), [conversations])
 
   const loadConversations = useCallback(async () => {
     const result = await getConversationsWithPreview()
@@ -81,34 +88,42 @@ export default function HistoryScreen() {
 
   return (
     <View className="flex-1 bg-background">
-      <FlatList
-        data={conversations}
+      <SectionList
+        sections={sections}
         keyExtractor={(item) => item.id.toString()}
-        contentContainerStyle={{ padding: 16, gap: 8 }}
+        contentContainerStyle={{ padding: 16 }}
+        stickySectionHeadersEnabled
         ListHeaderComponent={
           <Pressable onPress={handleClearAll} className="mb-2 self-end">
             <Text className="text-sm font-medium text-destructive">Clear All</Text>
           </Pressable>
         }
+        renderSectionHeader={({ section: { title } }) => (
+          <View className="bg-background pb-2 pt-4">
+            <Text className="text-sm font-semibold text-muted-foreground">{title}</Text>
+          </View>
+        )}
         renderItem={({ item }) => (
-          <SwipeableRow onDelete={() => handleDelete(item.id, getDisplayTitle(item))}>
-            <Pressable onPress={() => handleTap(item.id)}>
-            <Card className="p-4">
-              <Text className="text-base font-medium text-foreground" numberOfLines={1}>
-                {getDisplayTitle(item)}
-              </Text>
-              {item.preview && (
-                <Text className="mt-1 text-sm text-muted-foreground" numberOfLines={2}>
-                  {item.preview}
-                </Text>
-              )}
-              <Text className="mt-1 text-xs text-muted-foreground">
-                {formatDate(item.updated_at)}
-                {item.message_count > 0 ? ` \u00B7 ${item.message_count} message${item.message_count === 1 ? '' : 's'}` : ''}
-              </Text>
-            </Card>
-            </Pressable>
-          </SwipeableRow>
+          <View className="py-1">
+            <SwipeableRow onDelete={() => handleDelete(item.id, getDisplayTitle(item))}>
+              <Pressable onPress={() => handleTap(item.id)}>
+                <Card className="p-4">
+                  <Text className="text-base font-medium text-foreground" numberOfLines={1}>
+                    {getDisplayTitle(item)}
+                  </Text>
+                  {item.preview && (
+                    <Text className="mt-1 text-sm text-muted-foreground" numberOfLines={2}>
+                      {item.preview}
+                    </Text>
+                  )}
+                  <Text className="mt-1 text-xs text-muted-foreground">
+                    {formatDate(item.updated_at)}
+                    {item.message_count > 0 ? ` \u00B7 ${item.message_count} message${item.message_count === 1 ? '' : 's'}` : ''}
+                  </Text>
+                </Card>
+              </Pressable>
+            </SwipeableRow>
+          </View>
         )}
       />
     </View>
@@ -116,6 +131,37 @@ export default function HistoryScreen() {
 }
 
 // --- Helper Functions ---
+
+function groupConversationsByDate(conversations: ConversationWithPreview[]): ConversationSection[] {
+  const now = new Date()
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime()
+  const yesterdayStart = todayStart - 86_400_000
+
+  const groups = new Map<string, ConversationWithPreview[]>()
+
+  for (const conversation of conversations) {
+    const label = getDateLabel(conversation.updated_at, todayStart, yesterdayStart)
+    const existing = groups.get(label)
+    if (existing) {
+      existing.push(conversation)
+    } else {
+      groups.set(label, [conversation])
+    }
+  }
+
+  return Array.from(groups, ([title, data]) => ({ title, data }))
+}
+
+function getDateLabel(timestamp: number, todayStart: number, yesterdayStart: number): string {
+  if (timestamp >= todayStart) return 'Today'
+  if (timestamp >= yesterdayStart) return 'Yesterday'
+
+  return new Date(timestamp).toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  })
+}
 
 function getDisplayTitle(conversation: ConversationWithPreview): string {
   if (conversation.title && conversation.title !== 'New Conversation') {


### PR DESCRIPTION
## Summary
- Replace `FlatList` with `SectionList` in the history screen to group conversations under date headers
- Conversations are grouped as "Today", "Yesterday", or formatted as "Mon, Mar 23" for older dates
- Section headers are sticky while scrolling for easy orientation

Closes NAN-564

## Test plan
- [ ] Open the history tab with conversations spanning multiple days
- [ ] Verify "Today" and "Yesterday" headers appear correctly
- [ ] Verify older conversations show weekday + date format (e.g. "Mon, Mar 23")
- [ ] Verify section headers stick to the top while scrolling
- [ ] Verify swipe-to-delete and tap-to-open still work on conversation cards
- [ ] Verify "Clear All" button still functions
- [ ] Run `npx tsc --noEmit` to confirm TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)