### PR TITLE
Add latency tracking and stats display for Custom Pipeline (NAN-581)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,8 +1,9 @@
+import { LatencyBadge } from '@/components/latency-badge'
 import { Button } from '@/components/ui/button'
 import { Icon } from '@/components/ui/icon'
 import { Input } from '@/components/ui/input'
 import { Text } from '@/components/ui/text'
-import { addMessage, createConversation, getConversation, getLatestConversation, getMessages, getSetting, updateConversationVapi, type Message } from '@/db'
+import { addMessage, createConversation, getConversation, getLatestConversation, getMessages, getSetting, updateConversationVapi, type Message, type LatencyData } from '@/db'
 import { getApiConfig, streamCompletion } from '@/lib/chat'
 import { compactMessages } from '@/lib/compact'
 import { useConversationContext } from '@/lib/conversation-context'
@@ -11,6 +12,8 @@ import { useCallSounds } from '@/lib/sounds'
 import { useTranscriptBuffer } from '@/lib/use-transcript-buffer'
 import { useAutoReconnect } from '@/lib/use-auto-reconnect'
 import { sendVapiChat, syncMessagesToVapi } from '@/lib/vapi-chat'
+import ExpoCustomPipelineModule from '@/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule'
+import type { LatencyUpdateEvent } from '@/modules/expo-custom-pipeline/src/ExpoCustomPipeline.types'
 import ExpoVapiModule from '@/modules/expo-vapi'
 import type { FunctionCallEvent, SpeechEvent, TranscriptEvent } from '@/modules/expo-vapi'
 import { Stack } from 'expo-router'
