### PR TITLE
Fix Custom Pipeline: echo cancellation, assistant messages, TTS errors

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -85,6 +85,7 @@ export default function ChatScreen() {
   const [isThinking, setIsThinking] = useState(false)
   const [isConnecting, setIsConnecting] = useState(false)
   const [streamingText, setStreamingText] = useState<string | null>(null)
+  const [streamingRole, setStreamingRole] = useState<'user' | 'assistant'>('assistant')
   const flatListRef = useRef<FlatList<Message>>(null)
   const hasScrolledRef = useRef(false)
   const { playJoin, playEnd, startThinking, stopThinking } = useCallSounds()
@@ -430,6 +431,7 @@ export default function ChatScreen() {
     streamCompletion(allMessages, apiKey, model, apiUrl, systemPrompt, conversationId, {
       onToken: (text) => {
         setIsThinking(false)
+        setStreamingRole('assistant')
         setStreamingText(text)
       },
       onDone: async (text) => {
@@ -625,6 +627,7 @@ export default function ChatScreen() {
     if (ttsProvider === 'elevenlabs') {
       const elKey = await getSetting('elevenlabs_api_key')
       const elVoice = await getSetting('elevenlabs_voice_id')
+      console.log('[CustomPipeline] ElevenLabs config — key:', elKey ? `${elKey.substring(0, 8)}...` : 'MISSING', 'voice:', elVoice || 'default')
       if (elKey) ttsConfig.apiKey = elKey
       if (elVoice) ttsConfig.voiceId = elVoice
     } else if (ttsProvider === 'openai') {
@@ -638,21 +641,40 @@ export default function ChatScreen() {
     // Set up event listeners for custom pipeline
     customPipelineSubsRef.current.forEach((s) => s.remove())
     customPipelineSubsRef.current = []
+    console.log('[CustomPipeline] Starting listeners, conversationId:', conversationId)
     const subs = [
+      ExpoCustomPipelineModule.addListener('onPartialTranscript', (event) => {
+        if (__DEV__) console.log('[CustomPipeline] Partial:', event.text?.substring(0, 50))
+        setStreamingRole('user')
+        setStreamingText(event.text)
+      }),
       ExpoCustomPipelineModule.addListener('onFinalTranscript', (event: FinalTranscriptEvent) => {
+        console.log('[CustomPipeline] Final transcript:', event.text?.substring(0, 50))
+        setStreamingText(null)
         if (conversationId) {
           addMessage(conversationId, 'user', event.text).then(() => {
             loadMessages()
             maybeGenerateTitle(conversationId)
           })
         }
+        setIsThinking(true)
+        soundsRef.current.startThinking()
+      }),
+      ExpoCustomPipelineModule.addListener('onAssistantResponse', (event) => {
+        console.log('[CustomPipeline] Assistant response:', event.text?.substring(0, 50))
+        setIsThinking(false)
+        soundsRef.current.stopThinking()
+        if (conversationId && event.text) {
+          addMessage(conversationId, 'assistant', event.text).then(() => loadMessages())
+        }
       }),
       ExpoCustomPipelineModule.addListener('onTTSStart', () => {
+        console.log('[CustomPipeline] TTS started')
         setIsThinking(false)
         soundsRef.current.stopThinking()
       }),
       ExpoCustomPipelineModule.addListener('onTTSComplete', () => {
-        // TTS finished speaking
+        console.log('[CustomPipeline] TTS complete')
       }),
       ExpoCustomPipelineModule.addListener('onError', (event) => {
         console.error('[CustomPipeline]', event.message)
@@ -666,6 +688,7 @@ export default function ChatScreen() {
     customPipelineSubsRef.current = subs
 
     // Start conversation
+    console.log('[CustomPipeline] Starting conversation with', { apiUrl, model, sttProvider, ttsProvider })
     ExpoCustomPipelineModule.startConversation(apiUrl, apiKey, model)
     setIsCallActive(true)
     setIsConnecting(false)
@@ -692,7 +715,7 @@ export default function ChatScreen() {
 
   let displayMessages = messages as Message[]
   if (streamingText !== null) {
-    displayMessages = [...messages, { id: -1, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: streamingText, created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null }]
+    displayMessages = [...messages, { id: -1, conversation_id: conversationId ?? 0, role: streamingRole, content: streamingText, created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null }]
   } else if (isThinking) {
     displayMessages = [...messages, { id: THINKING_MESSAGE_ID, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: '', created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null }]
   }

--- a/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
+++ b/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
@@ -11,6 +11,7 @@ public class ExpoCustomPipelineModule: Module {
         Events(
             "onPartialTranscript",
             "onFinalTranscript",
+            "onAssistantResponse",
             "onTTSStart",
             "onTTSComplete",
             "onLatencyUpdate",
@@ -41,7 +42,7 @@ public class ExpoCustomPipelineModule: Module {
 
         Function("setTTSProvider") { (name: String, config: [String: String]?) in
             self.ttsProviderName = name
-            print("[ExpoCustomPipeline] TTS provider set to: \(name)")
+            print("[ExpoCustomPipeline] TTS provider set to: \(name), config keys: \(config?.keys.joined(separator: ", ") ?? "nil")")
 
             switch name {
             case "apple":
@@ -86,6 +87,9 @@ public class ExpoCustomPipelineModule: Module {
                 },
                 onComplete: { [weak self] in
                     self?.sendEvent("onTTSComplete", [:])
+                },
+                onError: { [weak self] message in
+                    self?.sendEvent("onError", ["message": message])
                 }
             )
         }
@@ -117,6 +121,10 @@ extension ExpoCustomPipelineModule: PipelineManagerDelegate {
 
     func pipelineDidReceiveFinalTranscript(_ text: String) {
         sendEvent("onFinalTranscript", ["text": text])
+    }
+
+    func pipelineDidReceiveAssistantResponse(_ text: String) {
+        sendEvent("onAssistantResponse", ["text": text])
     }
 
     func pipelineDidStartSpeaking() {

--- a/modules/expo-custom-pipeline/ios/Pipeline/PipelineManager.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/PipelineManager.swift
@@ -151,7 +151,9 @@ class PipelineManager {
             let payload = String(line.dropFirst(6))
 
             if payload == "[DONE]" {
+                isStreamComplete = true
                 flushSentenceBuffer()
+                restartSTTIfReady()
                 return
             }
 
@@ -232,19 +234,23 @@ class PipelineManager {
             },
             onComplete: { [weak self] in
                 guard let self = self else { return }
-                self.pendingTTSCount -= 1
+                self.pendingTTSCount = max(0, self.pendingTTSCount - 1)
                 print("[PipelineManager] TTS chunk complete (pending: \(self.pendingTTSCount), stream done: \(self.isStreamComplete))")
                 self.delegate?.pipelineDidFinishSpeaking()
                 self.restartSTTIfReady()
             },
             onError: { [weak self] message in
-                self?.delegate?.pipelineDidEncounterError(message)
+                guard let self = self else { return }
+                self.pendingTTSCount = max(0, self.pendingTTSCount - 1)
+                self.delegate?.pipelineDidEncounterError(message)
+                self.restartSTTIfReady()
             }
         )
     }
 
     private func restartSTTIfReady() {
         guard isConversationActive, isStreamComplete, pendingTTSCount <= 0 else { return }
+        isStreamComplete = false
         print("[PipelineManager] All TTS complete, restarting STT")
         startListening()
     }

--- a/modules/expo-custom-pipeline/ios/Pipeline/PipelineManager.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/PipelineManager.swift
@@ -3,6 +3,7 @@ import Foundation
 protocol PipelineManagerDelegate: AnyObject {
     func pipelineDidReceivePartialTranscript(_ text: String)
     func pipelineDidReceiveFinalTranscript(_ text: String)
+    func pipelineDidReceiveAssistantResponse(_ text: String)
     func pipelineDidStartSpeaking()
     func pipelineDidFinishSpeaking()
     func pipelineDidUpdateLatency(stt: Double, llm: Double, tts: Double)
@@ -28,6 +29,9 @@ class PipelineManager {
     private var ttsStartTime: CFAbsoluteTime = 0
     private var urlSession: URLSession?
     private var activeTask: URLSessionDataTask?
+    private var pendingTTSCount: Int = 0
+    private var isStreamComplete: Bool = false
+    private var fullResponse: String = ""
 
     // MARK: - Public Interface
 
@@ -45,6 +49,7 @@ class PipelineManager {
         self.model = model
         isConversationActive = true
 
+        print("[PipelineManager] Starting conversation, STT: \(sttProvider?.name ?? "none"), TTS: \(ttsProvider?.name ?? "none")")
         startListening()
     }
 
@@ -55,6 +60,9 @@ class PipelineManager {
         activeTask?.cancel()
         activeTask = nil
         sentenceBuffer = ""
+        pendingTTSCount = 0
+        isStreamComplete = false
+        fullResponse = ""
     }
 
     func getLatencyStats() -> [String: Double] {
@@ -73,11 +81,14 @@ class PipelineManager {
             return
         }
 
+        print("[PipelineManager] Starting STT provider: \(stt.name)")
         stt.startListening(
             onPartialResult: { [weak self] text in
+                print("[PipelineManager] Partial transcript: \(text.prefix(50))")
                 self?.delegate?.pipelineDidReceivePartialTranscript(text)
             },
             onFinalResult: { [weak self] text in
+                print("[PipelineManager] Final transcript: \(text.prefix(50))")
                 guard let self = self, self.isConversationActive else { return }
                 self.sttLatencyMs = stt.latencyMs
                 self.delegate?.pipelineDidReceiveFinalTranscript(text)
@@ -120,6 +131,9 @@ class PipelineManager {
 
         llmStartTime = CFAbsoluteTimeGetCurrent()
         sentenceBuffer = ""
+        pendingTTSCount = 0
+        isStreamComplete = false
+        fullResponse = ""
 
         let session = URLSession(configuration: .default, delegate: SSEDelegate(manager: self), delegateQueue: nil)
         urlSession = session
@@ -154,6 +168,7 @@ class PipelineManager {
                 notifyLatencyUpdate()
             }
 
+            fullResponse += content
             sentenceBuffer += content
             trySpeakCompleteSentences()
         }
@@ -165,10 +180,15 @@ class PipelineManager {
     }
 
     fileprivate func handleSSEComplete() {
+        isStreamComplete = true
         flushSentenceBuffer()
-        if isConversationActive {
-            startListening()
+        // Emit the full assistant response so JS can save it
+        let response = fullResponse.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !response.isEmpty {
+            delegate?.pipelineDidReceiveAssistantResponse(response)
         }
+        // If no TTS is pending (e.g. empty response), restart STT now
+        restartSTTIfReady()
     }
 
     private func trySpeakCompleteSentences() {
@@ -199,6 +219,8 @@ class PipelineManager {
             return
         }
 
+        pendingTTSCount += 1
+        print("[PipelineManager] Speaking text (pending: \(pendingTTSCount)): \(text.prefix(50))")
         ttsStartTime = CFAbsoluteTimeGetCurrent()
         tts.speak(
             text: text,
@@ -209,9 +231,22 @@ class PipelineManager {
                 self.delegate?.pipelineDidStartSpeaking()
             },
             onComplete: { [weak self] in
-                self?.delegate?.pipelineDidFinishSpeaking()
+                guard let self = self else { return }
+                self.pendingTTSCount -= 1
+                print("[PipelineManager] TTS chunk complete (pending: \(self.pendingTTSCount), stream done: \(self.isStreamComplete))")
+                self.delegate?.pipelineDidFinishSpeaking()
+                self.restartSTTIfReady()
+            },
+            onError: { [weak self] message in
+                self?.delegate?.pipelineDidEncounterError(message)
             }
         )
+    }
+
+    private func restartSTTIfReady() {
+        guard isConversationActive, isStreamComplete, pendingTTSCount <= 0 else { return }
+        print("[PipelineManager] All TTS complete, restarting STT")
+        startListening()
     }
 
     private func notifyLatencyUpdate() {

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleSTTProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleSTTProvider.swift
@@ -14,6 +14,11 @@ class AppleSTTProvider: STTProvider {
     private var audioEngine = AVAudioEngine()
     private var listenStartTime: CFAbsoluteTime = 0
     private var hasReceivedFirstResult = false
+    private var silenceTimer: Timer?
+    private var lastPartialText: String = ""
+    private let silenceTimeoutSeconds: TimeInterval = 1.5
+    private var activeOnPartial: ((String) -> Void)?
+    private var activeOnFinal: ((String) -> Void)?
 
     init(locale: Locale = Locale(identifier: "en-US")) {
         speechRecognizer = SFSpeechRecognizer(locale: locale)
@@ -36,6 +41,8 @@ class AppleSTTProvider: STTProvider {
             }
 
             DispatchQueue.main.async {
+                self.activeOnPartial = onPartialResult
+                self.activeOnFinal = onFinalResult
                 self.beginRecognition(onPartialResult: onPartialResult, onFinalResult: onFinalResult)
             }
         }
@@ -44,6 +51,8 @@ class AppleSTTProvider: STTProvider {
     func stopListening() {
         guard isListening else { return }
 
+        silenceTimer?.invalidate()
+        silenceTimer = nil
         audioEngine.stop()
         audioEngine.inputNode.removeTap(onBus: 0)
         recognitionRequest?.endAudio()
@@ -52,6 +61,7 @@ class AppleSTTProvider: STTProvider {
         recognitionRequest = nil
         recognitionTask = nil
         isListening = false
+        lastPartialText = ""
     }
 
     // MARK: - Helpers
@@ -73,6 +83,9 @@ class AppleSTTProvider: STTProvider {
 
         if speechRecognizer.supportsOnDeviceRecognition {
             request.requiresOnDeviceRecognition = true
+            print("[AppleSTTProvider] Using on-device recognition")
+        } else {
+            print("[AppleSTTProvider] On-device not available, using server")
         }
 
         recognitionRequest = request
@@ -92,10 +105,16 @@ class AppleSTTProvider: STTProvider {
                 }
 
                 if result.isFinal {
+                    print("[AppleSTTProvider] Final: \(text.prefix(50))")
+                    self.silenceTimer?.invalidate()
+                    self.silenceTimer = nil
                     onFinalResult(text)
-                    self.stopListening()
+                    self.lastPartialText = ""
                 } else {
+                    print("[AppleSTTProvider] Partial: \(text.prefix(50))")
+                    self.lastPartialText = text
                     onPartialResult(text)
+                    self.resetSilenceTimer(onFinalResult: onFinalResult)
                 }
             }
 
@@ -118,6 +137,7 @@ class AppleSTTProvider: STTProvider {
         do {
             try audioEngine.start()
             isListening = true
+            print("[AppleSTTProvider] Audio engine started, listening...")
         } catch {
             print("[AppleSTTProvider] Audio engine failed to start: \(error.localizedDescription)")
             stopListening()
@@ -144,16 +164,40 @@ class AppleSTTProvider: STTProvider {
     private func configureAudioSession() {
         let audioSession = AVAudioSession.sharedInstance()
         do {
-            try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+            try audioSession.setCategory(
+                .playAndRecord, mode: .voiceChat,
+                options: [.defaultToSpeaker, .allowBluetooth]
+            )
             try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
         } catch {
             print("[AppleSTTProvider] Failed to configure audio session: \(error.localizedDescription)")
         }
     }
 
+    private func resetSilenceTimer(onFinalResult: @escaping (String) -> Void) {
+        silenceTimer?.invalidate()
+        silenceTimer = Timer.scheduledTimer(
+            withTimeInterval: silenceTimeoutSeconds,
+            repeats: false
+        ) { [weak self] _ in
+            guard let self = self, self.isListening else { return }
+            let text = self.lastPartialText
+            guard !text.isEmpty else { return }
+            print("[AppleSTTProvider] Silence timeout — emitting final: \(text.prefix(50))")
+            self.lastPartialText = ""
+            onFinalResult(text)
+            self.stopListening()
+        }
+    }
+
     private func installAudioTap(for request: SFSpeechAudioBufferRecognitionRequest) {
         let inputNode = audioEngine.inputNode
         let recordingFormat = inputNode.outputFormat(forBus: 0)
+
+        guard recordingFormat.sampleRate > 0 else {
+            print("[AppleSTTProvider] Invalid audio format — no microphone available")
+            return
+        }
 
         inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { buffer, _ in
             request.append(buffer)

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleTTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleTTSProvider.swift
@@ -19,7 +19,7 @@ class AppleTTSProvider: NSObject, TTSProvider {
 
     // MARK: - TTSProvider
 
-    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void) {
+    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void, onError: @escaping (String) -> Void) {
         onStartCallback = onStart
         onCompleteCallback = onComplete
 

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/ElevenLabsTTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/ElevenLabsTTSProvider.swift
@@ -138,8 +138,10 @@ extension ElevenLabsTTSProvider: AVAudioPlayerDelegate {
     }
 
     func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {
+        let msg = "ElevenLabs: Audio decode error: \(error?.localizedDescription ?? "unknown")"
         logger.error("[ElevenLabs] Audio decode error: \(error?.localizedDescription ?? "unknown")")
         isSpeaking = false
+        onErrorCallback?(msg)
         onCompleteCallback?()
     }
 }
@@ -151,11 +153,11 @@ private extension ElevenLabsTTSProvider {
         let audioSession = AVAudioSession.sharedInstance()
         do {
             try audioSession.setCategory(
-                .playAndRecord, mode: .default,
+                .playAndRecord, mode: .voiceChat,
                 options: [.defaultToSpeaker, .allowBluetooth]
             )
             try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
-            logger.error("[ElevenLabs] Audio session configured for playback")
+            logger.debug("[ElevenLabs] Audio session configured for playback")
         } catch {
             logger.error("[ElevenLabs] Failed to configure audio session: \(error)")
         }

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/ElevenLabsTTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/ElevenLabsTTSProvider.swift
@@ -1,4 +1,7 @@
 import AVFoundation
+import os.log
+
+private let logger = Logger(subsystem: "com.yagudaev.voiceclaw", category: "ElevenLabs")
 
 class ElevenLabsTTSProvider: NSObject, TTSProvider {
     let name = "ElevenLabs TTS"
@@ -12,6 +15,7 @@ class ElevenLabsTTSProvider: NSObject, TTSProvider {
     private var audioPlayer: AVAudioPlayer?
     private var onStartCallback: (() -> Void)?
     private var onCompleteCallback: (() -> Void)?
+    private var onErrorCallback: ((String) -> Void)?
     private var currentTask: URLSessionDataTask?
 
     // MARK: - Configuration
@@ -20,23 +24,27 @@ class ElevenLabsTTSProvider: NSObject, TTSProvider {
         self.apiKey = apiKey
         if let voiceId = voiceId { self.voiceId = voiceId }
         if let modelId = modelId { self.modelId = modelId }
+        logger.debug("[ElevenLabs] Configured with key: \(apiKey.prefix(8))..., voice: \(self.voiceId)")
     }
 
     // MARK: - TTSProvider
 
-    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void) {
+    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void, onError: @escaping (String) -> Void) {
+        logger.debug("[ElevenLabs] speak() called with text: \(text.prefix(50))")
         guard !apiKey.isEmpty else {
-            print("[ElevenLabs] API key not configured")
+            logger.error("[ElevenLabs] API key not configured")
+            onError("ElevenLabs: API key not configured")
             onComplete()
             return
         }
 
         onStartCallback = onStart
         onCompleteCallback = onComplete
+        onErrorCallback = onError
 
         let urlString = "https://api.elevenlabs.io/v1/text-to-speech/\(voiceId)/stream"
         guard let url = URL(string: urlString) else {
-            print("[ElevenLabs] Invalid URL")
+            NSLog("[ElevenLabs] Invalid URL")
             onComplete()
             return
         }
@@ -54,7 +62,7 @@ class ElevenLabsTTSProvider: NSObject, TTSProvider {
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
         } catch {
-            print("[ElevenLabs] Failed to encode body: \(error)")
+            logger.error("[ElevenLabs] Failed to encode body: \(error)")
             onComplete()
             return
         }
@@ -66,18 +74,33 @@ class ElevenLabsTTSProvider: NSObject, TTSProvider {
             guard let self = self else { return }
 
             if let error = error {
-                print("[ElevenLabs] Request error: \(error.localizedDescription)")
+                let msg = "ElevenLabs: \(error.localizedDescription)"
+                logger.error("[ElevenLabs] Request error: \(error.localizedDescription)")
                 DispatchQueue.main.async {
                     self.isSpeaking = false
+                    self.onErrorCallback?(msg)
+                    self.onCompleteCallback?()
+                }
+                return
+            }
+
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+                let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+                let msg = "ElevenLabs HTTP \(httpResponse.statusCode): \(body.prefix(200))"
+                logger.error("[ElevenLabs] HTTP \(httpResponse.statusCode): \(body.prefix(200))")
+                DispatchQueue.main.async {
+                    self.isSpeaking = false
+                    self.onErrorCallback?(msg)
                     self.onCompleteCallback?()
                 }
                 return
             }
 
             guard let data = data, !data.isEmpty else {
-                print("[ElevenLabs] Empty response")
+                logger.error("[ElevenLabs] Empty response")
                 DispatchQueue.main.async {
                     self.isSpeaking = false
+                    self.onErrorCallback?("ElevenLabs: Empty audio response")
                     self.onCompleteCallback?()
                 }
                 return
@@ -102,6 +125,7 @@ class ElevenLabsTTSProvider: NSObject, TTSProvider {
         isSpeaking = false
         onStartCallback = nil
         onCompleteCallback = nil
+        onErrorCallback = nil
     }
 }
 
@@ -114,7 +138,7 @@ extension ElevenLabsTTSProvider: AVAudioPlayerDelegate {
     }
 
     func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {
-        print("[ElevenLabs] Audio decode error: \(error?.localizedDescription ?? "unknown")")
+        logger.error("[ElevenLabs] Audio decode error: \(error?.localizedDescription ?? "unknown")")
         isSpeaking = false
         onCompleteCallback?()
     }
@@ -123,14 +147,32 @@ extension ElevenLabsTTSProvider: AVAudioPlayerDelegate {
 // MARK: - Helpers
 
 private extension ElevenLabsTTSProvider {
+    func configureAudioSessionForPlayback() {
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            try audioSession.setCategory(
+                .playAndRecord, mode: .default,
+                options: [.defaultToSpeaker, .allowBluetooth]
+            )
+            try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+            logger.error("[ElevenLabs] Audio session configured for playback")
+        } catch {
+            logger.error("[ElevenLabs] Failed to configure audio session: \(error)")
+        }
+    }
+
     func playAudioData(_ data: Data) {
+        logger.debug("[ElevenLabs] Playing audio data: \(data.count) bytes")
+        configureAudioSessionForPlayback()
         do {
             audioPlayer = try AVAudioPlayer(data: data)
             audioPlayer?.delegate = self
+            let duration = audioPlayer?.duration ?? 0
+            logger.debug("[ElevenLabs] AVAudioPlayer created, duration: \(duration)s")
             onStartCallback?()
             audioPlayer?.play()
         } catch {
-            print("[ElevenLabs] Failed to create audio player: \(error)")
+            logger.error("[ElevenLabs] Failed to create audio player: \(error)")
             isSpeaking = false
             onCompleteCallback?()
         }

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/KokoroTTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/KokoroTTSProvider.swift
@@ -9,7 +9,7 @@ class KokoroTTSProvider: TTSProvider {
 
     // MARK: - TTSProvider
 
-    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void) {
+    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void, onError: @escaping (String) -> Void) {
         print("[Kokoro] Not yet implemented")
         onComplete()
     }

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/OpenAITTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/OpenAITTSProvider.swift
@@ -24,9 +24,9 @@ class OpenAITTSProvider: NSObject, TTSProvider {
 
     // MARK: - TTSProvider
 
-    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void) {
+    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void, onError: @escaping (String) -> Void) {
         guard !apiKey.isEmpty else {
-            print("[OpenAI TTS] API key not configured")
+            onError("OpenAI TTS: API key not configured")
             onComplete()
             return
         }

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/OpenAITTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/OpenAITTSProvider.swift
@@ -11,6 +11,7 @@ class OpenAITTSProvider: NSObject, TTSProvider {
     private var audioPlayer: AVAudioPlayer?
     private var onStartCallback: (() -> Void)?
     private var onCompleteCallback: (() -> Void)?
+    private var onErrorCallback: ((String) -> Void)?
     private var currentTask: URLSessionDataTask?
 
     // MARK: - Configuration
@@ -33,6 +34,7 @@ class OpenAITTSProvider: NSObject, TTSProvider {
 
         onStartCallback = onStart
         onCompleteCallback = onComplete
+        onErrorCallback = onError
 
         guard let url = URL(string: "https://api.openai.com/v1/audio/speech") else {
             print("[OpenAI TTS] Invalid URL")
@@ -66,9 +68,23 @@ class OpenAITTSProvider: NSObject, TTSProvider {
             guard let self = self else { return }
 
             if let error = error {
+                let msg = "OpenAI TTS: \(error.localizedDescription)"
                 print("[OpenAI TTS] Request error: \(error.localizedDescription)")
                 DispatchQueue.main.async {
                     self.isSpeaking = false
+                    self.onErrorCallback?(msg)
+                    self.onCompleteCallback?()
+                }
+                return
+            }
+
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+                let body = data.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+                let msg = "OpenAI TTS HTTP \(httpResponse.statusCode): \(body.prefix(200))"
+                print("[OpenAI TTS] HTTP \(httpResponse.statusCode): \(body.prefix(200))")
+                DispatchQueue.main.async {
+                    self.isSpeaking = false
+                    self.onErrorCallback?(msg)
                     self.onCompleteCallback?()
                 }
                 return
@@ -78,6 +94,7 @@ class OpenAITTSProvider: NSObject, TTSProvider {
                 print("[OpenAI TTS] Empty response")
                 DispatchQueue.main.async {
                     self.isSpeaking = false
+                    self.onErrorCallback?("OpenAI TTS: Empty audio response")
                     self.onCompleteCallback?()
                 }
                 return
@@ -102,6 +119,7 @@ class OpenAITTSProvider: NSObject, TTSProvider {
         isSpeaking = false
         onStartCallback = nil
         onCompleteCallback = nil
+        onErrorCallback = nil
     }
 }
 
@@ -114,8 +132,10 @@ extension OpenAITTSProvider: AVAudioPlayerDelegate {
     }
 
     func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {
+        let msg = "OpenAI TTS: Audio decode error: \(error?.localizedDescription ?? "unknown")"
         print("[OpenAI TTS] Audio decode error: \(error?.localizedDescription ?? "unknown")")
         isSpeaking = false
+        onErrorCallback?(msg)
         onCompleteCallback?()
     }
 }
@@ -130,8 +150,10 @@ private extension OpenAITTSProvider {
             onStartCallback?()
             audioPlayer?.play()
         } catch {
+            let msg = "OpenAI TTS: Failed to create audio player: \(error.localizedDescription)"
             print("[OpenAI TTS] Failed to create audio player: \(error)")
             isSpeaking = false
+            onErrorCallback?(msg)
             onCompleteCallback?()
         }
     }

--- a/modules/expo-custom-pipeline/ios/Pipeline/TTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/TTSProvider.swift
@@ -4,6 +4,6 @@ protocol TTSProvider {
     var name: String { get }
     var isSpeaking: Bool { get }
     var latencyMs: Double { get }
-    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void)
+    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void, onError: @escaping (String) -> Void)
     func stop()
 }

--- a/modules/expo-custom-pipeline/src/ExpoCustomPipeline.types.ts
+++ b/modules/expo-custom-pipeline/src/ExpoCustomPipeline.types.ts
@@ -22,9 +22,14 @@ export type LatencyStats = {
   ttsLatencyMs: number
 }
 
+export type AssistantResponseEvent = {
+  text: string
+}
+
 export type ExpoCustomPipelineModuleEvents = {
   onPartialTranscript: (event: PartialTranscriptEvent) => void
   onFinalTranscript: (event: FinalTranscriptEvent) => void
+  onAssistantResponse: (event: AssistantResponseEvent) => void
   onTTSStart: () => void
   onTTSComplete: () => void
   onLatencyUpdate: (event: LatencyUpdateEvent) => void


### PR DESCRIPTION
## Summary

- **Echo fix**: Switch audio session to `.voiceChat` mode for hardware echo cancellation; add `pendingTTSCount` + `isStreamComplete` tracking so STT only restarts after ALL TTS chunks finish (not between each sentence)
- **Assistant messages**: Add `onAssistantResponse` event that emits the full LLM response so JS can save it to conversation history
- **Partial transcript side**: Fix partial transcripts showing on the wrong (assistant/left) side of chat — they're user speech so they should be on the right
- **TTS errors in UI**: Add `onError` callback to `TTSProvider.speak()` protocol; ElevenLabs (and OpenAI) now surface HTTP errors, missing API keys, etc. directly as messages in the chat UI
- **Thinking state**: Clear thinking indicator on `onAssistantResponse` so it doesn't hang forever if TTS fails

## Test plan

- [ ] Start a Custom Pipeline call with Apple TTS — verify no echo (your own voice not transcribed back)
- [ ] Have a multi-sentence exchange — verify STT only restarts after the full response is spoken
- [ ] Verify assistant responses appear in conversation history after the call
- [ ] Speak something — verify partial transcript appears on the right (user) side
- [ ] Configure ElevenLabs with an invalid API key or free-tier library voice — verify error message appears in chat UI
- [ ] Configure ElevenLabs with a valid owned voice — verify TTS speaks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)