### PR TITLE
NAN-576: Custom Pipeline - STT/TTS provider protocols and PipelineManager

### DIFF
--- a/lib/use-custom-pipeline.ts
+++ b/lib/use-custom-pipeline.ts
@@ -1,0 +1,103 @@
+import { useEffect, useCallback, useState, useRef } from 'react'
+
+import ExpoCustomPipelineModule from '../modules/expo-custom-pipeline/src/ExpoCustomPipelineModule'
+import type {
+  PartialTranscriptEvent,
+  FinalTranscriptEvent,
+  LatencyUpdateEvent,
+  LatencyStats,
+} from '../modules/expo-custom-pipeline/src/ExpoCustomPipeline.types'
+
+export type CustomPipelineConfig = {
+  apiUrl: string
+  apiKey: string
+  model: string
+}
+
+export type CustomPipelineState = {
+  isListening: boolean
+  isSpeaking: boolean
+  partialTranscript: string
+  latencyStats: LatencyStats
+  startConversation: () => void
+  stopConversation: () => void
+}
+
+export function useCustomPipeline(config: CustomPipelineConfig): CustomPipelineState {
+  const [isListening, setIsListening] = useState(false)
+  const [isSpeaking, setIsSpeaking] = useState(false)
+  const [partialTranscript, setPartialTranscript] = useState('')
+  const [latencyStats, setLatencyStats] = useState<LatencyStats>({
+    sttLatencyMs: 0,
+    llmLatencyMs: 0,
+    ttsLatencyMs: 0,
+  })
+  const subscriptions = useRef<Array<{ remove: () => void }>>([])
+
+  useEffect(() => {
+    const subs = [
+      ExpoCustomPipelineModule.addListener(
+        'onPartialTranscript',
+        (event: PartialTranscriptEvent) => {
+          setPartialTranscript(event.text)
+          setIsListening(true)
+        }
+      ),
+      ExpoCustomPipelineModule.addListener(
+        'onFinalTranscript',
+        (_event: FinalTranscriptEvent) => {
+          setPartialTranscript('')
+          setIsListening(false)
+        }
+      ),
+      ExpoCustomPipelineModule.addListener('onTTSStart', () => {
+        setIsSpeaking(true)
+      }),
+      ExpoCustomPipelineModule.addListener('onTTSComplete', () => {
+        setIsSpeaking(false)
+      }),
+      ExpoCustomPipelineModule.addListener(
+        'onLatencyUpdate',
+        (event: LatencyUpdateEvent) => {
+          setLatencyStats({
+            sttLatencyMs: event.sttLatencyMs,
+            llmLatencyMs: event.llmLatencyMs,
+            ttsLatencyMs: event.ttsLatencyMs,
+          })
+        }
+      ),
+      ExpoCustomPipelineModule.addListener('onError', (event) => {
+        console.error('[CustomPipeline Error]', event.message)
+      }),
+    ]
+
+    subscriptions.current = subs
+
+    return () => {
+      subs.forEach((s) => s.remove())
+    }
+  }, [])
+
+  const startConversation = useCallback(() => {
+    setPartialTranscript('')
+    setLatencyStats({ sttLatencyMs: 0, llmLatencyMs: 0, ttsLatencyMs: 0 })
+    ExpoCustomPipelineModule.startConversation(config.apiUrl, config.apiKey, config.model)
+    setIsListening(true)
+  }, [config.apiUrl, config.apiKey, config.model])
+
+  const stopConversation = useCallback(() => {
+    ExpoCustomPipelineModule.stopConversation()
+    setIsListening(false)
+    setIsSpeaking(false)
+    setPartialTranscript('')
+  }, [])
+
+  return {
+    isListening,
+    isSpeaking,
+    partialTranscript,
+    latencyStats,
+    startConversation,
+    stopConversation,
+  }
+}

--- a/modules/expo-custom-pipeline/expo-module.config.json
+++ b/modules/expo-custom-pipeline/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["ExpoCustomPipelineModule"]
+  }
+}

