### PR TITLE
Add Apple STT provider with on-device Speech framework (NAN-577)

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -22,6 +22,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     bundleIdentifier: IS_DEV ? 'com.yagudaev.voiceclaw.dev' : 'com.yagudaev.voiceclaw',
     infoPlist: {
       NSMicrophoneUsageDescription: 'VoiceClaw needs microphone access for voice calls with your AI assistant.',
+      NSSpeechRecognitionUsageDescription: 'VoiceClaw uses speech recognition to transcribe your voice for the AI assistant.',
       UIBackgroundModes: ['audio', 'voip'],
     },
   },

--- a/app.json
+++ b/app.json
@@ -20,6 +20,7 @@
       "bundleIdentifier": "com.yagudaev.voiceclaw",
       "infoPlist": {
         "NSMicrophoneUsageDescription": "VoiceClaw needs microphone access for voice calls with your AI assistant.",
+        "NSSpeechRecognitionUsageDescription": "VoiceClaw uses speech recognition to transcribe your voice for the AI assistant.",
         "UIBackgroundModes": ["audio", "voip"]
       }
     },

--- a/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
+++ b/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
@@ -24,7 +24,13 @@ public class ExpoCustomPipelineModule: Module {
         Function("setSTTProvider") { (name: String) in
             self.sttProviderName = name
             print("[ExpoCustomPipeline] STT provider set to: \(name)")
-            // Provider implementations will be registered in future tickets
+
+            switch name {
+            case "apple":
+                self.pipelineManager.setSTTProvider(AppleSTTProvider())
+            default:
+                print("[ExpoCustomPipeline] Unknown STT provider: \(name)")
+            }
         }
 
         Function("setTTSProvider") { (name: String) in

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleSTTProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleSTTProvider.swift
@@ -1,0 +1,162 @@
+import Foundation
+import Speech
+import AVFoundation
+
+class AppleSTTProvider: STTProvider {
+    let name = "apple"
+
+    private(set) var isListening = false
+    private(set) var latencyMs: Double = 0
+
+    private let speechRecognizer: SFSpeechRecognizer?
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private var audioEngine = AVAudioEngine()
+    private var listenStartTime: CFAbsoluteTime = 0
+    private var hasReceivedFirstResult = false
+
+    init(locale: Locale = Locale(identifier: "en-US")) {
+        speechRecognizer = SFSpeechRecognizer(locale: locale)
+    }
+
+    // MARK: - STTProvider
+
+    func startListening(
+        onPartialResult: @escaping (String) -> Void,
+        onFinalResult: @escaping (String) -> Void
+    ) {
+        guard !isListening else { return }
+
+        requestAuthorizationIfNeeded { [weak self] authorized in
+            guard let self = self else { return }
+
+            guard authorized else {
+                print("[AppleSTTProvider] Speech recognition authorization denied")
+                return
+            }
+
+            DispatchQueue.main.async {
+                self.beginRecognition(onPartialResult: onPartialResult, onFinalResult: onFinalResult)
+            }
+        }
+    }
+
+    func stopListening() {
+        guard isListening else { return }
+
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        recognitionRequest?.endAudio()
+        recognitionTask?.cancel()
+
+        recognitionRequest = nil
+        recognitionTask = nil
+        isListening = false
+    }
+
+    // MARK: - Helpers
+
+    private func beginRecognition(
+        onPartialResult: @escaping (String) -> Void,
+        onFinalResult: @escaping (String) -> Void
+    ) {
+        guard let speechRecognizer = speechRecognizer, speechRecognizer.isAvailable else {
+            print("[AppleSTTProvider] Speech recognizer is unavailable")
+            return
+        }
+
+        // Clean up any previous session
+        stopListening()
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+
+        if speechRecognizer.supportsOnDeviceRecognition {
+            request.requiresOnDeviceRecognition = true
+        }
+
+        recognitionRequest = request
+        latencyMs = 0
+        hasReceivedFirstResult = false
+        listenStartTime = CFAbsoluteTimeGetCurrent()
+
+        recognitionTask = speechRecognizer.recognitionTask(with: request) { [weak self] result, error in
+            guard let self = self else { return }
+
+            if let result = result {
+                let text = result.bestTranscription.formattedString
+
+                if !self.hasReceivedFirstResult {
+                    self.hasReceivedFirstResult = true
+                    self.latencyMs = (CFAbsoluteTimeGetCurrent() - self.listenStartTime) * 1000
+                }
+
+                if result.isFinal {
+                    onFinalResult(text)
+                    self.stopListening()
+                } else {
+                    onPartialResult(text)
+                }
+            }
+
+            if let error = error {
+                let nsError = error as NSError
+                // Ignore cancellation errors (code 216 = request was canceled)
+                if nsError.domain == "kAFAssistantErrorDomain" && nsError.code == 216 {
+                    return
+                }
+                print("[AppleSTTProvider] Recognition error: \(error.localizedDescription)")
+                self.stopListening()
+            }
+        }
+
+        configureAudioSession()
+        installAudioTap(for: request)
+
+        audioEngine.prepare()
+
+        do {
+            try audioEngine.start()
+            isListening = true
+        } catch {
+            print("[AppleSTTProvider] Audio engine failed to start: \(error.localizedDescription)")
+            stopListening()
+        }
+    }
+
+    private func requestAuthorizationIfNeeded(completion: @escaping (Bool) -> Void) {
+        let status = SFSpeechRecognizer.authorizationStatus()
+
+        switch status {
+        case .authorized:
+            completion(true)
+        case .notDetermined:
+            SFSpeechRecognizer.requestAuthorization { newStatus in
+                completion(newStatus == .authorized)
+            }
+        case .denied, .restricted:
+            completion(false)
+        @unknown default:
+            completion(false)
+        }
+    }
+
+    private func configureAudioSession() {
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+            try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            print("[AppleSTTProvider] Failed to configure audio session: \(error.localizedDescription)")
+        }
+    }
+
+    private func installAudioTap(for request: SFSpeechAudioBufferRecognitionRequest) {
+        let inputNode = audioEngine.inputNode
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { buffer, _ in
+            request.append(buffer)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AppleSTTProvider` implementing the `STTProvider` protocol using Apple's Speech framework (`SFSpeechRecognizer`)
- Uses on-device recognition when available (`requiresOnDeviceRecognition = true`) with server fallback
- Real-time streaming via `SFSpeechAudioBufferRecognitionRequest` + `AVAudioEngine` with partial results
- Tracks latency from `startListening()` to first partial result callback
- Handles authorization flow, error recovery, and proper cleanup on stop
- Adds `NSSpeechRecognitionUsageDescription` to Info.plist via `app.json` and `app.config.ts`
- Wires up `"apple"` case in `ExpoCustomPipelineModule.setSTTProvider()`

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `xcodebuild` for ExpoCustomPipeline target succeeds (verified)
- [ ] Build to simulator with `npx expo run:ios`
- [ ] Build to device and verify speech recognition prompt appears on first use
- [ ] Verify partial and final transcripts arrive via events

🤖 Generated with [Claude Code](https://claude.com/claude-code)