### PR TITLE
Show thinking indicator inline in assistant response bubble

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -20,10 +20,11 @@ import { Stack } from 'expo-router'
 import { MicIcon, MicOffIcon, PhoneOffIcon, PlusIcon, RefreshCwIcon, SendIcon, XIcon } from 'lucide-react-native'
 import { useColorScheme } from 'nativewind'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { ActivityIndicator, FlatList, Image, KeyboardAvoidingView, Platform, Pressable, View } from 'react-native'
+import { ActivityIndicator, Animated, FlatList, Image, KeyboardAvoidingView, Platform, Pressable, View } from 'react-native'
 
 const MD_IMAGE_REGEX = /!\[([^\]]*)\]\(([^)]+)\)/g
 const URL_IMAGE_REGEX = /(?:^|\s)(https?:\/\/\S+\.(?:png|jpg|jpeg|gif|webp)(?:\?\S*)?)/gi
+const THINKING_MESSAGE_ID = -2
 
 const VOICE_SYSTEM_PROMPT = `\
 You are on a live voice call. Keep responses concise and conversational — short \
@@ -689,9 +690,15 @@ export default function ChatScreen() {
     setIsMuted(newMuted)
   }, [isMuted])
 
-  const displayMessages = streamingText !== null
-    ? [...messages, { id: -1, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: streamingText, created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null }]
-    : messages
+  const displayMessages = (() => {
+    let msgs = messages as Message[]
+    if (streamingText !== null) {
+      msgs = [...msgs, { id: -1, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: streamingText, created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null }]
+    } else if (isThinking) {
+      msgs = [...msgs, { id: THINKING_MESSAGE_ID, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: '', created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null }]
+    }
+    return msgs
+  })()
 
   const { partials } = transcriptBuffer
 
@@ -742,15 +749,6 @@ export default function ChatScreen() {
           ) : null
         }
       />
-
-      {isThinking && (
-        <View className="flex-row items-center gap-2 px-4 py-2">
-          <View className="flex-row items-center gap-2 rounded-2xl rounded-bl-sm bg-muted px-4 py-3">
-            <ActivityIndicator size="small" color="#888" />
-            <Text className="text-sm text-muted-foreground">Thinking...</Text>
-          </View>
-        </View>
-      )}
 
       {reconnectState.status === 'reconnecting' && (
         <View className="items-center gap-2 border-t border-border bg-muted/50 px-4 py-3">
@@ -838,6 +836,53 @@ function PartialBubble({ role, text }: { role: 'user' | 'assistant', text: strin
   )
 }
 
+function ThinkingDots() {
+  const dot1 = useRef(new Animated.Value(0.3)).current
+  const dot2 = useRef(new Animated.Value(0.3)).current
+  const dot3 = useRef(new Animated.Value(0.3)).current
+
+  useEffect(() => {
+    const animate = (dot: Animated.Value, delay: number) =>
+      Animated.loop(
+        Animated.sequence([
+          Animated.delay(delay),
+          Animated.timing(dot, { toValue: 1, duration: 400, useNativeDriver: true }),
+          Animated.timing(dot, { toValue: 0.3, duration: 400, useNativeDriver: true }),
+        ])
+      )
+
+    const a1 = animate(dot1, 0)
+    const a2 = animate(dot2, 200)
+    const a3 = animate(dot3, 400)
+    a1.start()
+    a2.start()
+    a3.start()
+
+    return () => {
+      a1.stop()
+      a2.stop()
+      a3.stop()
+    }
+  }, [dot1, dot2, dot3])
+
+  return (
+    <View className="flex-row items-center gap-1.5 py-0.5">
+      {[dot1, dot2, dot3].map((dot, i) => (
+        <Animated.View
+          key={i}
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: 4,
+            backgroundColor: '#888',
+            opacity: dot,
+          }}
+        />
+      ))}
+    </View>
+  )
+}
+
 function ChatImage({ url }: { url: string }) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
@@ -871,6 +916,18 @@ function ChatImage({ url }: { url: string }) {
 
 function MessageBubble({ message }: { message: Message }) {
   const isUser = message.role === 'user'
+  const isThinkingPlaceholder = message.id === THINKING_MESSAGE_ID
+
+  if (isThinkingPlaceholder) {
+    return (
+      <View className="mb-3 px-4 items-start">
+        <View className="max-w-[80%] rounded-2xl rounded-bl-sm bg-muted px-4 py-3">
+          <ThinkingDots />
+        </View>
+      </View>
+    )
+  }
+
   const parts = parseContent(message.content)
 
   return (

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -690,15 +690,12 @@ export default function ChatScreen() {
     setIsMuted(newMuted)
   }, [isMuted])
 
-  const displayMessages = (() => {
-    let msgs = messages as Message[]
-    if (streamingText !== null) {
-      msgs = [...msgs, { id: -1, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: streamingText, created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null }]
-    } else if (isThinking) {
-      msgs = [...msgs, { id: THINKING_MESSAGE_ID, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: '', created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null }]
-    }
-    return msgs
-  })()
+  let displayMessages = messages as Message[]
+  if (streamingText !== null) {
+    displayMessages = [...messages, { id: -1, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: streamingText, created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null }]
+  } else if (isThinking) {
+    displayMessages = [...messages, { id: THINKING_MESSAGE_ID, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: '', created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null }]
+  }
 
   const { partials } = transcriptBuffer
 
@@ -724,7 +721,7 @@ export default function ChatScreen() {
         renderItem={({ item }) => (
           <>
             <MessageBubble message={item} />
-            <LatencyBadge message={item} />
+            {item.id !== THINKING_MESSAGE_ID && <LatencyBadge message={item} />}
           </>
         )}
         contentContainerStyle={{ paddingTop: 16, paddingBottom: 8 }}
@@ -842,27 +839,22 @@ function ThinkingDots() {
   const dot3 = useRef(new Animated.Value(0.3)).current
 
   useEffect(() => {
-    const animate = (dot: Animated.Value, delay: number) =>
-      Animated.loop(
-        Animated.sequence([
-          Animated.delay(delay),
-          Animated.timing(dot, { toValue: 1, duration: 400, useNativeDriver: true }),
-          Animated.timing(dot, { toValue: 0.3, duration: 400, useNativeDriver: true }),
-        ])
-      )
+    // Single loop with sequential steps prevents animation drift between dots
+    const pulse = (dot: Animated.Value) =>
+      Animated.sequence([
+        Animated.timing(dot, { toValue: 1, duration: 200, useNativeDriver: true }),
+        Animated.timing(dot, { toValue: 0.3, duration: 200, useNativeDriver: true }),
+      ])
 
-    const a1 = animate(dot1, 0)
-    const a2 = animate(dot2, 200)
-    const a3 = animate(dot3, 400)
-    a1.start()
-    a2.start()
-    a3.start()
-
-    return () => {
-      a1.stop()
-      a2.stop()
-      a3.stop()
-    }
+    const loop = Animated.loop(
+      Animated.sequence([
+        pulse(dot1),
+        pulse(dot2),
+        pulse(dot3),
+      ])
+    )
+    loop.start()
+    return () => loop.stop()
   }, [dot1, dot2, dot3])
 
   return (
@@ -874,7 +866,7 @@ function ThinkingDots() {
             width: 8,
             height: 8,
             borderRadius: 4,
-            backgroundColor: '#888',
+            backgroundColor: '#aaa',
             opacity: dot,
           }}
         />


### PR DESCRIPTION
## Summary
- **Fixes NAN-573**: The thinking/loading indicator now renders inside an assistant response bubble in the FlatList instead of as a separate element below the list
- Animated typing dots (3 pulsing circles) replace the old `ActivityIndicator + "Thinking..."` text
- When streaming starts, the thinking bubble transitions to the streamed text in the same position — no layout shift or scroll jump

## What changed
- Added a `THINKING_MESSAGE_ID` (-2) sentinel to inject a placeholder assistant message into `displayMessages` when `isThinking` is true
- Created a `ThinkingDots` component using `Animated` opacity pulses on 3 dots with staggered delays
- Updated `MessageBubble` to detect the thinking placeholder and render `ThinkingDots` instead of text content
- Removed the standalone `isThinking` block that was rendered outside the FlatList

## Test plan
- [ ] Start a voice call, speak, and verify the thinking dots appear inline as an assistant bubble (not a separate element)
- [ ] Verify no layout shift when assistant starts responding — the bubble stays in place
- [ ] Send a text message and verify the thinking dots appear inline before streaming begins
- [ ] Verify the dots animate smoothly (3 pulsing circles with staggered timing)
- [ ] Verify `npx tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)