--- a/modules/expo-custom-pipeline/index.ts
+++ b/modules/expo-custom-pipeline/index.ts
@@ -1,0 +1,2 @@
+export { default } from './src/ExpoCustomPipelineModule'
+export * from './src/ExpoCustomPipeline.types'

--- a/modules/expo-custom-pipeline/ios/ExpoCustomPipeline.podspec
+++ b/modules/expo-custom-pipeline/ios/ExpoCustomPipeline.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name           = 'ExpoCustomPipeline'
+  s.version        = '1.0.0'
+  s.summary        = 'Expo module for custom voice pipeline with STT/TTS provider protocols'
+  s.description    = 'Provides React Native access to a custom voice pipeline that orchestrates STT, LLM, and TTS on-device'
+  s.author         = 'VoiceClaw'
+  s.homepage       = 'https://github.com/yagudaev/voiceclaw'
+  s.platforms      = { :ios => '15.1' }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.source_files = "*.swift", "Pipeline/**/*.swift"
+end

--- a/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
+++ b/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
@@ -1,0 +1,112 @@
+import ExpoModulesCore
+
+public class ExpoCustomPipelineModule: Module {
+    private let pipelineManager = PipelineManager()
+    private var sttProviderName: String = ""
+    private var ttsProviderName: String = ""
+
+    public func definition() -> ModuleDefinition {
+        Name("ExpoCustomPipeline")
+
+        Events(
+            "onPartialTranscript",
+            "onFinalTranscript",
+            "onTTSStart",
+            "onTTSComplete",
+            "onLatencyUpdate",
+            "onError"
+        )
+
+        OnCreate {
+            self.pipelineManager.delegate = self
+        }
+
+        Function("setSTTProvider") { (name: String) in
+            self.sttProviderName = name
+            print("[ExpoCustomPipeline] STT provider set to: \(name)")
+            // Provider implementations will be registered in future tickets
+        }
+
+        Function("setTTSProvider") { (name: String) in
+            self.ttsProviderName = name
+            print("[ExpoCustomPipeline] TTS provider set to: \(name)")
+            // Provider implementations will be registered in future tickets
+        }
+
+        Function("startListening") { () in
+            self.pipelineManager.sttProvider?.startListening(
+                onPartialResult: { [weak self] text in
+                    self?.sendEvent("onPartialTranscript", ["text": text])
+                },
+                onFinalResult: { [weak self] text in
+                    self?.sendEvent("onFinalTranscript", ["text": text])
+                }
+            )
+        }
+
+        Function("stopListening") { () in
+            self.pipelineManager.sttProvider?.stopListening()
+        }
+
+        Function("speak") { (text: String) in
+            self.pipelineManager.ttsProvider?.speak(
+                text: text,
+                onStart: { [weak self] in
+                    self?.sendEvent("onTTSStart", [:])
+                },
+                onComplete: { [weak self] in
+                    self?.sendEvent("onTTSComplete", [:])
+                }
+            )
+        }
+
+        Function("stopSpeaking") { () in
+            self.pipelineManager.ttsProvider?.stop()
+        }
+
+        Function("startConversation") { (apiUrl: String, apiKey: String, model: String) in
+            self.pipelineManager.startConversation(apiUrl: apiUrl, apiKey: apiKey, model: model)
+        }
+
+        Function("stopConversation") { () in
+            self.pipelineManager.stopConversation()
+        }
+
+        Function("getLatencyStats") { () -> [String: Double] in
+            return self.pipelineManager.getLatencyStats()
+        }
+    }
+}
+
+// MARK: - PipelineManagerDelegate
+
+extension ExpoCustomPipelineModule: PipelineManagerDelegate {
+    func pipelineDidReceivePartialTranscript(_ text: String) {
+        sendEvent("onPartialTranscript", ["text": text])
+    }
+
+    func pipelineDidReceiveFinalTranscript(_ text: String) {
+        sendEvent("onFinalTranscript", ["text": text])
+    }
+
+    func pipelineDidStartSpeaking() {
+        sendEvent("onTTSStart", [:])
+    }
+
+    func pipelineDidFinishSpeaking() {
+        sendEvent("onTTSComplete", [:])
+    }
+
+    func pipelineDidUpdateLatency(stt: Double, llm: Double, tts: Double) {
+        sendEvent("onLatencyUpdate", [
+            "sttLatencyMs": stt,
+            "llmLatencyMs": llm,
+            "ttsLatencyMs": tts
+        ])
+    }
+
+    func pipelineDidEncounterError(_ message: String) {
+        print("[ExpoCustomPipeline] Error: \(message)")
+        sendEvent("onError", ["message": message])
+    }
+}

