### PR TITLE
Autosave settings on change, remove save button (NAN-588)

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -3,7 +3,7 @@ import { Icon } from '@/components/ui/icon'
 import { Input } from '@/components/ui/input'
 import { Text } from '@/components/ui/text'
 import { getSetting, getLatencyAverages, type LatencyAverages } from '@/db'
-import { useAutoSave } from '@/lib/use-auto-save'
+import { useAutoSave, type SaveStatus } from '@/lib/use-auto-save'
 import { CheckIcon } from 'lucide-react-native'
 import { EyeIcon, EyeOffIcon } from 'lucide-react-native'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -484,7 +484,7 @@ function OptionGroup<T extends string>({
   )
 }
 
-function SavedIndicator({ status }: { status: import('@/lib/use-auto-save').SaveStatus }) {
+function SavedIndicator({ status }: { status: SaveStatus }) {
   const opacity = useRef(new Animated.Value(0)).current
 
   useEffect(() => {

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,12 +1,13 @@
-import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Icon } from '@/components/ui/icon'
 import { Input } from '@/components/ui/input'
 import { Text } from '@/components/ui/text'
-import { getSetting, setSetting, getLatencyAverages, type LatencyAverages } from '@/db'
+import { getSetting, getLatencyAverages, type LatencyAverages } from '@/db'
+import { useAutoSave } from '@/lib/use-auto-save'
+import { CheckIcon } from 'lucide-react-native'
 import { EyeIcon, EyeOffIcon } from 'lucide-react-native'
-import { useCallback, useEffect, useState } from 'react'
-import { ActivityIndicator, Alert, KeyboardAvoidingView, Platform, Pressable, ScrollView, TextInput, View } from 'react-native'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ActivityIndicator, Animated, KeyboardAvoidingView, Platform, Pressable, ScrollView, TextInput, View } from 'react-native'
 
 type VoiceMode = 'vapi' | 'custom'
 type STTProviderValue = 'apple' | 'deepgram'
@@ -21,7 +22,6 @@ export default function SettingsScreen() {
   const [openclawApiKey, setOpenclawApiKey] = useState('')
   const [openclawApiUrl, setOpenclawApiUrl] = useState('')
   const [systemPrompt, setSystemPrompt] = useState('You are a helpful assistant. Keep responses concise. Use markdown for formatting and images when appropriate. Your identity, personality, and capabilities are defined in your system files.')
-  const [saved, setSaved] = useState(false)
 
   // Voice Pipeline state
   const [voiceMode, setVoiceMode] = useState<VoiceMode>('vapi')
@@ -36,6 +36,10 @@ export default function SettingsScreen() {
   // Latency stats state
   const [latencyStats, setLatencyStats] = useState<LatencyAverages | null>(null)
   const [loadingStats, setLoadingStats] = useState(true)
+
+  // Auto-save: guard against saving during initial load
+  const loadedRef = useRef(false)
+  const { saveStatus, saveImmediate, saveDebounced } = useAutoSave()
 
   const loadLatencyStats = useCallback(async () => {
     setLoadingStats(true)
@@ -83,31 +87,83 @@ export default function SettingsScreen() {
       if (oaiKey) setOpenaiTtsApiKey(oaiKey)
       const oaiVoice = await getSetting('openai_tts_voice')
       if (oaiVoice) setOpenaiTtsVoice(oaiVoice)
+
+      loadedRef.current = true
     })()
   }, [])
 
-  const handleSave = async () => {
-    await setSetting('vapi_api_key', vapiApiKey)
-    await setSetting('assistant_id', assistantId)
-    await setSetting('default_model', defaultModel)
-    await setSetting('openclaw_api_key', openclawApiKey)
-    await setSetting('openclaw_api_url', openclawApiUrl)
-    await setSetting('system_prompt', systemPrompt)
+  // --- Auto-saving wrappers ---
+  // Immediate save for toggles/dropdowns
+  const updateVoiceMode = useCallback((v: VoiceMode) => {
+    setVoiceMode(v)
+    if (loadedRef.current) saveImmediate('voice_mode', v)
+  }, [saveImmediate])
 
-    // Save voice pipeline settings
-    await setSetting('voice_mode', voiceMode)
-    await setSetting('stt_provider', sttProvider)
-    await setSetting('tts_provider', ttsProvider)
-    await setSetting('deepgram_api_key', deepgramApiKey)
-    await setSetting('elevenlabs_api_key', elevenlabsApiKey)
-    await setSetting('elevenlabs_voice_id', elevenlabsVoiceId)
-    await setSetting('openai_tts_api_key', openaiTtsApiKey)
-    await setSetting('openai_tts_voice', openaiTtsVoice)
+  const updateSttProvider = useCallback((v: STTProviderValue) => {
+    setSttProvider(v)
+    if (loadedRef.current) saveImmediate('stt_provider', v)
+  }, [saveImmediate])
 
-    setSaved(true)
-    Alert.alert('Settings Saved', 'Your settings have been saved successfully.')
-    setTimeout(() => setSaved(false), 2000)
-  }
+  const updateTtsProvider = useCallback((v: TTSProviderValue) => {
+    setTtsProvider(v)
+    if (loadedRef.current) saveImmediate('tts_provider', v)
+  }, [saveImmediate])
+
+  const updateOpenaiTtsVoice = useCallback((v: string) => {
+    setOpenaiTtsVoice(v)
+    if (loadedRef.current) saveImmediate('openai_tts_voice', v)
+  }, [saveImmediate])
+
+  // Debounced save for text inputs
+  const updateVapiApiKey = useCallback((v: string) => {
+    setVapiApiKey(v)
+    if (loadedRef.current) saveDebounced('vapi_api_key', v)
+  }, [saveDebounced])
+
+  const updateAssistantId = useCallback((v: string) => {
+    setAssistantId(v)
+    if (loadedRef.current) saveDebounced('assistant_id', v)
+  }, [saveDebounced])
+
+  const updateDefaultModel = useCallback((v: string) => {
+    setDefaultModel(v)
+    if (loadedRef.current) saveDebounced('default_model', v)
+  }, [saveDebounced])
+
+  const updateOpenclawApiKey = useCallback((v: string) => {
+    setOpenclawApiKey(v)
+    if (loadedRef.current) saveDebounced('openclaw_api_key', v)
+  }, [saveDebounced])
+
+  const updateOpenclawApiUrl = useCallback((v: string) => {
+    setOpenclawApiUrl(v)
+    if (loadedRef.current) saveDebounced('openclaw_api_url', v)
+  }, [saveDebounced])
+
+  const updateSystemPrompt = useCallback((v: string) => {
+    setSystemPrompt(v)
+    if (loadedRef.current) saveDebounced('system_prompt', v)
+  }, [saveDebounced])
+
+  const updateDeepgramApiKey = useCallback((v: string) => {
+    setDeepgramApiKey(v)
+    if (loadedRef.current) saveDebounced('deepgram_api_key', v)
+  }, [saveDebounced])
+
+  const updateElevenlabsApiKey = useCallback((v: string) => {
+    setElevenlabsApiKey(v)
+    if (loadedRef.current) saveDebounced('elevenlabs_api_key', v)
+  }, [saveDebounced])
+
+  const updateElevenlabsVoiceId = useCallback((v: string) => {
+    setElevenlabsVoiceId(v)
+    if (loadedRef.current) saveDebounced('elevenlabs_voice_id', v)
+  }, [saveDebounced])
+
+  const updateOpenaiTtsApiKey = useCallback((v: string) => {
+    setOpenaiTtsApiKey(v)
+    if (loadedRef.current) saveDebounced('openai_tts_api_key', v)
+  }, [saveDebounced])
 
   return (
     <KeyboardAvoidingView
@@ -126,7 +182,7 @@ export default function SettingsScreen() {
                 { label: 'Custom Pipeline', value: 'custom' as const },
               ]}
               value={voiceMode}
-              onChange={(v) => setVoiceMode(v)}
+              onChange={updateVoiceMode}
             />
           </View>
 
@@ -140,7 +196,7 @@ export default function SettingsScreen() {
                     { label: 'Deepgram Cloud', value: 'deepgram' as const },
                   ]}
                   value={sttProvider}
-                  onChange={(v) => setSttProvider(v)}
+                  onChange={updateSttProvider}
                 />
               </View>
 
@@ -149,7 +205,7 @@ export default function SettingsScreen() {
                   <Text className="text-sm text-muted-foreground">Deepgram API Key</Text>
                   <SecretInput
                     value={deepgramApiKey}
-                    onChangeText={setDeepgramApiKey}
+                    onChangeText={updateDeepgramApiKey}
                     placeholder="Enter your Deepgram API key"
                   />
                 </View>
@@ -164,7 +220,7 @@ export default function SettingsScreen() {
                     { label: 'OpenAI TTS Cloud', value: 'openai' as const },
                   ]}
                   value={ttsProvider}
-                  onChange={(v) => setTtsProvider(v)}
+                  onChange={updateTtsProvider}
                 />
               </View>
 
@@ -174,7 +230,7 @@ export default function SettingsScreen() {
                     <Text className="text-sm text-muted-foreground">ElevenLabs API Key</Text>
                     <SecretInput
                       value={elevenlabsApiKey}
-                      onChangeText={setElevenlabsApiKey}
+                      onChangeText={updateElevenlabsApiKey}
                       placeholder="Enter your ElevenLabs API key"
                     />
                   </View>
@@ -183,7 +239,7 @@ export default function SettingsScreen() {
                     <Input
                       placeholder="Awx8TeMHHpDzbm42nIB6"
                       value={elevenlabsVoiceId}
-                      onChangeText={setElevenlabsVoiceId}
+                      onChangeText={updateElevenlabsVoiceId}
                       autoCapitalize="none"
                       autoCorrect={false}
                     />
@@ -197,7 +253,7 @@ export default function SettingsScreen() {
                     <Text className="text-sm text-muted-foreground">OpenAI TTS API Key</Text>
                     <SecretInput
                       value={openaiTtsApiKey}
-                      onChangeText={setOpenaiTtsApiKey}
+                      onChangeText={updateOpenaiTtsApiKey}
                       placeholder="Enter your OpenAI API key"
                     />
                   </View>
@@ -206,7 +262,7 @@ export default function SettingsScreen() {
                     <OptionGroup
                       options={OPENAI_TTS_VOICES.map((v) => ({ label: v, value: v }))}
                       value={openaiTtsVoice}
-                      onChange={setOpenaiTtsVoice}
+                      onChange={updateOpenaiTtsVoice}
                     />
                   </View>
                 </>
@@ -223,7 +279,7 @@ export default function SettingsScreen() {
               <Text className="text-sm text-muted-foreground">API Key</Text>
               <SecretInput
                 value={vapiApiKey}
-                onChangeText={setVapiApiKey}
+                onChangeText={updateVapiApiKey}
                 placeholder="Enter your Vapi API key"
               />
             </View>
@@ -233,7 +289,7 @@ export default function SettingsScreen() {
               <Input
                 placeholder="Enter your Vapi Assistant ID"
                 value={assistantId}
-                onChangeText={setAssistantId}
+                onChangeText={updateAssistantId}
                 autoCapitalize="none"
                 autoCorrect={false}
               />
@@ -244,7 +300,7 @@ export default function SettingsScreen() {
               <Input
                 placeholder="e.g. gpt-4o, claude-3-opus"
                 value={defaultModel}
-                onChangeText={setDefaultModel}
+                onChangeText={updateDefaultModel}
                 autoCapitalize="none"
                 autoCorrect={false}
               />
@@ -257,7 +313,7 @@ export default function SettingsScreen() {
                 placeholder="Default: Keep responses concise. Use markdown for formatting and images when appropriate."
                 placeholderTextColor="#888"
                 value={systemPrompt}
-                onChangeText={setSystemPrompt}
+                onChangeText={updateSystemPrompt}
                 multiline
                 textAlignVertical="top"
               />
@@ -273,7 +329,7 @@ export default function SettingsScreen() {
             <Input
               placeholder="https://your-server.com/v1/chat/completions"
               value={openclawApiUrl}
-              onChangeText={setOpenclawApiUrl}
+              onChangeText={updateOpenclawApiUrl}
               autoCapitalize="none"
               autoCorrect={false}
               keyboardType="url"
@@ -284,7 +340,7 @@ export default function SettingsScreen() {
             <Text className="text-sm text-muted-foreground">API Key</Text>
             <SecretInput
               value={openclawApiKey}
-              onChangeText={setOpenclawApiKey}
+              onChangeText={updateOpenclawApiKey}
               placeholder="Enter your OpenClaw API key"
             />
           </View>
@@ -311,9 +367,7 @@ export default function SettingsScreen() {
           )}
         </Card>
 
-        <Button onPress={handleSave}>
-          <Text>{saved ? 'Saved!' : 'Save Settings'}</Text>
-        </Button>
+        <SavedIndicator status={saveStatus} />
       </ScrollView>
     </KeyboardAvoidingView>
   )
@@ -430,7 +484,33 @@ function OptionGroup<T extends string>({
   )
 }
 
-// --- Helper Components ---
+function SavedIndicator({ status }: { status: import('@/lib/use-auto-save').SaveStatus }) {
+  const opacity = useRef(new Animated.Value(0)).current
+
+  useEffect(() => {
+    if (status === 'saved') {
+      Animated.sequence([
+        Animated.timing(opacity, { toValue: 1, duration: 200, useNativeDriver: true }),
+        Animated.delay(1000),
+        Animated.timing(opacity, { toValue: 0, duration: 300, useNativeDriver: true }),
+      ]).start()
+    } else if (status === 'idle') {
+      opacity.setValue(0)
+    }
+  }, [status, opacity])
+
+  if (status === 'idle') return null
+
+  return (
+    <Animated.View
+      style={{ opacity }}
+      className="flex-row items-center justify-center gap-2 py-2"
+    >
+      <Icon as={CheckIcon} size={16} className="text-primary" />
+      <Text className="text-sm text-muted-foreground">Saved</Text>
+    </Animated.View>
+  )
+}
 
 function LatencyStatRow({ label, value }: { label: string, value: number | null }) {
   return (

--- a/lib/use-auto-save.ts
+++ b/lib/use-auto-save.ts
@@ -34,7 +34,7 @@ export function useAutoSave(debounceMs = 500) {
     fadeTimerRef.current = setTimeout(() => {
       setSaveStatus('idle')
       fadeTimerRef.current = null
-    }, 1500)
+    }, 1800)
   }, [])
 
   const persistSetting = useCallback(async (key: string, value: string) => {

--- a/lib/use-auto-save.ts
+++ b/lib/use-auto-save.ts
@@ -1,0 +1,77 @@
+import { setSetting } from '@/db'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+type SaveStatus = 'idle' | 'saving' | 'saved'
+
+/**
+ * Hook that provides auto-save behavior for settings.
+ * - Immediate saves for toggles/dropdowns via `saveImmediate`
+ * - Debounced saves for text inputs via `saveDebounced`
+ * - Tracks save status for showing a brief "Saved" indicator
+ */
+export function useAutoSave(debounceMs = 500) {
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle')
+  const timerRefs = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+  const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Clean up all timers on unmount
+  useEffect(() => {
+    return () => {
+      for (const timer of timerRefs.current.values()) {
+        clearTimeout(timer)
+      }
+      if (fadeTimerRef.current) {
+        clearTimeout(fadeTimerRef.current)
+      }
+    }
+  }, [])
+
+  const showSavedIndicator = useCallback(() => {
+    setSaveStatus('saved')
+    if (fadeTimerRef.current) {
+      clearTimeout(fadeTimerRef.current)
+    }
+    fadeTimerRef.current = setTimeout(() => {
+      setSaveStatus('idle')
+      fadeTimerRef.current = null
+    }, 1500)
+  }, [])
+
+  const persistSetting = useCallback(async (key: string, value: string) => {
+    setSaveStatus('saving')
+    try {
+      await setSetting(key, value)
+      showSavedIndicator()
+    } catch (err) {
+      console.warn('[useAutoSave] Failed to save setting:', key, err)
+      setSaveStatus('idle')
+    }
+  }, [showSavedIndicator])
+
+  /** Save immediately - use for toggles, dropdowns, segmented controls */
+  const saveImmediate = useCallback((key: string, value: string) => {
+    // Cancel any pending debounced save for this key
+    const existing = timerRefs.current.get(key)
+    if (existing) {
+      clearTimeout(existing)
+      timerRefs.current.delete(key)
+    }
+    persistSetting(key, value)
+  }, [persistSetting])
+
+  /** Save with debounce - use for text inputs */
+  const saveDebounced = useCallback((key: string, value: string) => {
+    const existing = timerRefs.current.get(key)
+    if (existing) {
+      clearTimeout(existing)
+    }
+    timerRefs.current.set(key, setTimeout(() => {
+      timerRefs.current.delete(key)
+      persistSetting(key, value)
+    }, debounceMs))
+  }, [debounceMs, persistSetting])
+
+  return { saveStatus, saveImmediate, saveDebounced }
+}
+
+export type { SaveStatus }


### PR DESCRIPTION
## Summary
- Settings now auto-save as the user changes them -- no explicit save button needed
- Toggles, dropdowns, and segmented controls persist immediately via `saveImmediate`
- Text inputs are debounced at 500ms via `saveDebounced` to avoid saving on every keystroke
- A subtle animated "Saved" checkmark indicator replaces the old save button and alert dialog
- A `loadedRef` guard prevents spurious saves during initial hydration from the database
- New reusable `useAutoSave` hook in `lib/use-auto-save.ts`

## Test plan
- [ ] Open Settings tab, toggle Voice Mode between Vapi and Custom -- verify it persists after closing and reopening the tab
- [ ] Change a text field (e.g., API URL) and wait ~500ms -- verify "Saved" indicator appears briefly
- [ ] Type rapidly in a text field -- verify only one save occurs after typing stops
- [ ] Kill and relaunch the app -- verify all settings are preserved
- [ ] Verify no save occurs on initial screen load (no spurious "Saved" flash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)