### PR TITLE
Fix masked input fields: tap-to-focus and dot alignment (NAN-587, NAN-589)

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -335,18 +335,22 @@ function SecretInput({
   return (
     <View className="flex-row items-center rounded-md border border-input bg-background dark:bg-input/30">
       <TextInput
-        className="h-10 min-w-0 flex-1 px-3 text-base text-foreground"
+        className="h-10 min-w-0 flex-1 px-3 text-base leading-[40px] text-foreground"
         placeholder={placeholder}
         placeholderTextColor="#888"
-        value={visible ? value : value ? '\u2022'.repeat(Math.min(value.length, 30)) : ''}
-        onChangeText={visible ? onChangeText : undefined}
-        editable={visible}
+        value={value}
+        onChangeText={onChangeText}
+        secureTextEntry={!visible}
         autoCapitalize="none"
         autoCorrect={false}
         numberOfLines={1}
         scrollEnabled
       />
-      <Pressable onPress={() => setVisible((prev) => !prev)} className="shrink-0 px-3">
+      <Pressable
+        onPress={() => setVisible((prev) => !prev)}
+        className="h-10 shrink-0 items-center justify-center px-3"
+        hitSlop={{ top: 8, bottom: 8, left: 4, right: 8 }}
+      >
         <Icon
           as={visible ? EyeOffIcon : EyeIcon}
           size={20}

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -335,7 +335,7 @@ function SecretInput({
   return (
     <View className="flex-row items-center rounded-md border border-input bg-background dark:bg-input/30">
       <TextInput
-        className="h-10 min-w-0 flex-1 px-3 text-base leading-[40px] text-foreground"
+        className="h-10 min-w-0 flex-1 px-3 py-2 text-base text-foreground"
         placeholder={placeholder}
         placeholderTextColor="#888"
         value={value}
@@ -349,7 +349,7 @@ function SecretInput({
       <Pressable
         onPress={() => setVisible((prev) => !prev)}
         className="h-10 shrink-0 items-center justify-center px-3"
-        hitSlop={{ top: 8, bottom: 8, left: 4, right: 8 }}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
       >
         <Icon
           as={visible ? EyeOffIcon : EyeIcon}


### PR DESCRIPTION
## Summary
- **NAN-587:** Masked API key inputs were not focusable on tap because `editable={false}` was set when hidden. Replaced manual bullet-character rendering with native `secureTextEntry`, so the TextInput is always editable and focusable regardless of mask state.
- **NAN-589:** Masked dots were misaligned with the eye icon. Added `leading-[40px]` to the TextInput for vertical centering, and gave the eye-icon Pressable explicit height + `items-center justify-center` so both elements share the same vertical center.

## Changes
- `SecretInput` now uses `secureTextEntry={!visible}` instead of rendering `\u2022` characters manually
- TextInput is always editable and receives `onChangeText` in both states
- Eye icon Pressable has explicit `h-10` height with centering and `hitSlop` for better touch target

## Test plan
- [ ] Open Settings, scroll to any masked API key field (e.g. Vapi API Key, ElevenLabs API Key, OpenClaw API Key)
- [ ] Tap directly on the masked input field -- keyboard should appear and field should focus
- [ ] Type a value -- it should appear as masked dots
- [ ] Tap the eye icon -- value should be revealed
- [ ] Tap the eye icon again -- value should be masked again
- [ ] Verify the masked dots and eye icon are vertically centered/aligned
- [ ] Test on iOS device or Simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)