--- a/modules/expo-custom-pipeline/ios/Pipeline/PipelineManager.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/PipelineManager.swift
@@ -1,0 +1,248 @@
+import Foundation
+
+protocol PipelineManagerDelegate: AnyObject {
+    func pipelineDidReceivePartialTranscript(_ text: String)
+    func pipelineDidReceiveFinalTranscript(_ text: String)
+    func pipelineDidStartSpeaking()
+    func pipelineDidFinishSpeaking()
+    func pipelineDidUpdateLatency(stt: Double, llm: Double, tts: Double)
+    func pipelineDidEncounterError(_ message: String)
+}
+
+class PipelineManager {
+    weak var delegate: PipelineManagerDelegate?
+
+    private(set) var sttProvider: STTProvider?
+    private(set) var ttsProvider: TTSProvider?
+
+    private(set) var isConversationActive = false
+    private(set) var sttLatencyMs: Double = 0
+    private(set) var llmLatencyMs: Double = 0
+    private(set) var ttsLatencyMs: Double = 0
+
+    private var apiUrl: String = ""
+    private var apiKey: String = ""
+    private var model: String = ""
+    private var sentenceBuffer: String = ""
+    private var llmStartTime: CFAbsoluteTime = 0
+    private var ttsStartTime: CFAbsoluteTime = 0
+    private var urlSession: URLSession?
+    private var activeTask: URLSessionDataTask?
+
+    // MARK: - Public Interface
+
+    func setSTTProvider(_ provider: STTProvider) {
+        sttProvider = provider
+    }
+
+    func setTTSProvider(_ provider: TTSProvider) {
+        ttsProvider = provider
+    }
+
+    func startConversation(apiUrl: String, apiKey: String, model: String) {
+        self.apiUrl = apiUrl
+        self.apiKey = apiKey
+        self.model = model
+        isConversationActive = true
+
+        startListening()
+    }
+
+    func stopConversation() {
+        isConversationActive = false
+        sttProvider?.stopListening()
+        ttsProvider?.stop()
+        activeTask?.cancel()
+        activeTask = nil
+        sentenceBuffer = ""
+    }
+
+    func getLatencyStats() -> [String: Double] {
+        return [
+            "sttLatencyMs": sttLatencyMs,
+            "llmLatencyMs": llmLatencyMs,
+            "ttsLatencyMs": ttsLatencyMs
+        ]
+    }
+
+    // MARK: - Helpers
+
+    private func startListening() {
+        guard let stt = sttProvider else {
+            delegate?.pipelineDidEncounterError("No STT provider configured")
+            return
+        }
+
+        stt.startListening(
+            onPartialResult: { [weak self] text in
+                self?.delegate?.pipelineDidReceivePartialTranscript(text)
+            },
+            onFinalResult: { [weak self] text in
+                guard let self = self, self.isConversationActive else { return }
+                self.sttLatencyMs = stt.latencyMs
+                self.delegate?.pipelineDidReceiveFinalTranscript(text)
+                self.callOpenClawAPI(with: text)
+            }
+        )
+    }
+
+    private func callOpenClawAPI(with text: String) {
+        guard !apiUrl.isEmpty else {
+            delegate?.pipelineDidEncounterError("API URL not configured")
+            return
+        }
+
+        guard let url = URL(string: apiUrl) else {
+            delegate?.pipelineDidEncounterError("Invalid API URL: \(apiUrl)")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+
+        let body: [String: Any] = [
+            "model": model,
+            "messages": [
+                ["role": "user", "content": text]
+            ],
+            "stream": true
+        ]
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        } catch {
+            delegate?.pipelineDidEncounterError("Failed to encode request body: \(error.localizedDescription)")
+            return
+        }
+
+        llmStartTime = CFAbsoluteTimeGetCurrent()
+        sentenceBuffer = ""
+
+        let session = URLSession(configuration: .default, delegate: SSEDelegate(manager: self), delegateQueue: nil)
+        urlSession = session
+        let task = session.dataTask(with: request)
+        activeTask = task
+        task.resume()
+    }
+
+    fileprivate func handleSSEData(_ data: Data) {
+        guard let text = String(data: data, encoding: .utf8) else { return }
+
+        let lines = text.components(separatedBy: "\n")
+        for line in lines {
+            guard line.hasPrefix("data: ") else { continue }
+            let payload = String(line.dropFirst(6))
+
+            if payload == "[DONE]" {
+                flushSentenceBuffer()
+                return
+            }
+
+            guard let jsonData = payload.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+                  let choices = json["choices"] as? [[String: Any]],
+                  let delta = choices.first?["delta"] as? [String: Any],
+                  let content = delta["content"] as? String else {
+                continue
+            }
+
+            if llmLatencyMs == 0 {
+                llmLatencyMs = (CFAbsoluteTimeGetCurrent() - llmStartTime) * 1000
+                notifyLatencyUpdate()
+            }
+
+            sentenceBuffer += content
+            trySpeakCompleteSentences()
+        }
+    }
+
+    fileprivate func handleSSEError(_ error: Error) {
+        guard isConversationActive else { return }
+        delegate?.pipelineDidEncounterError("API error: \(error.localizedDescription)")
+    }
+
+    fileprivate func handleSSEComplete() {
+        flushSentenceBuffer()
+        if isConversationActive {
+            startListening()
+        }
+    }
+
+    private func trySpeakCompleteSentences() {
+        let sentenceEndings: [Character] = [".", "!", "?", "\n"]
+        while let lastIndex = sentenceBuffer.lastIndex(where: { sentenceEndings.contains($0) }) {
+            let sentenceEndPos = sentenceBuffer.index(after: lastIndex)
+            let sentence = String(sentenceBuffer[sentenceBuffer.startIndex..<sentenceEndPos]).trimmingCharacters(in: .whitespacesAndNewlines)
+            sentenceBuffer = String(sentenceBuffer[sentenceEndPos...])
+
+            if !sentence.isEmpty {
+                speakText(sentence)
+            }
+            break
+        }
+    }
+
+    private func flushSentenceBuffer() {
+        let remaining = sentenceBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
+        sentenceBuffer = ""
+        if !remaining.isEmpty {
+            speakText(remaining)
+        }
+    }
+
+    private func speakText(_ text: String) {
+        guard let tts = ttsProvider else {
+            delegate?.pipelineDidEncounterError("No TTS provider configured")
+            return
+        }
+
+        ttsStartTime = CFAbsoluteTimeGetCurrent()
+        tts.speak(
+            text: text,
+            onStart: { [weak self] in
+                guard let self = self else { return }
+                self.ttsLatencyMs = (CFAbsoluteTimeGetCurrent() - self.ttsStartTime) * 1000
+                self.notifyLatencyUpdate()
+                self.delegate?.pipelineDidStartSpeaking()
+            },
+            onComplete: { [weak self] in
+                self?.delegate?.pipelineDidFinishSpeaking()
+            }
+        )
+    }
+
+    private func notifyLatencyUpdate() {
+        delegate?.pipelineDidUpdateLatency(
+            stt: sttLatencyMs,
+            llm: llmLatencyMs,
+            tts: ttsLatencyMs
+        )
+    }
+}
+
+// MARK: - SSE URLSession Delegate
+
+private class SSEDelegate: NSObject, URLSessionDataDelegate {
+    weak var manager: PipelineManager?
+
+    init(manager: PipelineManager) {
+        self.manager = manager
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        manager?.handleSSEData(data)
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let error = error {
+            if (error as NSError).code != NSURLErrorCancelled {
+                manager?.handleSSEError(error)
+            }
+        } else {
+            manager?.handleSSEComplete()
+        }
+    }
+}

