### PR TITLE
Add latency display toggle in chat and detailed stats in settings (NAN-584)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -401,7 +401,7 @@ export default function ChatScreen() {
   }, [])
 
   useEffect(() => {
-    getSetting('show_latency').then((v) => { if (v === 'true') setShowLatency(true) })
+    getSetting('show_latency').then((v) => { if (v === 'true') setShowLatency(true) }).catch(() => {})
   }, [])
 
   useEffect(() => { loadMessages() }, [loadMessages])

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button'
 import { Icon } from '@/components/ui/icon'
 import { Input } from '@/components/ui/input'
 import { Text } from '@/components/ui/text'
-import { addMessage, createConversation, getConversation, getLatestConversation, getMessages, getSetting, updateConversationVapi, type Message, type LatencyData } from '@/db'
+import { addMessage, createConversation, getConversation, getLatestConversation, getMessages, getSetting, setSetting, updateConversationVapi, type Message, type LatencyData } from '@/db'
 import { getApiConfig, streamCompletion } from '@/lib/chat'
 import { compactMessages } from '@/lib/compact'
 import { useConversationContext } from '@/lib/conversation-context'
@@ -17,7 +17,7 @@ import type { FinalTranscriptEvent, LatencyUpdateEvent } from '@/modules/expo-cu
 import ExpoVapiModule from '@/modules/expo-vapi'
 import type { FunctionCallEvent, SpeechEvent, TranscriptEvent } from '@/modules/expo-vapi'
 import { Stack } from 'expo-router'
-import { MicIcon, MicOffIcon, PhoneOffIcon, PlusIcon, RefreshCwIcon, SendIcon, XIcon } from 'lucide-react-native'
+import { MicIcon, MicOffIcon, PhoneOffIcon, PlusIcon, RefreshCwIcon, SendIcon, TimerIcon, XIcon } from 'lucide-react-native'
 import { useColorScheme } from 'nativewind'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ActivityIndicator, Animated, FlatList, Image, KeyboardAvoidingView, Platform, Pressable, View } from 'react-native'
@@ -85,6 +85,7 @@ export default function ChatScreen() {
   const [isThinking, setIsThinking] = useState(false)
   const [isConnecting, setIsConnecting] = useState(false)
   const [streamingText, setStreamingText] = useState<string | null>(null)
+  const [showLatency, setShowLatency] = useState(false)
   const flatListRef = useRef<FlatList<Message>>(null)
   const hasScrolledRef = useRef(false)
   const { playJoin, playEnd, startThinking, stopThinking } = useCallSounds()
@@ -399,6 +400,10 @@ export default function ChatScreen() {
     })()
   }, [])
 
