### PR TITLE
NAN-569: Resume last conversation on app launch

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button'
 import { Icon } from '@/components/ui/icon'
 import { Input } from '@/components/ui/input'
 import { Text } from '@/components/ui/text'
-import { addMessage, createConversation, getConversation, getMessages, getSetting, updateConversationVapi, type Message } from '@/db'
+import { addMessage, createConversation, getConversation, getLatestConversation, getMessages, getSetting, updateConversationVapi, type Message } from '@/db'
 import { getApiConfig, streamCompletion } from '@/lib/chat'
 import { compactMessages } from '@/lib/compact'
 import { useConversationContext } from '@/lib/conversation-context'
@@ -231,9 +231,18 @@ export default function ChatScreen() {
     }
   }, [selectedConversationId, loadConversation, clearSelection])
 
-  // Create a new conversation on first mount only
+  // Resume the most recent conversation on first mount, or create a new one if none exist
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => { startNewConversation() }, [])
+  useEffect(() => {
+    (async () => {
+      const latest = await getLatestConversation()
+      if (latest) {
+        loadConversation(latest.id)
+      } else {
+        startNewConversation()
+      }
+    })()
+  }, [])
 
   const loadMessages = useCallback(async () => {
     if (!conversationId) return

--- a/db/conversations.ts
+++ b/db/conversations.ts
@@ -30,6 +30,10 @@ export type ConversationWithPreview = Conversation & {
   message_count: number
 }
 
+export async function getLatestConversation(): Promise<Conversation | null> {
+  return db.getFirstAsync<Conversation>('SELECT * FROM conversations ORDER BY updated_at DESC LIMIT 1')
+}
+
 export async function getConversations(): Promise<Conversation[]> {
   return db.getAllAsync<Conversation>('SELECT * FROM conversations ORDER BY updated_at DESC')
 }

--- a/db/index.ts
+++ b/db/index.ts
@@ -1,5 +1,6 @@
 export {
   createConversation,
+  getLatestConversation,
   getConversations,
   getConversationsWithPreview,
   getConversation,


### PR DESCRIPTION
## Summary
- On app launch, load the most recent conversation from the DB instead of always creating a new empty one
- Added `getLatestConversation()` helper to `db/conversations.ts` that returns the most recently updated conversation
- If no conversations exist, falls back to creating a new one (preserving current behavior for first-time users)
- The + button still creates a fresh conversation as before

## Test plan
- [ ] Launch the app with existing conversations -- should show the most recent one
- [ ] Launch the app with no conversations -- should create a new one
- [ ] Tap the + button -- should still create a fresh conversation
- [ ] Verify conversation history tab still works correctly when selecting a conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)