--- a/modules/expo-custom-pipeline/ios/Pipeline/STTProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/STTProvider.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+protocol STTProvider {
+    var name: String { get }
+    var isListening: Bool { get }
+    var latencyMs: Double { get }
+    func startListening(onPartialResult: @escaping (String) -> Void, onFinalResult: @escaping (String) -> Void)
+    func stopListening()
+}

--- a/modules/expo-custom-pipeline/ios/Pipeline/TTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/TTSProvider.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+protocol TTSProvider {
+    var name: String { get }
+    var isSpeaking: Bool { get }
+    var latencyMs: Double { get }
+    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void)
+    func stop()
+}

--- a/modules/expo-custom-pipeline/src/ExpoCustomPipeline.types.ts
+++ b/modules/expo-custom-pipeline/src/ExpoCustomPipeline.types.ts
@@ -1,0 +1,32 @@
+export type PartialTranscriptEvent = {
+  text: string
+}
+
+export type FinalTranscriptEvent = {
+  text: string
+}
+
+export type LatencyUpdateEvent = {
+  sttLatencyMs: number
+  llmLatencyMs: number
+  ttsLatencyMs: number
+}
+
+export type PipelineErrorEvent = {
+  message: string
+}
+
+export type LatencyStats = {
+  sttLatencyMs: number
+  llmLatencyMs: number
+  ttsLatencyMs: number
+}
+
+export type ExpoCustomPipelineModuleEvents = {
+  onPartialTranscript: (event: PartialTranscriptEvent) => void
+  onFinalTranscript: (event: FinalTranscriptEvent) => void
+  onTTSStart: () => void
+  onTTSComplete: () => void
+  onLatencyUpdate: (event: LatencyUpdateEvent) => void
+  onError: (event: PipelineErrorEvent) => void
+}

