### PR TITLE
Accumulate transcripts per speech turn into single message bubbles

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -8,6 +8,7 @@ import { compactMessages } from '@/lib/compact'
 import { useConversationContext } from '@/lib/conversation-context'
 import { maybeGenerateTitle } from '@/lib/title'
 import { useCallSounds } from '@/lib/sounds'
+import { useTranscriptBuffer } from '@/lib/use-transcript-buffer'
 import { useAutoReconnect } from '@/lib/use-auto-reconnect'
 import { sendVapiChat, syncMessagesToVapi } from '@/lib/vapi-chat'
 import ExpoVapiModule from '@/modules/expo-vapi'
@@ -89,6 +90,9 @@ export default function ChatScreen() {
   const wasCallActiveRef = useRef(false)
   const lastCallOverridesRef = useRef<Record<string, unknown> | null>(null)
   const lastAssistantIdRef = useRef<string | null>(null)
+  const transcriptBuffer = useTranscriptBuffer()
+  const transcriptBufferRef = useRef(transcriptBuffer)
+  transcriptBufferRef.current = transcriptBuffer
 
   const reconnectCall = useCallback(async () => {
     const assistantId = lastAssistantIdRef.current
@@ -137,6 +141,20 @@ export default function ChatScreen() {
         console.log('[Chat] onCallEnd fired')
         const wasActive = wasCallActiveRef.current
         const wasUserInitiated = userInitiatedEndRef.current
+
+        // Flush any in-progress transcript buffers before cleanup
+        if (conversationId) {
+          const pending = transcriptBufferRef.current.flushAll()
+          for (const { role, text } of pending) {
+            console.log('[Chat] Flushing buffered transcript on call end:', role, text.substring(0, 50))
+            await addMessage(conversationId, role, text)
+          }
+          if (pending.length > 0) {
+            loadMessages()
+            maybeGenerateTitle(conversationId)
+          }
+        }
+
         setIsCallActive(false)
         setIsMuted(false)
         setIsThinking(false)
@@ -157,21 +175,26 @@ export default function ChatScreen() {
           }
         }
       }),
-      ExpoVapiModule.addListener('onTranscript', async (event: TranscriptEvent) => {
+      ExpoVapiModule.addListener('onTranscript', (event: TranscriptEvent) => {
         console.log('[Chat] onTranscript:', event.role, event.type, event.text?.substring(0, 50))
-        if (event.type === 'final' && conversationId) {
-          await addMessage(conversationId, event.role, event.text)
-          loadMessages()
-          maybeGenerateTitle(conversationId)
+        if (event.type === 'final') {
+          transcriptBufferRef.current.onTranscriptFinal(event.role, event.text)
         }
       }),
       ExpoVapiModule.addListener('onSpeechStart', (event: SpeechEvent) => {
+        transcriptBufferRef.current.onSpeechStart(event.role)
         if (event.role === 'assistant') {
           setIsThinking(false)
           soundsRef.current.stopThinking()
         }
       }),
-      ExpoVapiModule.addListener('onSpeechEnd', (event: SpeechEvent) => {
+      ExpoVapiModule.addListener('onSpeechEnd', async (event: SpeechEvent) => {
+        const fullText = transcriptBufferRef.current.onSpeechEnd(event.role)
+        if (fullText && conversationId) {
+          await addMessage(conversationId, event.role, fullText)
+          loadMessages()
+          maybeGenerateTitle(conversationId)
+        }
         if (event.role === 'user') {
           setIsThinking(true)
           soundsRef.current.startThinking()
@@ -385,6 +408,8 @@ export default function ChatScreen() {
     ? [...messages, { id: -1, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: streamingText, created_at: Date.now() }]
     : messages
 
+  const { partials } = transcriptBuffer
+
   return (
     <KeyboardAvoidingView
       className="flex-1 bg-background"
@@ -412,6 +437,15 @@ export default function ChatScreen() {
             <Text className="text-lg text-muted-foreground">Start a conversation</Text>
             <Text className="mt-1 text-sm text-muted-foreground">Type a message or tap the mic to speak</Text>
           </View>
+        }
+        ListFooterComponent={
+          partials.length > 0 ? (
+            <View>
+              {partials.map((p) => (
+                <PartialBubble key={p.role} role={p.role} text={p.text} />
+              ))}
+            </View>
+          ) : null
         }
       />
 
@@ -492,6 +526,23 @@ export default function ChatScreen() {
 }
 
 // --- Helper Components ---
+
+function PartialBubble({ role, text }: { role: 'user' | 'assistant', text: string }) {
+  const isUser = role === 'user'
+  return (
+    <View className={`mb-3 px-4 ${isUser ? 'items-end' : 'items-start'}`}>
+      <View
+        className={`max-w-[80%] rounded-2xl px-4 py-3 ${
+          isUser ? 'rounded-br-sm bg-primary/60' : 'rounded-bl-sm bg-muted/60'
+        }`}>
+        <Text
+          className={`text-sm italic ${isUser ? 'text-primary-foreground/70' : 'text-muted-foreground'}`}>
+          {text}
+        </Text>
+      </View>
+    </View>
+  )
+}
 
 function ChatImage({ url }: { url: string }) {
   const [loading, setLoading] = useState(true)

--- a/lib/use-transcript-buffer.ts
+++ b/lib/use-transcript-buffer.ts
@@ -1,0 +1,75 @@
+import { useCallback, useRef, useState } from 'react'
+
+type Role = 'user' | 'assistant'
+
+type PartialTranscript = {
+  role: Role
+  text: string
+}
+
+type TranscriptBufferActions = {
+  /** Call when a speaker starts talking. Initializes/resets buffer for that role. */
+  onSpeechStart: (role: Role) => void
+  /** Call on each final transcript fragment. Appends to the buffer for that role. */
+  onTranscriptFinal: (role: Role, text: string) => void
+  /** Call when a speaker stops talking. Returns the accumulated text and clears the buffer. */
+  onSpeechEnd: (role: Role) => string | null
+  /** Flush all active buffers (e.g. when call ends mid-speech). Returns any pending text per role. */
+  flushAll: () => Array<{ role: Role, text: string }>
+  /** Current partial transcripts being accumulated (for real-time UI display). */
+  partials: PartialTranscript[]
+}
+
+export function useTranscriptBuffer(): TranscriptBufferActions {
+  const buffersRef = useRef<Map<Role, string>>(new Map())
+  const [partials, setPartials] = useState<PartialTranscript[]>([])
+
+  const syncPartials = useCallback(() => {
+    const next: PartialTranscript[] = []
+    for (const [role, text] of buffersRef.current.entries()) {
+      if (text.length > 0) {
+        next.push({ role, text })
+      }
+    }
+    setPartials(next)
+  }, [])
+
+  const onSpeechStart = useCallback((role: Role) => {
+    buffersRef.current.set(role, '')
+    syncPartials()
+  }, [syncPartials])
+
+  const onTranscriptFinal = useCallback((role: Role, text: string) => {
+    const existing = buffersRef.current.get(role)
+    if (existing === undefined) {
+      // Speech start may not have fired yet -- initialize buffer
+      buffersRef.current.set(role, text)
+    } else {
+      const separator = existing.length > 0 ? ' ' : ''
+      buffersRef.current.set(role, existing + separator + text)
+    }
+    syncPartials()
+  }, [syncPartials])
+
+  const onSpeechEnd = useCallback((role: Role): string | null => {
+    const text = buffersRef.current.get(role) ?? null
+    buffersRef.current.delete(role)
+    syncPartials()
+    return text && text.trim().length > 0 ? text.trim() : null
+  }, [syncPartials])
+
+  const flushAll = useCallback((): Array<{ role: Role, text: string }> => {
+    const results: Array<{ role: Role, text: string }> = []
+    for (const [role, text] of buffersRef.current.entries()) {
+      const trimmed = text.trim()
+      if (trimmed.length > 0) {
+        results.push({ role, text: trimmed })
+      }
+    }
+    buffersRef.current.clear()
+    syncPartials()
+    return results
+  }, [syncPartials])
+
+  return { onSpeechStart, onTranscriptFinal, onSpeechEnd, flushAll, partials }
+}


### PR DESCRIPTION
## Summary
- **New `useTranscriptBuffer` hook** (`lib/use-transcript-buffer.ts`) that buffers transcript fragments per role between `onSpeechStart` and `onSpeechEnd` events, then returns the full accumulated text as a single string
- **Rewired Vapi event listeners** in `app/(tabs)/index.tsx`: `onTranscript` feeds the buffer instead of saving to DB directly; `onSpeechEnd` flushes the buffer and saves one consolidated message; `onCallEnd` flushes any remaining buffers (handles call-ends-mid-speech)
- **Real-time partial transcript display**: italic/dimmed bubbles shown via `ListFooterComponent` while speech is in progress, replaced by the final consolidated message when the turn ends
- Independent buffers per role handle overlapping speech (user interrupts assistant)

Fixes NAN-570

## Test plan
- [ ] Start a voice call and speak a multi-sentence phrase -- verify it appears as one message bubble, not multiple
- [ ] Verify partial transcript text appears in italic/dimmed style while speaking
- [ ] End a call mid-sentence -- verify the partial buffer is flushed and saved
- [ ] Verify assistant responses also consolidate into single bubbles
- [ ] Interrupt the assistant while speaking -- verify both buffers resolve independently
- [ ] Run `npx tsc --noEmit` -- passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)