### PR TITLE
Implement Kokoro on-device TTS provider (NAN-586)

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input'
 import { Text } from '@/components/ui/text'
 import { getSetting, getLatencyAverages, clearLatencyData, type LatencyAverages } from '@/db'
 import { useAutoSave, type SaveStatus } from '@/lib/use-auto-save'
+import ExpoCustomPipelineModule from '@/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule'
 import { CheckIcon, EyeIcon, EyeOffIcon, RefreshCwIcon, Trash2Icon } from 'lucide-react-native'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ActivityIndicator, Alert, Animated, KeyboardAvoidingView, Platform, Pressable, ScrollView, TextInput, View } from 'react-native'
@@ -30,7 +31,10 @@ export default function SettingsScreen() {
   const [elevenlabsApiKey, setElevenlabsApiKey] = useState('')
   const [elevenlabsVoiceId, setElevenlabsVoiceId] = useState('Awx8TeMHHpDzbm42nIB6')
   const [openaiTtsApiKey, setOpenaiTtsApiKey] = useState('')
-  const [openaiTtsVoice, setOpenaiTtsVoice] = useState('alloy')
+  const [openaiTtsVoice, setOpenaiTtsVoice] = useState<typeof OPENAI_TTS_VOICES[number]>('alloy')
+
+  // Kokoro model download state
+  const [kokoroStatus, setKokoroStatus] = useState<'checking' | 'ready' | 'not-downloaded' | 'downloading' | 'error'>('checking')
 
   // Latency stats state
   const [latencyStats, setLatencyStats] = useState<LatencyAverages | null>(null)
@@ -39,6 +43,31 @@ export default function SettingsScreen() {
   // Auto-save: guard against saving during initial load
   const loadedRef = useRef(false)
   const { saveStatus, saveImmediate, saveDebounced } = useAutoSave()
+
+  const checkKokoroStatus = useCallback(() => {
+    setKokoroStatus('checking')
+    try {
+      const ready = ExpoCustomPipelineModule.isKokoroModelReady()
+      setKokoroStatus(ready ? 'ready' : 'not-downloaded')
+    } catch {
+      setKokoroStatus('not-downloaded')
+    }
+  }, [])
+
+  const downloadKokoroModel = useCallback(async () => {
+    setKokoroStatus('downloading')
+    try {
+      await ExpoCustomPipelineModule.prepareKokoroModel()
+      setKokoroStatus('ready')
+    } catch (err) {
+      console.warn('[Settings] Kokoro download failed:', err)
+      setKokoroStatus('error')
+    }
+  }, [])
+
+  useEffect(() => {
+    if (ttsProvider === 'kokoro') checkKokoroStatus()
+  }, [ttsProvider, checkKokoroStatus])
 
   const loadLatencyStats = useCallback(async () => {
     setLoadingStats(true)
@@ -85,7 +114,9 @@ export default function SettingsScreen() {
       const oaiKey = await getSetting('openai_tts_api_key')
       if (oaiKey) setOpenaiTtsApiKey(oaiKey)
       const oaiVoice = await getSetting('openai_tts_voice')
-      if (oaiVoice) setOpenaiTtsVoice(oaiVoice)
+      if (oaiVoice && (OPENAI_TTS_VOICES as readonly string[]).includes(oaiVoice)) {
+        setOpenaiTtsVoice(oaiVoice as typeof OPENAI_TTS_VOICES[number])
+      }
 
       loadedRef.current = true
     })()
@@ -108,7 +139,7 @@ export default function SettingsScreen() {
     if (loadedRef.current) saveImmediate('tts_provider', v)
   }, [saveImmediate])
 
-  const updateOpenaiTtsVoice = useCallback((v: string) => {
+  const updateOpenaiTtsVoice = useCallback((v: typeof OPENAI_TTS_VOICES[number]) => {
     setOpenaiTtsVoice(v)
     if (loadedRef.current) saveImmediate('openai_tts_voice', v)
   }, [saveImmediate])
@@ -224,6 +255,10 @@ export default function SettingsScreen() {
                   onChange={updateTtsProvider}
                 />
               </View>
+
+              {ttsProvider === 'kokoro' && (
+                <KokoroModelStatus status={kokoroStatus} onDownload={downloadKokoroModel} onRetry={checkKokoroStatus} />
+              )}
 
               {ttsProvider === 'elevenlabs' && (
                 <>
@@ -517,6 +552,65 @@ function OptionGroup<T extends string>({
         </Pressable>
       ))}
     </View>
+  )
+}
+
+function KokoroModelStatus({
+  status,
+  onDownload,
+  onRetry,
+}: {
+  status: 'checking' | 'ready' | 'not-downloaded' | 'downloading' | 'error'
+  onDownload: () => void
+  onRetry: () => void
+}) {
+  if (status === 'checking') {
+    return (
+      <View className="flex-row items-center gap-2 rounded-lg border border-input px-3 py-2">
+        <ActivityIndicator size="small" color="#888" />
+        <Text className="text-sm text-muted-foreground">Checking model...</Text>
+      </View>
+    )
+  }
+
+  if (status === 'ready') {
+    return (
+      <View className="flex-row items-center gap-2 rounded-lg border border-primary/30 bg-primary/5 px-3 py-2">
+        <Icon as={CheckIcon} size={16} className="text-primary" />
+        <Text className="text-sm text-primary">Model ready (~327 MB cached)</Text>
+      </View>
+    )
+  }
+
+  if (status === 'downloading') {
+    return (
+      <View className="flex-row items-center gap-2 rounded-lg border border-input px-3 py-2">
+        <ActivityIndicator size="small" color="#888" />
+        <Text className="text-sm text-muted-foreground">Downloading model (~327 MB)...</Text>
+      </View>
+    )
+  }
+
+  if (status === 'error') {
+    return (
+      <Pressable
+        onPress={onRetry}
+        className="flex-row items-center justify-between rounded-lg border border-destructive/50 bg-destructive/5 px-3 py-2"
+      >
+        <Text className="text-sm text-destructive">Download failed — tap to retry</Text>
+      </Pressable>
+    )
+  }
+
+  // not-downloaded
+  return (
+    <Pressable
+      onPress={onDownload}
+      className="flex-row items-center justify-between rounded-lg border border-input bg-background px-3 py-2 active:opacity-70 dark:bg-input/30"
+    >
+      <Text className="text-sm text-muted-foreground">Model not downloaded</Text>
+      <Text className="text-sm font-medium text-primary">Download (~327 MB)</Text>
+    </Pressable>
   )
 }
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -10,7 +10,7 @@ import { ActivityIndicator, Alert, Animated, KeyboardAvoidingView, Platform, Pre
 
 type VoiceMode = 'vapi' | 'custom'
 type STTProviderValue = 'apple' | 'deepgram'
-type TTSProviderValue = 'apple' | 'elevenlabs' | 'openai'
+type TTSProviderValue = 'apple' | 'elevenlabs' | 'openai' | 'kokoro'
 
 const OPENAI_TTS_VOICES = ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'] as const
 
@@ -75,7 +75,7 @@ export default function SettingsScreen() {
       const stt = await getSetting('stt_provider')
       if (stt === 'apple' || stt === 'deepgram') setSttProvider(stt)
       const tts = await getSetting('tts_provider')
-      if (tts === 'apple' || tts === 'elevenlabs' || tts === 'openai') setTtsProvider(tts)
+      if (tts === 'apple' || tts === 'elevenlabs' || tts === 'openai' || tts === 'kokoro') setTtsProvider(tts)
       const dgKey = await getSetting('deepgram_api_key')
       if (dgKey) setDeepgramApiKey(dgKey)
       const elKey = await getSetting('elevenlabs_api_key')
@@ -216,6 +216,7 @@ export default function SettingsScreen() {
                 <OptionGroup
                   options={[
                     { label: 'Apple Zoe On-Device', value: 'apple' as const },
+                    { label: 'Kokoro On-Device (iOS 18+)', value: 'kokoro' as const },
                     { label: 'ElevenLabs Cloud', value: 'elevenlabs' as const },
                     { label: 'OpenAI TTS Cloud', value: 'openai' as const },
                   ]}

--- a/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
+++ b/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
@@ -20,43 +20,14 @@ public class ExpoCustomPipelineModule: Module {
         Function("setSTTProvider") { (name: String, config: [String: String]?) in
             self.sttProviderName = name
             print("[ExpoCustomPipeline] STT provider set to: \(name)")
-
-            switch name {
-            case "apple":
-                self.sttProvider = AppleSTTProvider()
-            case "deepgram":
-                let provider = DeepgramSTTProvider()
-                if let apiKey = config?["apiKey"], !apiKey.isEmpty {
-                    provider.configure(apiKey: apiKey)
-                }
-                self.sttProvider = provider
-            default:
-                print("[ExpoCustomPipeline] Unknown STT provider: \(name)")
-            }
+            self.sttProvider = makeSTTProvider(name: name, config: config)
         }
 
         Function("setTTSProvider") { (name: String, config: [String: String]?) in
             self.ttsProviderName = name
-            print("[ExpoCustomPipeline] TTS provider set to: \(name), config keys: \(config?.keys.joined(separator: ", ") ?? "nil")")
-
-            switch name {
-            case "apple":
-                self.ttsProvider = AppleTTSProvider()
-            case "elevenlabs":
-                let provider = ElevenLabsTTSProvider()
-                if let apiKey = config?["apiKey"], !apiKey.isEmpty {
-                    provider.configure(apiKey: apiKey, voiceId: config?["voiceId"])
-                }
-                self.ttsProvider = provider
-            case "openai":
-                let provider = OpenAITTSProvider()
-                if let apiKey = config?["apiKey"], !apiKey.isEmpty {
-                    provider.configure(apiKey: apiKey, voice: config?["voice"])
-                }
-                self.ttsProvider = provider
-            default:
-                print("[ExpoCustomPipeline] Unknown TTS provider: \(name)")
-            }
+            let configKeys = config?.keys.joined(separator: ", ") ?? "nil"
+            print("[ExpoCustomPipeline] TTS provider set to: \(name), config keys: \(configKeys)")
+            self.ttsProvider = makeTTSProvider(name: name, config: config)
         }
 
         Function("startListening") { () in
@@ -92,5 +63,51 @@ public class ExpoCustomPipelineModule: Module {
         Function("stopSpeaking") { () in
             self.ttsProvider?.stop()
         }
+    }
+}
+
+// MARK: - Helpers
+
+private func makeSTTProvider(name: String, config: [String: String]?) -> STTProvider? {
+    switch name {
+    case "apple":
+        return AppleSTTProvider()
+    case "deepgram":
+        let provider = DeepgramSTTProvider()
+        if let apiKey = config?["apiKey"], !apiKey.isEmpty {
+            provider.configure(apiKey: apiKey)
+        }
+        return provider
+    default:
+        print("[ExpoCustomPipeline] Unknown STT provider: \(name)")
+        return nil
+    }
+}
+
+private func makeTTSProvider(name: String, config: [String: String]?) -> TTSProvider? {
+    switch name {
+    case "apple":
+        return AppleTTSProvider()
+    case "elevenlabs":
+        let provider = ElevenLabsTTSProvider()
+        if let apiKey = config?["apiKey"], !apiKey.isEmpty {
+            provider.configure(apiKey: apiKey, voiceId: config?["voiceId"])
+        }
+        return provider
+    case "openai":
+        let provider = OpenAITTSProvider()
+        if let apiKey = config?["apiKey"], !apiKey.isEmpty {
+            provider.configure(apiKey: apiKey, voice: config?["voice"])
+        }
+        return provider
+    case "kokoro":
+        if #available(iOS 18.0, *) {
+            return KokoroTTSProvider()
+        }
+        print("[ExpoCustomPipeline] Kokoro requires iOS 18+")
+        return nil
+    default:
+        print("[ExpoCustomPipeline] Unknown TTS provider: \(name)")
+        return nil
     }
 }

--- a/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
+++ b/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
@@ -63,6 +63,27 @@ public class ExpoCustomPipelineModule: Module {
         Function("stopSpeaking") { () in
             self.ttsProvider?.stop()
         }
+
+        Function("isKokoroModelReady") { () -> Bool in
+            if #available(iOS 18.0, *) {
+                return KokoroTTSProvider.isModelCached()
+            }
+            return false
+        }
+
+        AsyncFunction("prepareKokoroModel") { (promise: Promise) in
+            guard #available(iOS 18.0, *) else {
+                promise.resolve(false)
+                return
+            }
+            let provider = KokoroTTSProvider()
+            provider.downloadModel { result in
+                switch result {
+                case .success: promise.resolve(true)
+                case .failure(let err): promise.reject(err)
+                }
+            }
+        }
     }
 }
 

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/KokoroTTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/KokoroTTSProvider.swift
@@ -1,20 +1,351 @@
+#if canImport(KokoroSwift)
+import AVFoundation
 import Foundation
+import KokoroSwift
+import MLX
+import MLXUtilsLibrary
 
-// Future: mlalma/kokoro-ios MLX Swift, 327MB model, iOS 18+
+// MARK: - KokoroTTSProvider
 
+@available(iOS 18.0, *)
 class KokoroTTSProvider: TTSProvider {
     let name = "Kokoro TTS"
     private(set) var isSpeaking = false
     private(set) var latencyMs: Double = 0
 
+    private var audioEngine: AVAudioEngine?
+    private var playerNode: AVAudioPlayerNode?
+    private var ttsEngine: KokoroTTS?
+    private var voices: [String: MLXArray] = [:]
+
+    private var onStartCallback: (() -> Void)?
+    private var onCompleteCallback: (() -> Void)?
+    private var onErrorCallback: ((String) -> Void)?
+    private var downloadTask: URLSessionDownloadTask?
+
+    private var isModelReady = false
+
     // MARK: - TTSProvider
 
-    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void, onError: @escaping (String) -> Void) {
-        print("[Kokoro] Not yet implemented")
-        onComplete()
+    func speak(
+        text: String,
+        onStart: @escaping () -> Void,
+        onComplete: @escaping () -> Void,
+        onError: @escaping (String) -> Void
+    ) {
+        onStartCallback = onStart
+        onCompleteCallback = onComplete
+        onErrorCallback = onError
+
+        if isModelReady {
+            synthesizeAndPlay(text: text)
+        } else {
+            prepareModel { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .success:
+                    self.synthesizeAndPlay(text: text)
+                case .failure(let error):
+                    print("[Kokoro] Model preparation failed: \(error)")
+                    DispatchQueue.main.async {
+                        self.isSpeaking = false
+                        self.onErrorCallback?("Kokoro: \(error.localizedDescription)")
+                        self.onCompleteCallback?()
+                    }
+                }
+            }
+        }
     }
 
     func stop() {
-        print("[Kokoro] Not yet implemented")
+        downloadTask?.cancel()
+        downloadTask = nil
+        playerNode?.stop()
+        if audioEngine?.isRunning == true {
+            audioEngine?.stop()
+        }
+        isSpeaking = false
+        onStartCallback = nil
+        onCompleteCallback = nil
+        onErrorCallback = nil
     }
 }
+
+// MARK: - Model Preparation
+
+@available(iOS 18.0, *)
+private extension KokoroTTSProvider {
+    static let samplingRate = Double(KokoroTTS.Constants.samplingRate)
+
+    var cacheDirectory: URL {
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("KokoroTTS", isDirectory: true)
+    }
+
+    var cachedModelURL: URL {
+        cacheDirectory.appendingPathComponent("kokoro-v1_0.safetensors")
+    }
+
+    var cachedVoicesURL: URL {
+        cacheDirectory.appendingPathComponent("voices.npz")
+    }
+
+    // Default voice: af_heart (American female, 'a' prefix = US English)
+    var defaultVoiceKey: String { "af_heart.npy" }
+
+    func prepareModel(completion: @escaping (Result<Void, Error>) -> Void) {
+        do {
+            try FileManager.default.createDirectory(
+                at: cacheDirectory,
+                withIntermediateDirectories: true
+            )
+        } catch {
+            completion(.failure(error))
+            return
+        }
+
+        let needsModel = !FileManager.default.fileExists(atPath: cachedModelURL.path)
+        let needsVoices = !FileManager.default.fileExists(atPath: cachedVoicesURL.path)
+
+        if !needsModel && !needsVoices {
+            loadModel(completion: completion)
+            return
+        }
+
+        var filesToDownload: [(URL, URL)] = []
+        if needsModel {
+            let modelURL = URL(
+                string: "https://huggingface.co/prince-canuma/Kokoro-82M/resolve/main/kokoro-v1_0.safetensors"
+            )!
+            filesToDownload.append((modelURL, cachedModelURL))
+        }
+        if needsVoices {
+            let voicesURL = URL(
+                string: "https://huggingface.co/prince-canuma/Kokoro-82M/resolve/main/voices.npz"
+            )!
+            filesToDownload.append((voicesURL, cachedVoicesURL))
+        }
+
+        downloadFiles(filesToDownload, index: 0) { [weak self] result in
+            switch result {
+            case .success:
+                self?.loadModel(completion: completion)
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func downloadFiles(
+        _ pairs: [(URL, URL)],
+        index: Int,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        guard index < pairs.count else {
+            completion(.success(()))
+            return
+        }
+
+        let (remoteURL, localURL) = pairs[index]
+        print("[Kokoro] Downloading \(remoteURL.lastPathComponent)...")
+
+        let task = URLSession.shared.downloadTask(with: remoteURL) { [weak self] tempURL, response, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+                let msg = "HTTP \(http.statusCode) for \(remoteURL.lastPathComponent)"
+                completion(.failure(KokoroError.downloadFailed(msg)))
+                return
+            }
+
+            guard let tempURL = tempURL else {
+                let msg = "No temp file for \(remoteURL.lastPathComponent)"
+                completion(.failure(KokoroError.downloadFailed(msg)))
+                return
+            }
+
+            do {
+                if FileManager.default.fileExists(atPath: localURL.path) {
+                    try FileManager.default.removeItem(at: localURL)
+                }
+                try FileManager.default.moveItem(at: tempURL, to: localURL)
+                print("[Kokoro] Downloaded \(localURL.lastPathComponent)")
+                self.downloadFiles(pairs, index: index + 1, completion: completion)
+            } catch {
+                completion(.failure(error))
+            }
+        }
+        downloadTask = task
+        task.resume()
+    }
+
+    func loadModel(completion: @escaping (Result<Void, Error>) -> Void) {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+            do {
+                self.ttsEngine = KokoroTTS(modelPath: self.cachedModelURL, g2p: .misaki)
+                self.voices = NpyzReader.read(
+                    fileFromPath: self.cachedVoicesURL
+                ) ?? [:]
+                self.isModelReady = true
+                print("[Kokoro] Model loaded successfully")
+                completion(.success(()))
+            } catch {
+                print("[Kokoro] Failed to load model: \(error)")
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
+// MARK: - Synthesis & Playback
+
+@available(iOS 18.0, *)
+private extension KokoroTTSProvider {
+    func synthesizeAndPlay(text: String) {
+        guard let engine = ttsEngine else {
+            onErrorCallback?("Kokoro: model not ready")
+            onCompleteCallback?()
+            return
+        }
+
+        guard let voice = voices[defaultVoiceKey] else {
+            onErrorCallback?("Kokoro: voice '\(defaultVoiceKey)' not found in voices.npz")
+            onCompleteCallback?()
+            return
+        }
+
+        let startTime = CFAbsoluteTimeGetCurrent()
+        isSpeaking = true
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+            do {
+                let (audio, _) = try engine.generateAudio(
+                    voice: voice,
+                    language: .enUS,
+                    text: text
+                )
+                self.latencyMs = (CFAbsoluteTimeGetCurrent() - startTime) * 1000
+                DispatchQueue.main.async { self.playAudioSamples(audio) }
+            } catch {
+                print("[Kokoro] Synthesis error: \(error)")
+                DispatchQueue.main.async {
+                    self.isSpeaking = false
+                    self.onErrorCallback?("Kokoro synthesis error: \(error.localizedDescription)")
+                    self.onCompleteCallback?()
+                }
+            }
+        }
+    }
+
+    func playAudioSamples(_ samples: [Float]) {
+        let format = AVAudioFormat(
+            standardFormatWithSampleRate: KokoroTTSProvider.samplingRate,
+            channels: 1
+        )!
+
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(samples.count)
+        ) else {
+            print("[Kokoro] Failed to create PCM buffer")
+            isSpeaking = false
+            onErrorCallback?("Kokoro: Failed to create audio buffer")
+            onCompleteCallback?()
+            return
+        }
+
+        buffer.frameLength = buffer.frameCapacity
+        let dst = buffer.floatChannelData![0]
+        samples.withUnsafeBufferPointer { buf in
+            guard let src = buf.baseAddress else { return }
+            dst.assign(from: src, count: samples.count)
+        }
+
+        if audioEngine == nil {
+            let eng = AVAudioEngine()
+            let player = AVAudioPlayerNode()
+            eng.attach(player)
+            audioEngine = eng
+            playerNode = player
+        }
+
+        guard let eng = audioEngine, let player = playerNode else {
+            isSpeaking = false
+            onErrorCallback?("Kokoro: Audio engine not initialized")
+            onCompleteCallback?()
+            return
+        }
+
+        eng.connect(player, to: eng.mainMixerNode, format: format)
+
+        if !eng.isRunning {
+            do {
+                try eng.start()
+            } catch {
+                print("[Kokoro] Audio engine failed to start: \(error)")
+                isSpeaking = false
+                onErrorCallback?("Kokoro: Audio engine error: \(error.localizedDescription)")
+                onCompleteCallback?()
+                return
+            }
+        }
+
+        onStartCallback?()
+
+        player.scheduleBuffer(buffer, at: nil, options: .interrupts) { [weak self] in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.isSpeaking = false
+                self.onCompleteCallback?()
+            }
+        }
+        player.play()
+    }
+}
+
+// MARK: - KokoroError
+
+enum KokoroError: LocalizedError {
+    case notAvailable(String)
+    case downloadFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notAvailable(let msg): return msg
+        case .downloadFailed(let msg): return msg
+        }
+    }
+}
+
+#else
+
+import Foundation
+
+// Fallback: KokoroSwift framework not linked (iOS < 18 simulator or missing SPM package)
+class KokoroTTSProvider: TTSProvider {
+    let name = "Kokoro TTS"
+    private(set) var isSpeaking = false
+    private(set) var latencyMs: Double = 0
+
+    func speak(
+        text: String,
+        onStart: @escaping () -> Void,
+        onComplete: @escaping () -> Void,
+        onError: @escaping (String) -> Void
+    ) {
+        print("[Kokoro] KokoroSwift not available — requires iOS 18+ and KokoroSwift SPM package")
+        onError("Kokoro TTS requires iOS 18+ and the KokoroSwift package")
+        onComplete()
+    }
+
+    func stop() {}
+}
+
+#endif

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/KokoroTTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/KokoroTTSProvider.swift
@@ -69,6 +69,21 @@ class KokoroTTSProvider: TTSProvider {
         onCompleteCallback = nil
         onErrorCallback = nil
     }
+
+    // MARK: - Public helpers
+
+    static func isModelCached() -> Bool {
+        let cache = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("KokoroTTS", isDirectory: true)
+        let model = cache.appendingPathComponent("kokoro-v1_0.safetensors")
+        let voices = cache.appendingPathComponent("voices.npz")
+        return FileManager.default.fileExists(atPath: model.path)
+            && FileManager.default.fileExists(atPath: voices.path)
+    }
+
+    func downloadModel(completion: @escaping (Result<Void, Error>) -> Void) {
+        prepareModel(completion: completion)
+    }
 }
 
 // MARK: - Model Preparation
@@ -214,8 +229,10 @@ private extension KokoroTTSProvider {
             return
         }
 
-        guard let voice = voices[defaultVoiceKey] else {
-            onErrorCallback?("Kokoro: voice '\(defaultVoiceKey)' not found in voices.npz")
+        // Try both with and without .npy extension — NPZ key format varies
+        let voiceKey = defaultVoiceKey
+        guard let voice = voices[voiceKey] ?? voices[String(voiceKey.dropLast(4))] else {
+            onErrorCallback?("Kokoro: voice '\(voiceKey)' not found in voices.npz")
             onCompleteCallback?()
             return
         }
@@ -333,6 +350,13 @@ class KokoroTTSProvider: TTSProvider {
     let name = "Kokoro TTS"
     private(set) var isSpeaking = false
     private(set) var latencyMs: Double = 0
+
+    static func isModelCached() -> Bool { return false }
+
+    func downloadModel(completion: @escaping (Result<Void, Error>) -> Void) {
+        completion(.failure(NSError(domain: "KokoroTTS", code: 0,
+            userInfo: [NSLocalizedDescriptionKey: "Kokoro TTS requires iOS 18+ and the KokoroSwift package"])))
+    }
 
     func speak(
         text: String,

--- a/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule.ts
+++ b/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule.ts
@@ -9,6 +9,8 @@ declare class ExpoCustomPipelineModule extends NativeModule<ExpoCustomPipelineMo
   stopListening(): void
   speak(text: string): void
   stopSpeaking(): void
+  isKokoroModelReady(): boolean
+  prepareKokoroModel(): Promise<boolean>
 }
 
 export default requireNativeModule<ExpoCustomPipelineModule>('ExpoCustomPipeline')


### PR DESCRIPTION
## Summary

- **KokoroTTSProvider**: Full implementation using `mlalma/kokoro-ios` MLX Swift library
  - Downloads model (`kokoro-v1_0.safetensors`) + voices (`voices.npz`) from HuggingFace on first use
  - Caches files in app's caches directory — no re-download after first run
  - Synthesizes audio via `KokoroTTS.generateAudio()` on a background thread
  - Plays back via `AVAudioEngine` + `AVAudioPlayerNode` (mono, 24kHz)
  - Guarded with `#if canImport(KokoroSwift)` — graceful fallback on iOS < 18 or if package not linked
- **ExpoCustomPipelineModule**: extracted `makeSTTProvider`/`makeTTSProvider` helpers to bottom; added `"kokoro"` case with `@available(iOS 18.0, *)` guard
- **Settings UI**: added "Kokoro On-Device (iOS 18+)" as a TTS provider option
- **Xcode project**: `KokoroSwift` SPM package added to `VoiceClaw` target

## Notes
- First use triggers a model download (~300-600MB) — no UI progress indicator yet
- Requires iOS 18+ (iPhone 12 Pro running iOS 18 is the test device ✓)
- Voice used: `af_heart` (American female) from the bundled voices.npz

## Test plan
- [ ] Go to Settings → TTS Provider → select "Kokoro On-Device (iOS 18+)"
- [ ] Start a custom pipeline call — first use will download the model (may take a minute on WiFi)
- [ ] Subsequent calls should use cached model and speak immediately
- [ ] On a device running iOS < 18, selecting Kokoro should surface an error via the pipeline's onError event

🤖 Generated with [Claude Code](https://claude.com/claude-code)