--- a/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule.ts
+++ b/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule.ts
@@ -1,0 +1,17 @@
+import { NativeModule, requireNativeModule } from 'expo'
+
+import { ExpoCustomPipelineModuleEvents, LatencyStats } from './ExpoCustomPipeline.types'
+
+declare class ExpoCustomPipelineModule extends NativeModule<ExpoCustomPipelineModuleEvents> {
+  setSTTProvider(name: string): void
+  setTTSProvider(name: string): void
+  startListening(): void
+  stopListening(): void
+  speak(text: string): void
+  stopSpeaking(): void
+  startConversation(apiUrl: string, apiKey: string, model: string): void
+  stopConversation(): void
+  getLatencyStats(): LatencyStats
+}
+
+export default requireNativeModule<ExpoCustomPipelineModule>('ExpoCustomPipeline')


### PR DESCRIPTION
## Summary
- Adds new `expo-custom-pipeline` Expo module with Swift protocols (`STTProvider`, `TTSProvider`) for pluggable voice providers
- Implements `PipelineManager` that orchestrates the full voice loop: STT -> OpenClaw streaming API (SSE) -> sentence-chunked TTS for low-latency playback
- Exposes React Native bridge (`ExpoCustomPipelineModule`) with functions (`startConversation`, `stopConversation`, `setSTTProvider`, `setTTSProvider`, etc.) and events (`onPartialTranscript`, `onFinalTranscript`, `onTTSStart`, `onTTSComplete`, `onLatencyUpdate`, `onError`)
- Adds `useCustomPipeline` React hook wrapping the native module with state management

This is the foundation layer -- protocols are stubs with no real STT/TTS implementations yet. Future tickets will add concrete providers (e.g., Apple Speech, ElevenLabs).

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] `npx expo run:ios` builds successfully on iOS simulator (0 errors)
- [x] `libExpoCustomPipeline.a` confirmed in build artifacts
- [x] Expo auto-linking detects the module
- [ ] Manual: app launches without crash on simulator

Generated with [Claude Code](https://claude.com/claude-code)