+  useEffect(() => {
+    getSetting('show_latency').then((v) => { if (v === 'true') setShowLatency(true) })
+  }, [])
+
   useEffect(() => { loadMessages() }, [loadMessages])
 
   const sendMessage = useCallback(async () => {
@@ -699,6 +704,12 @@ export default function ChatScreen() {
 
   const { partials } = transcriptBuffer
 
+  const toggleLatencyDisplay = useCallback(async () => {
+    const next = !showLatency
+    setShowLatency(next)
+    await setSetting('show_latency', next ? 'true' : 'false')
+  }, [showLatency])
+
   return (
     <KeyboardAvoidingView
       className="flex-1 bg-background"
@@ -707,9 +718,14 @@ export default function ChatScreen() {
       <Stack.Screen
         options={{
           headerRight: () => (
-            <Pressable onPress={startNewConversation} className="mr-2 p-2">
-              <PlusIcon size={22} color={colorScheme === 'dark' ? '#fff' : '#000'} />
-            </Pressable>
+            <View className="mr-2 flex-row items-center">
+              <Pressable onPress={toggleLatencyDisplay} className="p-2">
+                <TimerIcon size={20} color={showLatency ? '#f59e0b' : (colorScheme === 'dark' ? '#666' : '#999')} />
+              </Pressable>
+              <Pressable onPress={startNewConversation} className="p-2">
+                <PlusIcon size={22} color={colorScheme === 'dark' ? '#fff' : '#000'} />
+              </Pressable>
+            </View>
           ),
         }}
       />
@@ -721,7 +737,7 @@ export default function ChatScreen() {
         renderItem={({ item }) => (
           <>
             <MessageBubble message={item} />
-            {item.id !== THINKING_MESSAGE_ID && <LatencyBadge message={item} />}
+            {showLatency && item.id !== THINKING_MESSAGE_ID && <LatencyBadge message={item} />}
           </>
         )}
         contentContainerStyle={{ paddingTop: 16, paddingBottom: 8 }}

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -3,8 +3,8 @@ import { Card } from '@/components/ui/card'
 import { Icon } from '@/components/ui/icon'
 import { Input } from '@/components/ui/input'
 import { Text } from '@/components/ui/text'
-import { getSetting, setSetting, getLatencyAverages, type LatencyAverages } from '@/db'
-import { EyeIcon, EyeOffIcon } from 'lucide-react-native'
+import { getSetting, setSetting, getLatencyAverages, clearLatencyData, type LatencyAverages } from '@/db'
+import { EyeIcon, EyeOffIcon, RefreshCwIcon, Trash2Icon } from 'lucide-react-native'
 import { useCallback, useEffect, useState } from 'react'
 import { ActivityIndicator, Alert, KeyboardAvoidingView, Platform, Pressable, ScrollView, TextInput, View } from 'react-native'
 
@@ -291,22 +291,53 @@ export default function SettingsScreen() {
         </Card>
 
         <Card className="gap-4 p-4">
-          <Text className="text-lg font-semibold text-foreground">Latency Stats</Text>
+          <View className="flex-row items-center justify-between">
+            <Text className="text-lg font-semibold text-foreground">Latency Stats</Text>
+            <View className="flex-row items-center gap-2">
+              <Pressable onPress={loadLatencyStats} className="p-2" disabled={loadingStats}>
+                <Icon as={RefreshCwIcon} size={18} className="text-muted-foreground" />
+              </Pressable>
+              {latencyStats && latencyStats.turnCount > 0 && (
+                <Pressable
+                  onPress={() => {
+                    Alert.alert(
+                      'Clear Latency Data',
+                      'This will remove all latency measurements from messages. The messages themselves will not be deleted.',
+                      [
+                        { text: 'Cancel', style: 'cancel' },
+                        {
+                          text: 'Clear',
+                          style: 'destructive',
+                          onPress: async () => {
+                            await clearLatencyData()
+                            loadLatencyStats()
+                          },
+                        },
+                      ]
+                    )
+                  }}
+                  className="p-2"
+                >
+                  <Icon as={Trash2Icon} size={18} className="text-destructive" />
+                </Pressable>
+              )}
+            </View>
+          </View>
           {loadingStats ? (
             <ActivityIndicator size="small" color="#888" />
           ) : latencyStats && latencyStats.turnCount > 0 ? (
-            <View className="gap-2">
-              <LatencyStatRow label="Avg STT" value={latencyStats.avgStt} />
-              <LatencyStatRow label="Avg LLM" value={latencyStats.avgLlm} />
-              <LatencyStatRow label="Avg TTS" value={latencyStats.avgTts} />
-              <LatencyStatRow label="Avg Total" value={latencyStats.avgTotal} />
+            <View className="gap-3">
+              <LatencyStageSection label="STT" avg={latencyStats.avgStt} min={latencyStats.minStt} max={latencyStats.maxStt} />
+              <LatencyStageSection label="LLM" avg={latencyStats.avgLlm} min={latencyStats.minLlm} max={latencyStats.maxLlm} />
+              <LatencyStageSection label="TTS" avg={latencyStats.avgTts} min={latencyStats.minTts} max={latencyStats.maxTts} />
+              <LatencyStageSection label="Total" avg={latencyStats.avgTotal} min={latencyStats.minTotal} max={latencyStats.maxTotal} />
               <Text className="text-xs text-muted-foreground/60">
                 Based on {latencyStats.turnCount} turn{latencyStats.turnCount !== 1 ? 's' : ''} with latency data
               </Text>
             </View>
           ) : (
             <Text className="text-sm text-muted-foreground">
-              No latency data yet. Use Custom Pipeline mode to collect stats.
+              No latency data yet. Use Custom Pipeline or Vapi mode to collect stats.
             </Text>
           )}
         </Card>
@@ -432,13 +463,26 @@ function OptionGroup<T extends string>({
 
 // --- Helper Components ---
 
-function LatencyStatRow({ label, value }: { label: string, value: number | null }) {
+function LatencyStageSection({ label, avg, min, max }: {
+  label: string
+  avg: number | null
+  min: number | null
+  max: number | null
+}) {
   return (
-    <View className="flex-row items-center justify-between">
-      <Text className="text-sm text-muted-foreground">{label}</Text>
-      <Text className="text-sm font-medium text-foreground">
-        {value != null ? formatLatencyMs(value) : '--'}
-      </Text>
+    <View className="gap-1">
+      <View className="flex-row items-center justify-between">
+        <Text className="text-sm font-medium text-foreground">{label}</Text>
+        <Text className="text-sm font-semibold text-foreground">
+          {avg != null ? formatLatencyMs(avg) : '--'}
+        </Text>
+      </View>
+      <View className="flex-row items-center justify-between pl-2">
+        <Text className="text-xs text-muted-foreground">Min / Max</Text>
+        <Text className="text-xs text-muted-foreground">
+          {min != null ? formatLatencyMs(min) : '--'} / {max != null ? formatLatencyMs(max) : '--'}
+        </Text>
+      </View>
     </View>
   )
 }

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -310,7 +310,7 @@ export default function SettingsScreen() {
                           style: 'destructive',
                           onPress: async () => {
                             await clearLatencyData()
-                            loadLatencyStats()
+                            await loadLatencyStats()
                           },
                         },
                       ]
@@ -460,8 +460,6 @@ function OptionGroup<T extends string>({
     </View>
   )
 }
-
-// --- Helper Components ---
 
 function LatencyStageSection({ label, avg, min, max }: {
   label: string

--- a/db/index.ts
+++ b/db/index.ts
@@ -9,7 +9,7 @@ export {
   deleteAllConversations,
   updateConversationVapi,
 } from './conversations'
-export { addMessage, getMessages, getLatencyAverages } from './messages'
+export { addMessage, getMessages, getLatencyAverages, clearLatencyData } from './messages'
 export { getSetting, setSetting, getAllSettings } from './settings'
 export { getSummary, saveSummary, deleteSummaries } from './summaries'
 export { runMigrations } from './migrations'

--- a/db/messages.ts
+++ b/db/messages.ts
@@ -22,6 +22,14 @@ export type LatencyAverages = {
   avgLlm: number | null
   avgTts: number | null
   avgTotal: number | null
+  minStt: number | null
+  maxStt: number | null
+  minLlm: number | null
+  maxLlm: number | null
+  minTts: number | null
+  maxTts: number | null
+  minTotal: number | null
+  maxTotal: number | null
   turnCount: number
 }
 
@@ -68,6 +76,14 @@ export async function getLatencyAverages(): Promise<LatencyAverages> {
     avg_llm: number | null
     avg_tts: number | null
     avg_total: number | null
+    min_stt: number | null
+    max_stt: number | null
+    min_llm: number | null
+    max_llm: number | null
+    min_tts: number | null
+    max_tts: number | null
+    min_total: number | null
+    max_total: number | null
     turn_count: number
   }>(
     `SELECT
@@ -75,6 +91,14 @@ export async function getLatencyAverages(): Promise<LatencyAverages> {
       AVG(llm_latency_ms) as avg_llm,
       AVG(tts_latency_ms) as avg_tts,
       AVG(COALESCE(stt_latency_ms, 0) + COALESCE(llm_latency_ms, 0) + COALESCE(tts_latency_ms, 0)) as avg_total,
+      MIN(stt_latency_ms) as min_stt,
+      MAX(stt_latency_ms) as max_stt,
+      MIN(llm_latency_ms) as min_llm,
+      MAX(llm_latency_ms) as max_llm,
+      MIN(tts_latency_ms) as min_tts,
+      MAX(tts_latency_ms) as max_tts,
+      MIN(COALESCE(stt_latency_ms, 0) + COALESCE(llm_latency_ms, 0) + COALESCE(tts_latency_ms, 0)) as min_total,
+      MAX(COALESCE(stt_latency_ms, 0) + COALESCE(llm_latency_ms, 0) + COALESCE(tts_latency_ms, 0)) as max_total,
       COUNT(*) as turn_count
     FROM messages
     WHERE stt_latency_ms IS NOT NULL
@@ -83,7 +107,7 @@ export async function getLatencyAverages(): Promise<LatencyAverages> {
   )
 
   if (!row) {
-    return { avgStt: null, avgLlm: null, avgTts: null, avgTotal: null, turnCount: 0 }
+    return emptyLatencyAverages()
   }
 
   return {
@@ -91,6 +115,32 @@ export async function getLatencyAverages(): Promise<LatencyAverages> {
     avgLlm: row.avg_llm,
     avgTts: row.avg_tts,
     avgTotal: row.avg_total,
+    minStt: row.min_stt,
+    maxStt: row.max_stt,
+    minLlm: row.min_llm,
+    maxLlm: row.max_llm,
+    minTts: row.min_tts,
+    maxTts: row.max_tts,
+    minTotal: row.min_total,
+    maxTotal: row.max_total,
     turnCount: row.turn_count,
+  }
+}
+
+export async function clearLatencyData(): Promise<void> {
+  await db.runAsync(
+    `UPDATE messages SET stt_latency_ms = NULL, llm_latency_ms = NULL, tts_latency_ms = NULL
+    WHERE stt_latency_ms IS NOT NULL OR llm_latency_ms IS NOT NULL OR tts_latency_ms IS NOT NULL`
+  )
+}
+
+// --- Helper Functions ---
+
+function emptyLatencyAverages(): LatencyAverages {
+  return {
+    avgStt: null, avgLlm: null, avgTts: null, avgTotal: null,
+    minStt: null, maxStt: null, minLlm: null, maxLlm: null,
+    minTts: null, maxTts: null, minTotal: null, maxTotal: null,
+    turnCount: 0,
   }
 }

--- a/db/messages.ts
+++ b/db/messages.ts
@@ -97,8 +97,8 @@ export async function getLatencyAverages(): Promise<LatencyAverages> {
       MAX(llm_latency_ms) as max_llm,
       MIN(tts_latency_ms) as min_tts,
       MAX(tts_latency_ms) as max_tts,
-      MIN(COALESCE(stt_latency_ms, 0) + COALESCE(llm_latency_ms, 0) + COALESCE(tts_latency_ms, 0)) as min_total,
-      MAX(COALESCE(stt_latency_ms, 0) + COALESCE(llm_latency_ms, 0) + COALESCE(tts_latency_ms, 0)) as max_total,
+      MIN(CASE WHEN stt_latency_ms IS NOT NULL AND llm_latency_ms IS NOT NULL AND tts_latency_ms IS NOT NULL THEN COALESCE(stt_latency_ms, 0) + COALESCE(llm_latency_ms, 0) + COALESCE(tts_latency_ms, 0) END) as min_total,
+      MAX(CASE WHEN stt_latency_ms IS NOT NULL AND llm_latency_ms IS NOT NULL AND tts_latency_ms IS NOT NULL THEN COALESCE(stt_latency_ms, 0) + COALESCE(llm_latency_ms, 0) + COALESCE(tts_latency_ms, 0) END) as max_total,
       COUNT(*) as turn_count
     FROM messages
     WHERE stt_latency_ms IS NOT NULL


### PR DESCRIPTION
## Summary
- Add a stopwatch icon toggle in the chat header that shows/hides per-message latency badges (STT, LLM, TTS). The toggle persists across sessions via the `show_latency` setting and is off by default.
- Enhance the Settings "Latency Stats" section to show min/max alongside averages for each pipeline stage (STT, LLM, TTS, Total), with turn count.
- Add refresh (reload stats) and clear (null out latency data with confirmation) buttons to the latency stats card.
- Add `clearLatencyData()` DB function that nulls latency columns without deleting messages.

## Test plan
- [ ] Open the Chat tab and verify the stopwatch icon appears in the header (dimmed/inactive)
- [ ] Tap the stopwatch icon -- it should turn amber and latency badges should appear under messages that have latency data
- [ ] Kill and reopen the app -- the toggle state should persist
- [ ] Open Settings and scroll to "Latency Stats" -- verify avg, min, and max are shown for each stage
- [ ] Tap the refresh icon to reload stats
- [ ] Tap the trash icon and confirm the alert clears latency data
- [ ] Run `npx tsc --noEmit` -- no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)