### PR TITLE
Add settings UI for voice mode and STT/TTS provider selection (NAN-580)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -12,7 +12,9 @@ import { useTranscriptBuffer } from '@/lib/use-transcript-buffer'
 import { useAutoReconnect } from '@/lib/use-auto-reconnect'
 import { sendVapiChat, syncMessagesToVapi } from '@/lib/vapi-chat'
 import ExpoVapiModule from '@/modules/expo-vapi'
+import ExpoCustomPipelineModule from '@/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule'
 import type { FunctionCallEvent, SpeechEvent, TranscriptEvent } from '@/modules/expo-vapi'
+import type { FinalTranscriptEvent } from '@/modules/expo-custom-pipeline/src/ExpoCustomPipeline.types'
 import { Stack } from 'expo-router'
 import { MicIcon, MicOffIcon, PhoneOffIcon, PlusIcon, RefreshCwIcon, SendIcon, XIcon } from 'lucide-react-native'
 import { useColorScheme } from 'nativewind'
@@ -91,6 +93,9 @@ export default function ChatScreen() {
   const wasCallActiveRef = useRef(false)
   const lastCallOverridesRef = useRef<Record<string, unknown> | null>(null)
   const lastAssistantIdRef = useRef<string | null>(null)
+  const activeVoiceModeRef = useRef<'vapi' | 'custom'>('vapi')
+  const customPipelineSubsRef = useRef<Array<{ remove: () => void }>>([])
+
   const loadMessages = useCallback(async () => {
     if (!conversationId) return
     setMessages(await getMessages(conversationId))
@@ -373,7 +378,11 @@ export default function ChatScreen() {
     if (isCallActive) {
       userInitiatedEndRef.current = true
       cancelReconnect()
-      await ExpoVapiModule.stopCall()
+      if (activeVoiceModeRef.current === 'custom') {
+        stopCustomPipeline()
+      } else {
+        await ExpoVapiModule.stopCall()
+      }
       return
     }
 
@@ -382,97 +391,20 @@ export default function ChatScreen() {
     let callStarted = false
 
     try {
-      // Check assistantId first to avoid unnecessary Vapi initialization
-      const assistantId = await getSetting('assistant_id')
-      if (!assistantId) {
-        if (conversationId) {
-          await addMessage(conversationId, 'assistant', 'Please configure your Vapi API key and Assistant ID in Settings first.')
-          await loadMessages()
-        }
-        return
-      }
-
-      const ready = await ensureVapiReady()
-      if (!ready) {
-        if (conversationId) {
-          await addMessage(conversationId, 'assistant', 'Please configure your Vapi API key and Assistant ID in Settings first.')
-          await loadMessages()
-        }
-        return
-      }
+      const voiceMode = (await getSetting('voice_mode')) || 'vapi'
 
       if (!conversationId) {
         console.warn('[Chat] No active conversation, cannot start call')
         return
       }
 
-      const { apiKey, apiUrl, model } = await getApiConfig()
-      const modelMessages: Array<{ role: string, content: string }> = [
-        { role: 'system', content: VOICE_SYSTEM_PROMPT },
-      ]
-
-      const prevMessages = await getMessages(conversationId)
-      if (prevMessages.length > 0) {
-        const compacted = apiKey && apiUrl
-          ? await compactMessages(conversationId, prevMessages, apiKey, model, apiUrl)
-          : prevMessages.map((m) => ({ role: m.role, content: m.content }))
-
-        const summaryMsg = compacted.find((m) => m.role === 'system' && m.content.startsWith('Previous conversation summary:'))
-        const historyMsgs = compacted.filter((m) => m.role !== 'system')
-
-        const history = historyMsgs
-          .map((m) => `${m.role}: ${m.content}`)
-          .join('\n')
-        const contextParts = []
-        if (summaryMsg) contextParts.push(summaryMsg.content)
-        if (history) contextParts.push(`Recent messages:\n${history}`)
-        contextParts.push('Continue the conversation naturally from where we left off.')
-
-        modelMessages.push({
-          role: 'system',
-          content: contextParts.join('\n\n'),
-        })
+      if (voiceMode === 'custom') {
+        activeVoiceModeRef.current = 'custom'
+        callStarted = await startCustomPipelineCall()
+      } else {
+        activeVoiceModeRef.current = 'vapi'
+        callStarted = await startVapiCall()
       }
-
-      const overrides: Record<string, unknown> = {
-        server: { timeoutSeconds: 45 },
-        silenceTimeoutSeconds: 120,
-        endCallPhrases: [],
-        clientMessages: [
-          'transcript',
-          'hang',
-          'function-call',
-          'speech-update',
-          'status-update',
-          'conversation-update',
-          'model-output',
-        ],
-        firstMessage: modelMessages.length > 1 ? 'Welcome back :)' : undefined,
-        model: {
-          url: apiUrl,
-          provider: 'custom-llm',
-          model,
-          messages: modelMessages,
-          functions: [DISPLAY_TEXT_FUNCTION],
-        },
-        metadata: { conversationId: `voiceclaw:${conversationId}` },
-      }
-
-      const callOverrides = Object.keys(overrides).length > 0 ? overrides : undefined
-      lastAssistantIdRef.current = assistantId
-      lastCallOverridesRef.current = callOverrides ?? null
-
-      // Safety timeout: reset isConnecting if onCallStart never fires
-      if (connectingTimeoutRef.current) clearTimeout(connectingTimeoutRef.current)
-      connectingTimeoutRef.current = setTimeout(() => {
-        setIsConnecting((current) => {
-          if (current) console.warn('[Chat] Connecting timed out after 15s, resetting state')
-          return false
-        })
-      }, 15_000)
-
-      await ExpoVapiModule.startCall(assistantId, callOverrides)
-      callStarted = true
     } catch (e: any) {
       const errorMsg = e?.message || String(e)
       console.error('Failed to start call:', errorMsg)
@@ -490,6 +422,182 @@ export default function ChatScreen() {
       }
     }
   }, [isCallActive, ensureVapiReady, conversationId, loadMessages])
+
+  const startVapiCall = useCallback(async (): Promise<boolean> => {
+    const assistantId = await getSetting('assistant_id')
+    if (!assistantId) {
+      if (conversationId) {
+        await addMessage(conversationId, 'assistant', 'Please configure your Vapi API key and Assistant ID in Settings first.')
+        await loadMessages()
+      }
+      return false
+    }
+
+    const ready = await ensureVapiReady()
+    if (!ready) {
+      if (conversationId) {
+        await addMessage(conversationId, 'assistant', 'Please configure your Vapi API key and Assistant ID in Settings first.')
+        await loadMessages()
+      }
+      return false
+    }
+
+    if (!conversationId) return false
+
+    const { apiKey, apiUrl, model } = await getApiConfig()
+    const modelMessages: Array<{ role: string, content: string }> = [
+      { role: 'system', content: VOICE_SYSTEM_PROMPT },
+    ]
+
+    const prevMessages = await getMessages(conversationId)
+    if (prevMessages.length > 0) {
+      const compacted = apiKey && apiUrl
+        ? await compactMessages(conversationId, prevMessages, apiKey, model, apiUrl)
+        : prevMessages.map((m) => ({ role: m.role, content: m.content }))
+
+      const summaryMsg = compacted.find((m) => m.role === 'system' && m.content.startsWith('Previous conversation summary:'))
+      const historyMsgs = compacted.filter((m) => m.role !== 'system')
+
+      const history = historyMsgs
+        .map((m) => `${m.role}: ${m.content}`)
+        .join('\n')
+      const contextParts = []
+      if (summaryMsg) contextParts.push(summaryMsg.content)
+      if (history) contextParts.push(`Recent messages:\n${history}`)
+      contextParts.push('Continue the conversation naturally from where we left off.')
+
+      modelMessages.push({
+        role: 'system',
+        content: contextParts.join('\n\n'),
+      })
+    }
+
+    const overrides: Record<string, unknown> = {
+      server: { timeoutSeconds: 45 },
+      silenceTimeoutSeconds: 120,
+      endCallPhrases: [],
+      clientMessages: [
+        'transcript',
+        'hang',
+        'function-call',
+        'speech-update',
+        'status-update',
+        'conversation-update',
+        'model-output',
+      ],
+      firstMessage: modelMessages.length > 1 ? 'Welcome back :)' : undefined,
+      model: {
+        url: apiUrl,
+        provider: 'custom-llm',
+        model,
+        messages: modelMessages,
+        functions: [DISPLAY_TEXT_FUNCTION],
+      },
+      metadata: { conversationId: `voiceclaw:${conversationId}` },
+    }
+
+    const callOverrides = Object.keys(overrides).length > 0 ? overrides : undefined
+    lastAssistantIdRef.current = assistantId
+    lastCallOverridesRef.current = callOverrides ?? null
+
+    // Safety timeout: reset isConnecting if onCallStart never fires
+    if (connectingTimeoutRef.current) clearTimeout(connectingTimeoutRef.current)
+    connectingTimeoutRef.current = setTimeout(() => {
+      setIsConnecting((current) => {
+        if (current) console.warn('[Chat] Connecting timed out after 15s, resetting state')
+        return false
+      })
+    }, 15_000)
+
+    await ExpoVapiModule.startCall(assistantId, callOverrides)
+    return true
+  }, [ensureVapiReady, conversationId, loadMessages])
+
+  const startCustomPipelineCall = useCallback(async (): Promise<boolean> => {
+    if (!conversationId) return false
+
+    const { apiKey, apiUrl, model } = await getApiConfig()
+    if (!apiKey || !apiUrl) {
+      await addMessage(conversationId, 'assistant', 'Please configure your OpenClaw API URL and key in Settings first.')
+      await loadMessages()
+      return false
+    }
+
+    // Read STT/TTS provider settings
+    const sttProvider = (await getSetting('stt_provider')) || 'apple'
+    const ttsProvider = (await getSetting('tts_provider')) || 'apple'
+
+    // Configure STT provider
+    const sttConfig: Record<string, string> = {}
+    if (sttProvider === 'deepgram') {
+      const deepgramKey = await getSetting('deepgram_api_key')
+      if (deepgramKey) sttConfig.apiKey = deepgramKey
+    }
+    ExpoCustomPipelineModule.setSTTProvider(sttProvider, sttConfig)
+
+    // Configure TTS provider
+    const ttsConfig: Record<string, string> = {}
+    if (ttsProvider === 'elevenlabs') {
+      const elKey = await getSetting('elevenlabs_api_key')
+      const elVoice = await getSetting('elevenlabs_voice_id')
+      if (elKey) ttsConfig.apiKey = elKey
+      if (elVoice) ttsConfig.voiceId = elVoice
+    } else if (ttsProvider === 'openai') {
+      const oaiKey = await getSetting('openai_tts_api_key')
+      const oaiVoice = await getSetting('openai_tts_voice')
+      if (oaiKey) ttsConfig.apiKey = oaiKey
+      if (oaiVoice) ttsConfig.voice = oaiVoice
+    }
+    ExpoCustomPipelineModule.setTTSProvider(ttsProvider, ttsConfig)
+
+    // Set up event listeners for custom pipeline
+    customPipelineSubsRef.current.forEach((s) => s.remove())
+    customPipelineSubsRef.current = []
+    const subs = [
+      ExpoCustomPipelineModule.addListener('onFinalTranscript', (event: FinalTranscriptEvent) => {
+        if (conversationId) {
+          addMessage(conversationId, 'user', event.text).then(() => {
+            loadMessages()
+            maybeGenerateTitle(conversationId)
+          })
+        }
+      }),
+      ExpoCustomPipelineModule.addListener('onTTSStart', () => {
+        setIsThinking(false)
+        soundsRef.current.stopThinking()
+      }),
+      ExpoCustomPipelineModule.addListener('onTTSComplete', () => {
+        // TTS finished speaking
+      }),
+      ExpoCustomPipelineModule.addListener('onError', (event) => {
+        console.error('[CustomPipeline]', event.message)
+        setIsThinking(false)
+        soundsRef.current.stopThinking()
+        if (conversationId) {
+          addMessage(conversationId, 'assistant', `Error: ${event.message}`).then(() => loadMessages())
+        }
+      }),
+    ]
+    customPipelineSubsRef.current = subs
+
+    // Start conversation
+    ExpoCustomPipelineModule.startConversation(apiUrl, apiKey, model)
+    setIsCallActive(true)
+    setIsConnecting(false)
+    soundsRef.current.playJoin()
+    return true
+  }, [conversationId, loadMessages])
+
+  const stopCustomPipeline = useCallback(() => {
+    ExpoCustomPipelineModule.stopConversation()
+    customPipelineSubsRef.current.forEach((s) => s.remove())
+    customPipelineSubsRef.current = []
+    setIsCallActive(false)
+    setIsMuted(false)
+    setIsThinking(false)
+    soundsRef.current.stopThinking()
+    soundsRef.current.playEnd()
+  }, [])
 
   const toggleMute = useCallback(async () => {
     const newMuted = !isMuted

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -6,7 +6,281 @@ import { Text } from '@/components/ui/text'
 import { getSetting, setSetting } from '@/db'
 import { EyeIcon, EyeOffIcon } from 'lucide-react-native'
 import { useEffect, useState } from 'react'
-import { Alert, Keyboard, KeyboardAvoidingView, Platform, Pressable, ScrollView, TextInput, TouchableWithoutFeedback, View } from 'react-native'
+import { Alert, KeyboardAvoidingView, Platform, Pressable, ScrollView, TextInput, View } from 'react-native'
+
+type VoiceMode = 'vapi' | 'custom'
+type STTProviderValue = 'apple' | 'deepgram'
+type TTSProviderValue = 'apple' | 'elevenlabs' | 'openai'
+
+const OPENAI_TTS_VOICES = ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'] as const
+
+export default function SettingsScreen() {
+  const [vapiApiKey, setVapiApiKey] = useState('')
+  const [assistantId, setAssistantId] = useState('')
+  const [defaultModel, setDefaultModel] = useState('openclaw:voice')
+  const [openclawApiKey, setOpenclawApiKey] = useState('')
+  const [openclawApiUrl, setOpenclawApiUrl] = useState('')
+  const [systemPrompt, setSystemPrompt] = useState('You are a helpful assistant. Keep responses concise. Use markdown for formatting and images when appropriate. Your identity, personality, and capabilities are defined in your system files.')
+  const [saved, setSaved] = useState(false)
+
+  // Voice Pipeline state
+  const [voiceMode, setVoiceMode] = useState<VoiceMode>('vapi')
+  const [sttProvider, setSttProvider] = useState<STTProviderValue>('apple')
+  const [ttsProvider, setTtsProvider] = useState<TTSProviderValue>('apple')
+  const [deepgramApiKey, setDeepgramApiKey] = useState('')
+  const [elevenlabsApiKey, setElevenlabsApiKey] = useState('')
+  const [elevenlabsVoiceId, setElevenlabsVoiceId] = useState('Awx8TeMHHpDzbm42nIB6')
+  const [openaiTtsApiKey, setOpenaiTtsApiKey] = useState('')
+  const [openaiTtsVoice, setOpenaiTtsVoice] = useState('alloy')
+
+  useEffect(() => {
+    ;(async () => {
+      const key = await getSetting('vapi_api_key')
+      const assistant = await getSetting('assistant_id')
+      const model = await getSetting('default_model')
+      const ocKey = await getSetting('openclaw_api_key')
+      const ocUrl = await getSetting('openclaw_api_url')
+      if (key) setVapiApiKey(key)
+      if (assistant) setAssistantId(assistant)
+      if (model) setDefaultModel(model)
+      if (ocKey) setOpenclawApiKey(ocKey)
+      if (ocUrl) setOpenclawApiUrl(ocUrl)
+      const sp = await getSetting('system_prompt')
+      if (sp) setSystemPrompt(sp)
+
+      // Load voice pipeline settings
+      const vm = await getSetting('voice_mode')
+      if (vm === 'vapi' || vm === 'custom') setVoiceMode(vm)
+      const stt = await getSetting('stt_provider')
+      if (stt === 'apple' || stt === 'deepgram') setSttProvider(stt)
+      const tts = await getSetting('tts_provider')
+      if (tts === 'apple' || tts === 'elevenlabs' || tts === 'openai') setTtsProvider(tts)
+      const dgKey = await getSetting('deepgram_api_key')
+      if (dgKey) setDeepgramApiKey(dgKey)
+      const elKey = await getSetting('elevenlabs_api_key')
+      if (elKey) setElevenlabsApiKey(elKey)
+      const elVoice = await getSetting('elevenlabs_voice_id')
+      if (elVoice) setElevenlabsVoiceId(elVoice)
+      const oaiKey = await getSetting('openai_tts_api_key')
+      if (oaiKey) setOpenaiTtsApiKey(oaiKey)
+      const oaiVoice = await getSetting('openai_tts_voice')
+      if (oaiVoice) setOpenaiTtsVoice(oaiVoice)
+    })()
+  }, [])
+
+  const handleSave = async () => {
+    await setSetting('vapi_api_key', vapiApiKey)
+    await setSetting('assistant_id', assistantId)
+    await setSetting('default_model', defaultModel)
+    await setSetting('openclaw_api_key', openclawApiKey)
+    await setSetting('openclaw_api_url', openclawApiUrl)
+    await setSetting('system_prompt', systemPrompt)
+
+    // Save voice pipeline settings
+    await setSetting('voice_mode', voiceMode)
+    await setSetting('stt_provider', sttProvider)
+    await setSetting('tts_provider', ttsProvider)
+    await setSetting('deepgram_api_key', deepgramApiKey)
+    await setSetting('elevenlabs_api_key', elevenlabsApiKey)
+    await setSetting('elevenlabs_voice_id', elevenlabsVoiceId)
+    await setSetting('openai_tts_api_key', openaiTtsApiKey)
+    await setSetting('openai_tts_voice', openaiTtsVoice)
+
+    setSaved(true)
+    Alert.alert('Settings Saved', 'Your settings have been saved successfully.')
+    setTimeout(() => setSaved(false), 2000)
+  }
+
+  return (
+    <KeyboardAvoidingView
+      className="flex-1 bg-background"
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={90}>
+      <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }} keyboardDismissMode="on-drag" keyboardShouldPersistTaps="handled">
+        <Card className="gap-4 p-4">
+          <Text className="text-lg font-semibold text-foreground">Voice Pipeline</Text>
+
+          <View className="gap-2">
+            <Text className="text-sm text-muted-foreground">Voice Mode</Text>
+            <SegmentedControl
+              options={[
+                { label: 'Vapi All-in-One', value: 'vapi' as const },
+                { label: 'Custom Pipeline', value: 'custom' as const },
+              ]}
+              value={voiceMode}
+              onChange={(v) => setVoiceMode(v)}
+            />
+          </View>
+
+          {voiceMode === 'custom' && (
+            <>
+              <View className="gap-2">
+                <Text className="text-sm text-muted-foreground">STT Provider</Text>
+                <SegmentedControl
+                  options={[
+                    { label: 'Apple On-Device', value: 'apple' as const },
+                    { label: 'Deepgram Cloud', value: 'deepgram' as const },
+                  ]}
+                  value={sttProvider}
+                  onChange={(v) => setSttProvider(v)}
+                />
+              </View>
+
+              {sttProvider === 'deepgram' && (
+                <View className="gap-2">
+                  <Text className="text-sm text-muted-foreground">Deepgram API Key</Text>
+                  <SecretInput
+                    value={deepgramApiKey}
+                    onChangeText={setDeepgramApiKey}
+                    placeholder="Enter your Deepgram API key"
+                  />
+                </View>
+              )}
+
+              <View className="gap-2">
+                <Text className="text-sm text-muted-foreground">TTS Provider</Text>
+                <OptionGroup
+                  options={[
+                    { label: 'Apple Zoe On-Device', value: 'apple' as const },
+                    { label: 'ElevenLabs Cloud', value: 'elevenlabs' as const },
+                    { label: 'OpenAI TTS Cloud', value: 'openai' as const },
+                  ]}
+                  value={ttsProvider}
+                  onChange={(v) => setTtsProvider(v)}
+                />
+              </View>
+
+              {ttsProvider === 'elevenlabs' && (
+                <>
+                  <View className="gap-2">
+                    <Text className="text-sm text-muted-foreground">ElevenLabs API Key</Text>
+                    <SecretInput
+                      value={elevenlabsApiKey}
+                      onChangeText={setElevenlabsApiKey}
+                      placeholder="Enter your ElevenLabs API key"
+                    />
+                  </View>
+                  <View className="gap-2">
+                    <Text className="text-sm text-muted-foreground">ElevenLabs Voice ID</Text>
+                    <Input
+                      placeholder="Awx8TeMHHpDzbm42nIB6"
+                      value={elevenlabsVoiceId}
+                      onChangeText={setElevenlabsVoiceId}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                    />
+                  </View>
+                </>
+              )}
+
+              {ttsProvider === 'openai' && (
+                <>
+                  <View className="gap-2">
+                    <Text className="text-sm text-muted-foreground">OpenAI TTS API Key</Text>
+                    <SecretInput
+                      value={openaiTtsApiKey}
+                      onChangeText={setOpenaiTtsApiKey}
+                      placeholder="Enter your OpenAI API key"
+                    />
+                  </View>
+                  <View className="gap-2">
+                    <Text className="text-sm text-muted-foreground">OpenAI TTS Voice</Text>
+                    <OptionGroup
+                      options={OPENAI_TTS_VOICES.map((v) => ({ label: v, value: v }))}
+                      value={openaiTtsVoice}
+                      onChange={setOpenaiTtsVoice}
+                    />
+                  </View>
+                </>
+              )}
+            </>
+          )}
+        </Card>
+
+        {voiceMode === 'vapi' && (
+          <Card className="gap-4 p-4">
+            <Text className="text-lg font-semibold text-foreground">Vapi Configuration</Text>
+
+            <View className="gap-2">
+              <Text className="text-sm text-muted-foreground">API Key</Text>
+              <SecretInput
+                value={vapiApiKey}
+                onChangeText={setVapiApiKey}
+                placeholder="Enter your Vapi API key"
+              />
+            </View>
+
+            <View className="gap-2">
+              <Text className="text-sm text-muted-foreground">Assistant ID</Text>
+              <Input
+                placeholder="Enter your Vapi Assistant ID"
+                value={assistantId}
+                onChangeText={setAssistantId}
+                autoCapitalize="none"
+                autoCorrect={false}
+              />
+            </View>
+
+            <View className="gap-2">
+              <Text className="text-sm text-muted-foreground">Default Model</Text>
+              <Input
+                placeholder="e.g. gpt-4o, claude-3-opus"
+                value={defaultModel}
+                onChangeText={setDefaultModel}
+                autoCapitalize="none"
+                autoCorrect={false}
+              />
+            </View>
+
+            <View className="gap-2">
+              <Text className="text-sm text-muted-foreground">System Prompt</Text>
+              <TextInput
+                className="min-h-[80px] rounded-md border border-input bg-background px-3 py-2 text-base text-foreground dark:bg-input/30"
+                placeholder="Default: Keep responses concise. Use markdown for formatting and images when appropriate."
+                placeholderTextColor="#888"
+                value={systemPrompt}
+                onChangeText={setSystemPrompt}
+                multiline
+                textAlignVertical="top"
+              />
+            </View>
+          </Card>
+        )}
+
+        <Card className="gap-4 p-4">
+          <Text className="text-lg font-semibold text-foreground">OpenClaw Configuration</Text>
+
+          <View className="gap-2">
+            <Text className="text-sm text-muted-foreground">API URL</Text>
+            <Input
+              placeholder="https://your-server.com/v1/chat/completions"
+              value={openclawApiUrl}
+              onChangeText={setOpenclawApiUrl}
+              autoCapitalize="none"
+              autoCorrect={false}
+              keyboardType="url"
+            />
+          </View>
+
+          <View className="gap-2">
+            <Text className="text-sm text-muted-foreground">API Key</Text>
+            <SecretInput
+              value={openclawApiKey}
+              onChangeText={setOpenclawApiKey}
+              placeholder="Enter your OpenClaw API key"
+            />
+          </View>
+        </Card>
+
+        <Button onPress={handleSave}>
+          <Text>{saved ? 'Saved!' : 'Save Settings'}</Text>
+        </Button>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  )
+}
+
+// --- Helper Components ---
 
 function SecretInput({
   value,
@@ -44,127 +318,75 @@ function SecretInput({
   )
 }
 
-export default function SettingsScreen() {
-  const [vapiApiKey, setVapiApiKey] = useState('')
-  const [assistantId, setAssistantId] = useState('')
-  const [defaultModel, setDefaultModel] = useState('openclaw:voice')
-  const [openclawApiKey, setOpenclawApiKey] = useState('')
-  const [openclawApiUrl, setOpenclawApiUrl] = useState('')
-  const [systemPrompt, setSystemPrompt] = useState('You are a helpful assistant. Keep responses concise. Use markdown for formatting and images when appropriate. Your identity, personality, and capabilities are defined in your system files.')
-  const [saved, setSaved] = useState(false)
-
-  useEffect(() => {
-    ;(async () => {
-      const key = await getSetting('vapi_api_key')
-      const assistant = await getSetting('assistant_id')
-      const model = await getSetting('default_model')
-      const ocKey = await getSetting('openclaw_api_key')
-      const ocUrl = await getSetting('openclaw_api_url')
-      if (key) setVapiApiKey(key)
-      if (assistant) setAssistantId(assistant)
-      if (model) setDefaultModel(model)
-      if (ocKey) setOpenclawApiKey(ocKey)
-      if (ocUrl) setOpenclawApiUrl(ocUrl)
-      const sp = await getSetting('system_prompt')
-      if (sp) setSystemPrompt(sp)
-    })()
-  }, [])
-
-  const handleSave = async () => {
-    await setSetting('vapi_api_key', vapiApiKey)
-    await setSetting('assistant_id', assistantId)
-    await setSetting('default_model', defaultModel)
-    await setSetting('openclaw_api_key', openclawApiKey)
-    await setSetting('openclaw_api_url', openclawApiUrl)
-    await setSetting('system_prompt', systemPrompt)
-    setSaved(true)
-    Alert.alert('Settings Saved', 'Your settings have been saved successfully.')
-    setTimeout(() => setSaved(false), 2000)
-  }
-
+function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: Array<{ label: string, value: T }>
+  value: T
+  onChange: (value: T) => void
+}) {
   return (
-    <KeyboardAvoidingView
-      className="flex-1 bg-background"
-      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-      keyboardVerticalOffset={90}>
-      <ScrollView contentContainerStyle={{ padding: 16, gap: 16 }} keyboardDismissMode="on-drag" keyboardShouldPersistTaps="handled">
-        <Card className="gap-4 p-4">
-          <Text className="text-lg font-semibold text-foreground">Vapi Configuration</Text>
+    <View className="flex-row rounded-lg border border-input bg-background dark:bg-input/30">
+      {options.map((option, index) => (
+        <Pressable
+          key={option.value}
+          onPress={() => onChange(option.value)}
+          className={`flex-1 items-center px-3 py-2 ${
+            value === option.value ? 'rounded-lg bg-primary' : ''
+          } ${index > 0 ? 'border-l border-input' : ''}`}
+        >
+          <Text
+            className={`text-sm font-medium ${
+              value === option.value ? 'text-primary-foreground' : 'text-muted-foreground'
+            }`}
+          >
+            {option.label}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
+  )
+}
 
-          <View className="gap-2">
-            <Text className="text-sm text-muted-foreground">API Key</Text>
-            <SecretInput
-              value={vapiApiKey}
-              onChangeText={setVapiApiKey}
-              placeholder="Enter your Vapi API key"
-            />
+function OptionGroup<T extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: Array<{ label: string, value: T }>
+  value: T
+  onChange: (value: T) => void
+}) {
+  return (
+    <View className="gap-1">
+      {options.map((option) => (
+        <Pressable
+          key={option.value}
+          onPress={() => onChange(option.value)}
+          className={`flex-row items-center rounded-lg px-3 py-2 ${
+            value === option.value ? 'border border-primary bg-primary/10' : 'border border-input'
+          }`}
+        >
+          <View
+            className={`mr-3 h-4 w-4 items-center justify-center rounded-full border ${
+              value === option.value ? 'border-primary' : 'border-muted-foreground'
+            }`}
+          >
+            {value === option.value && (
+              <View className="h-2 w-2 rounded-full bg-primary" />
+            )}
           </View>
-
-          <View className="gap-2">
-            <Text className="text-sm text-muted-foreground">Assistant ID</Text>
-            <Input
-              placeholder="Enter your Vapi Assistant ID"
-              value={assistantId}
-              onChangeText={setAssistantId}
-              autoCapitalize="none"
-              autoCorrect={false}
-            />
-          </View>
-
-          <View className="gap-2">
-            <Text className="text-sm text-muted-foreground">Default Model</Text>
-            <Input
-              placeholder="e.g. gpt-4o, claude-3-opus"
-              value={defaultModel}
-              onChangeText={setDefaultModel}
-              autoCapitalize="none"
-              autoCorrect={false}
-            />
-          </View>
-
-          <View className="gap-2">
-            <Text className="text-sm text-muted-foreground">System Prompt</Text>
-            <TextInput
-              className="min-h-[80px] rounded-md border border-input bg-background px-3 py-2 text-base text-foreground dark:bg-input/30"
-              placeholder="Default: Keep responses concise. Use markdown for formatting and images when appropriate."
-              placeholderTextColor="#888"
-              value={systemPrompt}
-              onChangeText={setSystemPrompt}
-              multiline
-              textAlignVertical="top"
-            />
-          </View>
-        </Card>
-
-        <Card className="gap-4 p-4">
-          <Text className="text-lg font-semibold text-foreground">OpenClaw Configuration</Text>
-
-          <View className="gap-2">
-            <Text className="text-sm text-muted-foreground">API URL</Text>
-            <Input
-              placeholder="https://your-server.com/v1/chat/completions"
-              value={openclawApiUrl}
-              onChangeText={setOpenclawApiUrl}
-              autoCapitalize="none"
-              autoCorrect={false}
-              keyboardType="url"
-            />
-          </View>
-
-          <View className="gap-2">
-            <Text className="text-sm text-muted-foreground">API Key</Text>
-            <SecretInput
-              value={openclawApiKey}
-              onChangeText={setOpenclawApiKey}
-              placeholder="Enter your OpenClaw API key"
-            />
-          </View>
-        </Card>
-
-        <Button onPress={handleSave}>
-          <Text>{saved ? 'Saved!' : 'Save Settings'}</Text>
-        </Button>
-      </ScrollView>
-    </KeyboardAvoidingView>
+          <Text
+            className={`text-sm ${
+              value === option.value ? 'font-medium text-foreground' : 'text-muted-foreground'
+            }`}
+          >
+            {option.label}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
   )
 }

--- a/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
+++ b/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
@@ -21,22 +21,46 @@ public class ExpoCustomPipelineModule: Module {
             self.pipelineManager.delegate = self
         }
 
-        Function("setSTTProvider") { (name: String) in
+        Function("setSTTProvider") { (name: String, config: [String: String]?) in
             self.sttProviderName = name
             print("[ExpoCustomPipeline] STT provider set to: \(name)")
 
             switch name {
             case "apple":
                 self.pipelineManager.setSTTProvider(AppleSTTProvider())
+            case "deepgram":
+                let provider = DeepgramSTTProvider()
+                if let apiKey = config?["apiKey"], !apiKey.isEmpty {
+                    provider.configure(apiKey: apiKey)
+                }
+                self.pipelineManager.setSTTProvider(provider)
             default:
                 print("[ExpoCustomPipeline] Unknown STT provider: \(name)")
             }
         }
 
-        Function("setTTSProvider") { (name: String) in
+        Function("setTTSProvider") { (name: String, config: [String: String]?) in
             self.ttsProviderName = name
             print("[ExpoCustomPipeline] TTS provider set to: \(name)")
-            // Provider implementations will be registered in future tickets
+
+            switch name {
+            case "apple":
+                self.pipelineManager.setTTSProvider(AppleTTSProvider())
+            case "elevenlabs":
+                let provider = ElevenLabsTTSProvider()
+                if let apiKey = config?["apiKey"], !apiKey.isEmpty {
+                    provider.configure(apiKey: apiKey, voiceId: config?["voiceId"])
+                }
+                self.pipelineManager.setTTSProvider(provider)
+            case "openai":
+                let provider = OpenAITTSProvider()
+                if let apiKey = config?["apiKey"], !apiKey.isEmpty {
+                    provider.configure(apiKey: apiKey, voice: config?["voice"])
+                }
+                self.pipelineManager.setTTSProvider(provider)
+            default:
+                print("[ExpoCustomPipeline] Unknown TTS provider: \(name)")
+            }
         }
 
         Function("startListening") { () in

--- a/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule.ts
+++ b/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule.ts
@@ -3,8 +3,8 @@ import { NativeModule, requireNativeModule } from 'expo'
 import { ExpoCustomPipelineModuleEvents, LatencyStats } from './ExpoCustomPipeline.types'
 
 declare class ExpoCustomPipelineModule extends NativeModule<ExpoCustomPipelineModuleEvents> {
-  setSTTProvider(name: string): void
-  setTTSProvider(name: string): void
+  setSTTProvider(name: string, config?: Record<string, string>): void
+  setTTSProvider(name: string, config?: Record<string, string>): void
   startListening(): void
   stopListening(): void
   speak(text: string): void


### PR DESCRIPTION
## Summary
- Add "Voice Pipeline" settings card with a segmented control to toggle between "Vapi All-in-One" (default) and "Custom Pipeline" voice modes
- When Custom Pipeline is selected, show STT provider picker (Apple On-Device / Deepgram Cloud) and TTS provider picker (Apple Zoe / ElevenLabs / OpenAI) with provider-specific API key and config fields
- Wire up chat screen mic button to read `voice_mode` setting and branch between existing Vapi flow and new custom pipeline flow, configuring STT/TTS providers with saved settings
- Update native Swift module to accept config dictionaries for `setSTTProvider` and `setTTSProvider`, enabling Deepgram STT with API key and ElevenLabs/OpenAI TTS with API keys and voice selection

## Test plan
- [ ] Verify Vapi mode still works exactly as before (default behavior unchanged)
- [ ] Switch to Custom Pipeline mode in settings, configure Apple STT + Apple TTS, tap mic -- should start custom pipeline conversation
- [ ] Configure Deepgram STT with API key, verify speech recognition works
- [ ] Configure ElevenLabs TTS with API key, verify TTS playback
- [ ] Configure OpenAI TTS with API key and voice selection, verify TTS playback
- [ ] Verify settings persist across app restarts
- [ ] Verify Vapi config cards hide when Custom Pipeline selected, and vice versa

🤖 Generated with [Claude Code](https://claude.com/claude-code)