### PR TITLE
Fix incomplete user message bubble at end of speech turn

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -91,17 +91,22 @@ export default function ChatScreen() {
   const wasCallActiveRef = useRef(false)
   const lastCallOverridesRef = useRef<Record<string, unknown> | null>(null)
   const lastAssistantIdRef = useRef<string | null>(null)
-  const conversationIdRef = useRef(conversationId)
-  conversationIdRef.current = conversationId
+  const loadMessages = useCallback(async () => {
+    if (!conversationId) return
+    setMessages(await getMessages(conversationId))
+  }, [conversationId])
 
   const handleTranscriptFlush = useCallback(async (role: 'user' | 'assistant', text: string) => {
-    const convId = conversationIdRef.current
-    if (!convId) return
-    console.log('[Chat] Transcript flush:', role, text.substring(0, 50))
-    await addMessage(convId, role, text)
-    setMessages(await getMessages(convId))
-    maybeGenerateTitle(convId)
-  }, [])
+    if (!conversationId) return
+    if (__DEV__) console.log('[Chat] Transcript flush:', role, text.substring(0, 50))
+    try {
+      await addMessage(conversationId, role, text)
+      await loadMessages()
+      maybeGenerateTitle(conversationId)
+    } catch (err) {
+      console.warn('[Chat] Failed to flush transcript:', err)
+    }
+  }, [conversationId, loadMessages])
 
   const transcriptBuffer = useTranscriptBuffer({ onFlush: handleTranscriptFlush })
   const transcriptBufferRef = useRef(transcriptBuffer)
@@ -276,11 +281,6 @@ export default function ChatScreen() {
       }
     })()
   }, [])
-
-  const loadMessages = useCallback(async () => {
-    if (!conversationId) return
-    setMessages(await getMessages(conversationId))
-  }, [conversationId])
 
   useEffect(() => { loadMessages() }, [loadMessages])
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -91,7 +91,19 @@ export default function ChatScreen() {
   const wasCallActiveRef = useRef(false)
   const lastCallOverridesRef = useRef<Record<string, unknown> | null>(null)
   const lastAssistantIdRef = useRef<string | null>(null)
-  const transcriptBuffer = useTranscriptBuffer()
+  const conversationIdRef = useRef(conversationId)
+  conversationIdRef.current = conversationId
+
+  const handleTranscriptFlush = useCallback(async (role: 'user' | 'assistant', text: string) => {
+    const convId = conversationIdRef.current
+    if (!convId) return
+    console.log('[Chat] Transcript flush:', role, text.substring(0, 50))
+    await addMessage(convId, role, text)
+    setMessages(await getMessages(convId))
+    maybeGenerateTitle(convId)
+  }, [])
+
+  const transcriptBuffer = useTranscriptBuffer({ onFlush: handleTranscriptFlush })
   const transcriptBufferRef = useRef(transcriptBuffer)
   transcriptBufferRef.current = transcriptBuffer
 
@@ -189,13 +201,8 @@ export default function ChatScreen() {
           soundsRef.current.stopThinking()
         }
       }),