@@ -91,6 +94,7 @@ export default function ChatScreen() {
   const wasCallActiveRef = useRef(false)
   const lastCallOverridesRef = useRef<Record<string, unknown> | null>(null)
   const lastAssistantIdRef = useRef<string | null>(null)
+  const pendingLatencyRef = useRef<LatencyData | null>(null)
   const loadMessages = useCallback(async () => {
     if (!conversationId) return
     setMessages(await getMessages(conversationId))
@@ -100,7 +104,10 @@ export default function ChatScreen() {
     if (!conversationId) return
     if (__DEV__) console.log('[Chat] Transcript flush:', role, text.substring(0, 50))
     try {
-      await addMessage(conversationId, role, text)
+      // Attach latency data to assistant messages from Custom Pipeline
+      const latency = role === 'assistant' ? pendingLatencyRef.current ?? undefined : undefined
+      if (role === 'assistant') pendingLatencyRef.current = null
+      await addMessage(conversationId, role, text, latency)
       await loadMessages()
       maybeGenerateTitle(conversationId)
     } catch (err) {
@@ -270,6 +277,21 @@ export default function ChatScreen() {
     ]
     return () => subs.forEach((s) => s.remove())
   }, [conversationId, cancelReconnect, triggerReconnect])
+
+  // Listen for latency updates from the Custom Pipeline
+  useEffect(() => {
+    const sub = ExpoCustomPipelineModule.addListener(
+      'onLatencyUpdate',
+      (event: LatencyUpdateEvent) => {
+        pendingLatencyRef.current = {
+          sttLatencyMs: event.sttLatencyMs,
+          llmLatencyMs: event.llmLatencyMs,
+          ttsLatencyMs: event.ttsLatencyMs,
+        }
+      }
+    )
+    return () => sub.remove()
+  }, [])
 
   const startNewConversation = useCallback(async () => {
     hasScrolledRef.current = false
@@ -498,7 +520,7 @@ export default function ChatScreen() {
   }, [isMuted])
 
   const displayMessages = streamingText !== null
-    ? [...messages, { id: -1, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: streamingText, created_at: Date.now() }]
+    ? [...messages, { id: -1, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: streamingText, created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null }]
     : messages
 
   const { partials } = transcriptBuffer
@@ -522,7 +544,12 @@ export default function ChatScreen() {
         ref={flatListRef}
         data={displayMessages}
         keyExtractor={(item) => item.id.toString()}
-        renderItem={({ item }) => <MessageBubble message={item} />}
+        renderItem={({ item }) => (
+          <>
+            <MessageBubble message={item} />
+            <LatencyBadge message={item} />
+          </>
+        )}
         contentContainerStyle={{ paddingTop: 16, paddingBottom: 8 }}
         onContentSizeChange={() => {
           const animated = hasScrolledRef.current

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -3,10 +3,10 @@ import { Card } from '@/components/ui/card'
 import { Icon } from '@/components/ui/icon'
 import { Input } from '@/components/ui/input'
 import { Text } from '@/components/ui/text'
-import { getSetting, setSetting } from '@/db'
+import { getSetting, setSetting, getLatencyAverages, type LatencyAverages } from '@/db'
 import { EyeIcon, EyeOffIcon } from 'lucide-react-native'
-import { useEffect, useState } from 'react'
-import { Alert, Keyboard, KeyboardAvoidingView, Platform, Pressable, ScrollView, TextInput, TouchableWithoutFeedback, View } from 'react-native'
+import { useCallback, useEffect, useState } from 'react'
+import { ActivityIndicator, Alert, Keyboard, KeyboardAvoidingView, Platform, Pressable, ScrollView, TextInput, TouchableWithoutFeedback, View } from 'react-native'
 
 function SecretInput({
   value,
@@ -52,6 +52,22 @@ export default function SettingsScreen() {
   const [openclawApiUrl, setOpenclawApiUrl] = useState('')
   const [systemPrompt, setSystemPrompt] = useState('You are a helpful assistant. Keep responses concise. Use markdown for formatting and images when appropriate. Your identity, personality, and capabilities are defined in your system files.')
   const [saved, setSaved] = useState(false)
+  const [latencyStats, setLatencyStats] = useState<LatencyAverages | null>(null)
+  const [loadingStats, setLoadingStats] = useState(true)
+
+  const loadLatencyStats = useCallback(async () => {
+    setLoadingStats(true)
+    try {
+      const stats = await getLatencyAverages()
+      setLatencyStats(stats)
+    } catch (err) {
+      console.warn('[Settings] Failed to load latency stats:', err)
+    } finally {
+      setLoadingStats(false)
+    }
+  }, [])
+
+  useEffect(() => { loadLatencyStats() }, [loadLatencyStats])
 
   useEffect(() => {
     ;(async () => {
@@ -161,10 +177,51 @@ export default function SettingsScreen() {
           </View>
         </Card>
 
+        <Card className="gap-4 p-4">
+          <Text className="text-lg font-semibold text-foreground">Latency Stats</Text>
+          {loadingStats ? (
+            <ActivityIndicator size="small" color="#888" />
+          ) : latencyStats && latencyStats.turnCount > 0 ? (
+            <View className="gap-2">
+              <LatencyStatRow label="Avg STT" value={latencyStats.avgStt} />
+              <LatencyStatRow label="Avg LLM" value={latencyStats.avgLlm} />
+              <LatencyStatRow label="Avg TTS" value={latencyStats.avgTts} />
+              <LatencyStatRow label="Avg Total" value={latencyStats.avgTotal} />
+              <Text className="text-xs text-muted-foreground/60">
+                Based on {latencyStats.turnCount} turn{latencyStats.turnCount !== 1 ? 's' : ''} with latency data
+              </Text>
+            </View>
+          ) : (
+            <Text className="text-sm text-muted-foreground">
+              No latency data yet. Use Custom Pipeline mode to collect stats.
+            </Text>
+          )}
+        </Card>
+
         <Button onPress={handleSave}>
           <Text>{saved ? 'Saved!' : 'Save Settings'}</Text>
         </Button>
       </ScrollView>
     </KeyboardAvoidingView>
   )
+}
+
+// --- Helper Components ---
+
+function LatencyStatRow({ label, value }: { label: string, value: number | null }) {
+  return (
+    <View className="flex-row items-center justify-between">
+      <Text className="text-sm text-muted-foreground">{label}</Text>
+      <Text className="text-sm font-medium text-foreground">
+        {value != null ? formatLatencyMs(value) : '--'}
+      </Text>
+    </View>
+  )
+}
+
+// --- Helper Functions ---
+
+function formatLatencyMs(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`
+  return `${Math.round(ms)}ms`
 }

--- a/components/latency-badge.tsx
+++ b/components/latency-badge.tsx
@@ -1,0 +1,39 @@
+import { Text } from '@/components/ui/text'
+import { View } from 'react-native'
+import type { Message } from '@/db'
+
+type LatencyBadgeProps = {
+  message: Message
+}
+
+export function LatencyBadge({ message }: LatencyBadgeProps) {
+  if (!hasLatencyData(message)) return null
+
+  const parts: string[] = []
+  if (message.stt_latency_ms != null) parts.push(`STT: ${formatMs(message.stt_latency_ms)}`)
+  if (message.llm_latency_ms != null) parts.push(`LLM: ${formatMs(message.llm_latency_ms)}`)
+  if (message.tts_latency_ms != null) parts.push(`TTS: ${formatMs(message.tts_latency_ms)}`)
+
+  return (
+    <View className="mt-1 px-4">
+      <Text className="text-xs text-muted-foreground/60">
+        {parts.join(' | ')}
+      </Text>
+    </View>
+  )
+}
+
+// --- Helper Functions ---
+
+function hasLatencyData(message: Message): boolean {
+  return (
+    message.stt_latency_ms != null ||
+    message.llm_latency_ms != null ||
+    message.tts_latency_ms != null
+  )
+}
+
+function formatMs(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`
+  return `${Math.round(ms)}ms`
+}

--- a/db/index.ts
+++ b/db/index.ts
@@ -9,11 +9,11 @@ export {
   deleteAllConversations,
   updateConversationVapi,
 } from './conversations'
-export { addMessage, getMessages } from './messages'
+export { addMessage, getMessages, getLatencyAverages } from './messages'
 export { getSetting, setSetting, getAllSettings } from './settings'
 export { getSummary, saveSummary, deleteSummaries } from './summaries'
 export { runMigrations } from './migrations'
 
 export type { Conversation, ConversationWithPreview } from './conversations'
-export type { Message } from './messages'
+export type { Message, LatencyData, LatencyAverages } from './messages'
 export type { ConversationSummary } from './summaries'

--- a/db/messages.ts
+++ b/db/messages.ts
@@ -6,17 +6,39 @@ export type Message = {
   role: 'user' | 'assistant'
   content: string
   created_at: number
+  stt_latency_ms: number | null
+  llm_latency_ms: number | null
+  tts_latency_ms: number | null
+}
+
+export type LatencyData = {
+  sttLatencyMs?: number
+  llmLatencyMs?: number
+  ttsLatencyMs?: number
+}
+
+export type LatencyAverages = {
+  avgStt: number | null
+  avgLlm: number | null
+  avgTts: number | null
+  avgTotal: number | null
+  turnCount: number
 }
 
 export async function addMessage(
   conversationId: number,
   role: 'user' | 'assistant',
-  content: string
+  content: string,
+  latency?: LatencyData
 ): Promise<Message> {
   const now = Date.now()
+  const stt = latency?.sttLatencyMs ?? null
+  const llm = latency?.llmLatencyMs ?? null
+  const tts = latency?.ttsLatencyMs ?? null
+
   const result = await db.runAsync(
-    'INSERT INTO messages (conversation_id, role, content, created_at) VALUES (?, ?, ?, ?)',
-    [conversationId, role, content, now]
+    'INSERT INTO messages (conversation_id, role, content, created_at, stt_latency_ms, llm_latency_ms, tts_latency_ms) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    [conversationId, role, content, now, stt, llm, tts]
   )
 
   await db.runAsync('UPDATE conversations SET updated_at = ? WHERE id = ?', [now, conversationId])
@@ -27,6 +49,9 @@ export async function addMessage(
     role,
     content,
     created_at: now,
+    stt_latency_ms: stt,
+    llm_latency_ms: llm,
+    tts_latency_ms: tts,
   }
 }
 
@@ -35,4 +60,37 @@ export async function getMessages(conversationId: number): Promise<Message[]> {
     'SELECT * FROM messages WHERE conversation_id = ? ORDER BY created_at ASC',
     [conversationId]
   )
+}
+
+export async function getLatencyAverages(): Promise<LatencyAverages> {
+  const row = await db.getFirstAsync<{
+    avg_stt: number | null
+    avg_llm: number | null
+    avg_tts: number | null
+    avg_total: number | null
+    turn_count: number
+  }>(
+    `SELECT
+      AVG(stt_latency_ms) as avg_stt,
+      AVG(llm_latency_ms) as avg_llm,
+      AVG(tts_latency_ms) as avg_tts,
+      AVG(COALESCE(stt_latency_ms, 0) + COALESCE(llm_latency_ms, 0) + COALESCE(tts_latency_ms, 0)) as avg_total,
+      COUNT(*) as turn_count
+    FROM messages
+    WHERE stt_latency_ms IS NOT NULL
+      OR llm_latency_ms IS NOT NULL
+      OR tts_latency_ms IS NOT NULL`
+  )
+
+  if (!row) {
+    return { avgStt: null, avgLlm: null, avgTts: null, avgTotal: null, turnCount: 0 }
+  }
+
+  return {
+    avgStt: row.avg_stt,
+    avgLlm: row.avg_llm,
+    avgTts: row.avg_tts,
+    avgTotal: row.avg_total,
+    turnCount: row.turn_count,
+  }
 }

--- a/db/migrations.ts
+++ b/db/migrations.ts
@@ -4,9 +4,21 @@ import { CREATE_TABLES } from './schema'
 export async function runMigrations() {
   await db.execAsync(CREATE_TABLES)
   await addVapiColumns()
+  await addLatencyColumns()
 }
 
 // --- Migration Helpers ---
+
+async function addLatencyColumns() {
+  const columns = ['stt_latency_ms', 'llm_latency_ms', 'tts_latency_ms']
+  for (const col of columns) {
+    try {
+      await db.execAsync(`ALTER TABLE messages ADD COLUMN ${col} REAL`)
+    } catch {
+      // Column already exists
+    }
+  }
+}
 
 async function addVapiColumns() {
   try {

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -16,7 +16,10 @@ export const CREATE_TABLES = `
     conversation_id INTEGER NOT NULL REFERENCES conversations(id),
     role TEXT NOT NULL CHECK(role IN ('user', 'assistant')),
     content TEXT NOT NULL,
-    created_at INTEGER NOT NULL
+    created_at INTEGER NOT NULL,
+    stt_latency_ms REAL,
+    llm_latency_ms REAL,
+    tts_latency_ms REAL
   );
 
   CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id);

--- a/lib/use-custom-pipeline.ts
+++ b/lib/use-custom-pipeline.ts
@@ -7,11 +7,13 @@ import type {
   LatencyUpdateEvent,
   LatencyStats,
 } from '../modules/expo-custom-pipeline/src/ExpoCustomPipeline.types'
+import type { LatencyData } from '@/db'
 
 export type CustomPipelineConfig = {
   apiUrl: string
   apiKey: string
   model: string
+  onLatencyUpdate?: (latency: LatencyData) => void
 }
 
 export type CustomPipelineState = {
@@ -33,6 +35,8 @@ export function useCustomPipeline(config: CustomPipelineConfig): CustomPipelineS
     ttsLatencyMs: 0,
   })
   const subscriptions = useRef<Array<{ remove: () => void }>>([])
+  const onLatencyUpdateRef = useRef(config.onLatencyUpdate)
+  onLatencyUpdateRef.current = config.onLatencyUpdate
 
   useEffect(() => {
     const subs = [
@@ -60,6 +64,11 @@ export function useCustomPipeline(config: CustomPipelineConfig): CustomPipelineS
         'onLatencyUpdate',
         (event: LatencyUpdateEvent) => {
           setLatencyStats({
+            sttLatencyMs: event.sttLatencyMs,
+            llmLatencyMs: event.llmLatencyMs,
+            ttsLatencyMs: event.ttsLatencyMs,
+          })
+          onLatencyUpdateRef.current?.({
             sttLatencyMs: event.sttLatencyMs,
             llmLatencyMs: event.llmLatencyMs,
             ttsLatencyMs: event.ttsLatencyMs,


### PR DESCRIPTION
## Summary
- Add `stt_latency_ms`, `llm_latency_ms`, `tts_latency_ms` columns to the messages table (schema + migration for existing DBs)
- Update `addMessage` to accept optional `LatencyData`, update `Message` type with nullable latency fields
- Create `LatencyBadge` component that renders "STT: 45ms | LLM: 2.1s | TTS: 180ms" in muted gray text below message bubbles (only for messages with latency data)
- Wire up `onLatencyUpdate` events from Custom Pipeline module in the chat screen, storing per-turn latency in a ref and attaching it to assistant messages on flush
- Add `onLatencyUpdate` callback to the `useCustomPipeline` hook config
- Add "Latency Stats" section to Settings page showing average STT, LLM, TTS, and total turn latency queried from the messages table
- Add `getLatencyAverages()` query function and `LatencyAverages` type

## Test plan
- [ ] Verify app builds: `npx tsc --noEmit` passes
- [ ] Start a Custom Pipeline voice call and confirm latency badges appear under assistant messages
- [ ] Check Settings page shows Latency Stats section with "No latency data yet" when empty
- [ ] After Custom Pipeline conversations, verify Settings shows correct average latency values
- [ ] Confirm Vapi mode messages do NOT show latency badges (no latency data attached)
- [ ] Verify existing messages without latency columns load correctly (migration handles existing DBs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)