-      ExpoVapiModule.addListener('onSpeechEnd', async (event: SpeechEvent) => {
-        const fullText = transcriptBufferRef.current.onSpeechEnd(event.role)
-        if (fullText && conversationId) {
-          await addMessage(conversationId, event.role, fullText)
-          loadMessages()
-          maybeGenerateTitle(conversationId)
-        }
+      ExpoVapiModule.addListener('onSpeechEnd', (event: SpeechEvent) => {
+        transcriptBufferRef.current.onSpeechEnd(event.role)
         if (event.role === 'user') {
           setIsThinking(true)
           soundsRef.current.startThinking()

--- a/lib/use-transcript-buffer.ts
+++ b/lib/use-transcript-buffer.ts
@@ -7,21 +7,36 @@ type PartialTranscript = {
   text: string
 }
 
+/** Delay (ms) after onSpeechEnd before we flush -- gives late final transcripts time to arrive */
+const FLUSH_DELAY_MS = 300
+
 type TranscriptBufferActions = {
   /** Call when a speaker starts talking. Initializes/resets buffer for that role. */
   onSpeechStart: (role: Role) => void
   /** Call on each final transcript fragment. Appends to the buffer for that role. */
   onTranscriptFinal: (role: Role, text: string) => void
-  /** Call when a speaker stops talking. Returns the accumulated text and clears the buffer. */
-  onSpeechEnd: (role: Role) => string | null
+  /**
+   * Call when a speaker stops talking. Marks the buffer as pending flush.
+   * The actual flush happens after a short delay to capture any late-arriving
+   * final transcripts. The flushed text is delivered via the onFlush callback.
+   */
+  onSpeechEnd: (role: Role) => void
   /** Flush all active buffers (e.g. when call ends mid-speech). Returns any pending text per role. */
   flushAll: () => Array<{ role: Role, text: string }>
   /** Current partial transcripts being accumulated (for real-time UI display). */
   partials: PartialTranscript[]
 }
 
-export function useTranscriptBuffer(): TranscriptBufferActions {
+type UseTranscriptBufferOptions = {
+  /** Called when a speech turn is finalized with the accumulated transcript text. */
+  onFlush: (role: Role, text: string) => void
+}
+
+export function useTranscriptBuffer(options: UseTranscriptBufferOptions): TranscriptBufferActions {
   const buffersRef = useRef<Map<Role, string>>(new Map())
+  const pendingFlushRef = useRef<Map<Role, ReturnType<typeof setTimeout>>>(new Map())
+  const onFlushRef = useRef(options.onFlush)
+  onFlushRef.current = options.onFlush
   const [partials, setPartials] = useState<PartialTranscript[]>([])
 
   const syncPartials = useCallback(() => {
@@ -34,10 +49,29 @@ export function useTranscriptBuffer(): TranscriptBufferActions {
     setPartials(next)
   }, [])
 
+  const flushRole = useCallback((role: Role) => {
+    const timer = pendingFlushRef.current.get(role)
+    if (timer) {
+      clearTimeout(timer)
+      pendingFlushRef.current.delete(role)
+    }
+    const text = buffersRef.current.get(role) ?? null
+    buffersRef.current.delete(role)
+    syncPartials()
+    if (text && text.trim().length > 0) {
+      onFlushRef.current(role, text.trim())
+    }
+  }, [syncPartials])
+
   const onSpeechStart = useCallback((role: Role) => {
+    // If there is a pending flush for this role, flush it immediately before
+    // starting a new buffer -- a new speech turn has begun.
+    if (pendingFlushRef.current.has(role)) {
+      flushRole(role)
+    }
     buffersRef.current.set(role, '')
     syncPartials()
-  }, [syncPartials])
+  }, [syncPartials, flushRole])
 
   const onTranscriptFinal = useCallback((role: Role, text: string) => {
     const existing = buffersRef.current.get(role)
@@ -49,16 +83,31 @@ export function useTranscriptBuffer(): TranscriptBufferActions {
       buffersRef.current.set(role, existing + separator + text)
     }
     syncPartials()
-  }, [syncPartials])
 
-  const onSpeechEnd = useCallback((role: Role): string | null => {
-    const text = buffersRef.current.get(role) ?? null
-    buffersRef.current.delete(role)
-    syncPartials()
-    return text && text.trim().length > 0 ? text.trim() : null
-  }, [syncPartials])
+    // If this role is pending flush, a late transcript just arrived.
+    // Reset the timer so we wait a bit more for any additional fragments.
+    if (pendingFlushRef.current.has(role)) {
+      clearTimeout(pendingFlushRef.current.get(role))
+      pendingFlushRef.current.set(role, setTimeout(() => flushRole(role), FLUSH_DELAY_MS))
+    }
+  }, [syncPartials, flushRole])
+
+  const onSpeechEnd = useCallback((role: Role) => {
+    // Don't flush immediately -- wait for any late-arriving final transcripts
+    const existingTimer = pendingFlushRef.current.get(role)
+    if (existingTimer) {
+      clearTimeout(existingTimer)
+    }
+    pendingFlushRef.current.set(role, setTimeout(() => flushRole(role), FLUSH_DELAY_MS))
+  }, [flushRole])
 
   const flushAll = useCallback((): Array<{ role: Role, text: string }> => {
+    // Clear all pending flush timers
+    for (const timer of pendingFlushRef.current.values()) {
+      clearTimeout(timer)
+    }
+    pendingFlushRef.current.clear()
+
     const results: Array<{ role: Role, text: string }> = []
     for (const [role, text] of buffersRef.current.entries()) {
       const trimmed = text.trim()

--- a/lib/use-transcript-buffer.ts
+++ b/lib/use-transcript-buffer.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 type Role = 'user' | 'assistant'
 
@@ -29,7 +29,7 @@ type TranscriptBufferActions = {
 
 type UseTranscriptBufferOptions = {
   /** Called when a speech turn is finalized with the accumulated transcript text. */
-  onFlush: (role: Role, text: string) => void
+  onFlush: (role: Role, text: string) => void | Promise<void>
 }
 
 export function useTranscriptBuffer(options: UseTranscriptBufferOptions): TranscriptBufferActions {
@@ -59,7 +59,16 @@ export function useTranscriptBuffer(options: UseTranscriptBufferOptions): Transc
     buffersRef.current.delete(role)
     syncPartials()
     if (text && text.trim().length > 0) {
-      onFlushRef.current(role, text.trim())
+      try {
+        const result = onFlushRef.current(role, text.trim())
+        if (result && typeof result.catch === 'function') {
+          result.catch((err: unknown) => {
+            console.warn('[TranscriptBuffer] onFlush error:', err)
+          })
+        }
+      } catch (err) {
+        console.warn('[TranscriptBuffer] onFlush error:', err)
+      }
     }
   }, [syncPartials])
 
@@ -119,6 +128,16 @@ export function useTranscriptBuffer(options: UseTranscriptBufferOptions): Transc
     syncPartials()
     return results
   }, [syncPartials])
+
+  // Clean up pending timers on unmount to prevent calling onFlush after unmount
+  useEffect(() => {
+    return () => {
+      for (const timer of pendingFlushRef.current.values()) {
+        clearTimeout(timer)
+      }
+      pendingFlushRef.current.clear()
+    }
+  }, [])
 
   return { onSpeechStart, onTranscriptFinal, onSpeechEnd, flushAll, partials }
 }


### PR DESCRIPTION
## Summary
- **Bug**: User message bubble sometimes shows incomplete or partial transcription because `onSpeechEnd` fires before the last `final` transcript event arrives from Vapi
- **Fix**: Instead of flushing the transcript buffer immediately on `onSpeechEnd`, mark it as "pending flush" and wait 300ms for any late-arriving final transcripts before saving the message
- **Safety nets**: If a new speech turn starts (`onSpeechStart`) or the call ends (`flushAll`), any pending buffer is flushed immediately so nothing hangs

Resolves NAN-571

## Test plan
- [ ] Start a voice call and speak a sentence, verify the full transcript appears in the message bubble
- [ ] Speak multiple turns in quick succession, verify each turn is captured completely
- [ ] End a call mid-speech, verify the partial transcript is still saved
- [ ] Run `npx tsc --noEmit` -- passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)