### PR TITLE
Add barge-in interruption and fix multi-turn STT pipeline

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -812,9 +812,15 @@ export default function ChatScreen() {
 
       {isCallActive && (
         <View testID="call-controls" className="flex-row items-center justify-center gap-4 border-t border-border bg-muted/50 px-4 py-3">
-          <Button testID="mute-button" variant={isMuted ? 'destructive' : 'secondary'} size="icon" className="rounded-full" onPress={toggleMute}>
-            <Icon as={isMuted ? MicOffIcon : MicIcon} size={20} className="text-foreground" />
-          </Button>
+          {activeVoiceModeRef.current === 'custom' ? (
+            <Button testID="interrupt-button" variant="secondary" size="icon" className="rounded-full" onPress={pipeline.interrupt}>
+              <Icon as={MicIcon} size={20} className="text-foreground" />
+            </Button>
+          ) : (
+            <Button testID="mute-button" variant={isMuted ? 'destructive' : 'secondary'} size="icon" className="rounded-full" onPress={toggleMute}>
+              <Icon as={isMuted ? MicOffIcon : MicIcon} size={20} className="text-foreground" />
+            </Button>
+          )}
           <Button testID="end-call-button" variant="destructive" className="rounded-full px-6" onPress={toggleCall}>
             <Icon as={PhoneOffIcon} size={20} className="text-destructive-foreground" />
             <Text className="ml-2 text-destructive-foreground">End Call</Text>

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -34,7 +34,7 @@ export default function SettingsScreen() {
   const [openaiTtsVoice, setOpenaiTtsVoice] = useState<typeof OPENAI_TTS_VOICES[number]>('alloy')
 
   // Kokoro model download state
-  const [kokoroStatus, setKokoroStatus] = useState<'checking' | 'ready' | 'not-downloaded' | 'downloading' | 'error'>('checking')
+  const [kokoroStatus, setKokoroStatus] = useState<'checking' | 'ready' | 'not-downloaded' | 'downloading' | 'error' | 'unavailable'>('checking')
 
   // Latency stats state
   const [latencyStats, setLatencyStats] = useState<LatencyAverages | null>(null)
@@ -47,10 +47,15 @@ export default function SettingsScreen() {
   const checkKokoroStatus = useCallback(() => {
     setKokoroStatus('checking')
     try {
+      const available = ExpoCustomPipelineModule.isKokoroAvailable()
+      if (!available) {
+        setKokoroStatus('unavailable')
+        return
+      }
       const ready = ExpoCustomPipelineModule.isKokoroModelReady()
       setKokoroStatus(ready ? 'ready' : 'not-downloaded')
     } catch {
-      setKokoroStatus('not-downloaded')
+      setKokoroStatus('unavailable')
     }
   }, [])
 
@@ -560,10 +565,18 @@ function KokoroModelStatus({
   onDownload,
   onRetry,
 }: {
-  status: 'checking' | 'ready' | 'not-downloaded' | 'downloading' | 'error'
+  status: 'checking' | 'ready' | 'not-downloaded' | 'downloading' | 'error' | 'unavailable'
   onDownload: () => void
   onRetry: () => void
 }) {
+  if (status === 'unavailable') {
+    return (
+      <View className="flex-row items-center gap-2 rounded-lg border border-input px-3 py-2">
+        <Text className="text-sm text-muted-foreground">Kokoro TTS is not available in this build. Requires KokoroSwift package.</Text>
+      </View>
+    )
+  }
+
   if (status === 'checking') {
     return (
       <View className="flex-row items-center gap-2 rounded-lg border border-input px-3 py-2">

--- a/lib/use-pipeline.ts
+++ b/lib/use-pipeline.ts
@@ -22,6 +22,7 @@ export type PipelineCallbacks = {
 export type PipelineControls = {
   start: () => void
   stop: () => void
+  interrupt: () => void
 }
 
 export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
@@ -44,10 +45,13 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
   callbacksRef.current = callbacks
 
   const restartSTTIfReady = useCallback(() => {
-    if (!isActiveRef.current) return
-    if (!isStreamCompleteRef.current) return
-    if (pendingTTSCountRef.current > 0) return
+    console.log('[Pipeline] restartSTTIfReady called — isActive:', isActiveRef.current, 'isStreamComplete:', isStreamCompleteRef.current, 'pendingTTS:', pendingTTSCountRef.current)
+    if (!isActiveRef.current) { console.log('[Pipeline] restartSTT BLOCKED: not active'); return }
+    if (!isStreamCompleteRef.current) { console.log('[Pipeline] restartSTT BLOCKED: stream not complete'); return }
 
+    if (pendingTTSCountRef.current > 0) { console.log('[Pipeline] restartSTT BLOCKED: pending TTS:', pendingTTSCountRef.current); return }
+
+    console.log('[Pipeline] restartSTT — ALL CONDITIONS MET, restarting STT')
     isStreamCompleteRef.current = false
     sentenceBufferRef.current = ''
     callbacksRef.current.onLatencyUpdate?.({
@@ -131,10 +135,12 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
             trySpeakCompleteSentences()
           },
           onDone: (text) => {
+            console.log('[Pipeline] LLM onDone — pendingTTS:', pendingTTSCountRef.current, 'isActive:', isActiveRef.current)
             if (!isActiveRef.current) return
             callbacksRef.current.onAssistantResponse?.(text)
             isStreamCompleteRef.current = true
             flushSentenceBuffer()
+            console.log('[Pipeline] After flushSentenceBuffer — pendingTTS:', pendingTTSCountRef.current)
             restartSTTIfReady()
           },
           onError: (error) => {
@@ -151,7 +157,8 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
   }, [trySpeakCompleteSentences, flushSentenceBuffer, restartSTTIfReady])
 
   const startListening = useCallback(() => {
-    if (!isActiveRef.current) return
+    console.log('[Pipeline] startListening called — isActive:', isActiveRef.current)
+    if (!isActiveRef.current) { console.log('[Pipeline] startListening BLOCKED: not active'); return }
 
     // Reset latency for new turn
     finalTranscriptTimeRef.current = null
@@ -160,6 +167,7 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
     llmLatencyMsRef.current = 0
     ttsLatencyMsRef.current = 0
 
+    console.log('[Pipeline] Calling ExpoCustomPipelineModule.startListening()')
     ExpoCustomPipelineModule.startListening()
   }, [])
 
@@ -183,13 +191,19 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
         'onFinalTranscript',
         (event: FinalTranscriptEvent) => {
           const now = Date.now()
-          // STT latency: time from startListening call to final transcript
-          // We use finalTranscriptTimeRef to compute it relative to when we started listening
-          // (simple approximation: wall-clock time captured when listening started)
           if (finalTranscriptTimeRef.current != null) {
             sttLatencyMsRef.current = now - finalTranscriptTimeRef.current
           }
           finalTranscriptTimeRef.current = now
+
+          // Barge-in: cancel any in-progress LLM stream and TTS playback
+          console.log('[Pipeline] onFinalTranscript — cancelling pending LLM/TTS for barge-in')
+          stopCompletionRef.current?.()
+          stopCompletionRef.current = null
+          ExpoCustomPipelineModule.stopSpeaking()
+          pendingTTSCountRef.current = 0
+          sentenceBufferRef.current = ''
+          speakStartTimesRef.current = []
 
           callbacksRef.current.onFinalTranscript?.(event.text)
           callAPI(event.text)
@@ -201,15 +215,44 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
         if (speakTime != null) {
           ttsLatencyMsRef.current = Date.now() - speakTime
         }
+        // Start VAD while TTS is playing so we can detect barge-in
+        ExpoCustomPipelineModule.startBargeInDetection()
         callbacksRef.current.onTTSStart?.()
       }),
       ExpoCustomPipelineModule.addListener('onTTSComplete', () => {
         pendingTTSCountRef.current = Math.max(0, pendingTTSCountRef.current - 1)
+        console.log('[Pipeline] onTTSComplete — pendingTTS now:', pendingTTSCountRef.current, 'isStreamComplete:', isStreamCompleteRef.current)
         callbacksRef.current.onTTSComplete?.()
+        // Stop VAD when all TTS finished — STT will take over
+        if (pendingTTSCountRef.current === 0) {
+          ExpoCustomPipelineModule.stopBargeInDetection()
+          if (isStreamCompleteRef.current) {
+            callbacksRef.current.onLatencyUpdate?.({
+              sttLatencyMs: sttLatencyMsRef.current,
+              llmLatencyMs: llmLatencyMsRef.current,
+              ttsLatencyMs: ttsLatencyMsRef.current,
+            })
+          }
+        }
         restartSTTIfReady()
+      }),
+      ExpoCustomPipelineModule.addListener('onBargeIn', () => {
+        console.log('[Pipeline] onBargeIn — user voice detected, interrupting')
+        ExpoCustomPipelineModule.stopBargeInDetection()
+        // Cancel in-progress LLM and TTS
+        stopCompletionRef.current?.()
+        stopCompletionRef.current = null
+        ExpoCustomPipelineModule.stopSpeaking()
+        pendingTTSCountRef.current = 0
+        sentenceBufferRef.current = ''
+        speakStartTimesRef.current = []
+        isStreamCompleteRef.current = false
+        // Start listening for the user's speech
+        startListening()
       }),
       ExpoCustomPipelineModule.addListener('onError', (event) => {
         pendingTTSCountRef.current = Math.max(0, pendingTTSCountRef.current - 1)
+        console.log('[Pipeline] onError:', event.message, '— pendingTTS now:', pendingTTSCountRef.current)
         callbacksRef.current.onError?.(event.message)
         restartSTTIfReady()
       }),
@@ -226,6 +269,7 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
     stopCompletionRef.current = null
     ExpoCustomPipelineModule.stopListening()
     ExpoCustomPipelineModule.stopSpeaking()
+    ExpoCustomPipelineModule.stopBargeInDetection()
     subsRef.current.forEach((s) => s.remove())
     subsRef.current = []
     pendingTTSCountRef.current = 0
@@ -234,5 +278,19 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
     speakStartTimesRef.current = []
   }, [])
 
-  return { start, stop }
+  const interrupt = useCallback(() => {
+    if (!isActiveRef.current) return
+    console.log('[Pipeline] interrupt — user tapped to interrupt')
+    ExpoCustomPipelineModule.stopBargeInDetection()
+    stopCompletionRef.current?.()
+    stopCompletionRef.current = null
+    ExpoCustomPipelineModule.stopSpeaking()
+    pendingTTSCountRef.current = 0
+    sentenceBufferRef.current = ''
+    speakStartTimesRef.current = []
+    isStreamCompleteRef.current = false
+    startListening()
+  }, [])
+
+  return { start, stop, interrupt }
 }

--- a/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
+++ b/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
@@ -5,6 +5,7 @@ public class ExpoCustomPipelineModule: Module {
     private var ttsProvider: TTSProvider?
     private var sttProviderName: String = ""
     private var ttsProviderName: String = ""
+    private let bargeInDetector = BargeInDetector()
 
     public func definition() -> ModuleDefinition {
         Name("ExpoCustomPipeline")
@@ -14,7 +15,8 @@ public class ExpoCustomPipelineModule: Module {
             "onFinalTranscript",
             "onTTSStart",
             "onTTSComplete",
-            "onError"
+            "onError",
+            "onBargeIn"
         )
 
         Function("setSTTProvider") { (name: String, config: [String: String]?) in
@@ -64,6 +66,16 @@ public class ExpoCustomPipelineModule: Module {
             self.ttsProvider?.stop()
         }
 
+        Function("startBargeInDetection") { () in
+            self.bargeInDetector.startMonitoring { [weak self] in
+                self?.sendEvent("onBargeIn", [:])
+            }
+        }
+
+        Function("stopBargeInDetection") { () in
+            self.bargeInDetector.stopMonitoring()
+        }
+
         Function("isKokoroModelReady") { () -> Bool in
             if #available(iOS 18.0, *) {
                 return KokoroTTSProvider.isModelCached()
@@ -71,9 +83,20 @@ public class ExpoCustomPipelineModule: Module {
             return false
         }
 
+        Function("isKokoroAvailable") { () -> Bool in
+            #if canImport(KokoroSwift)
+            if #available(iOS 18.0, *) {
+                return true
+            }
+            #endif
+            return false
+        }
+
         AsyncFunction("prepareKokoroModel") { (promise: Promise) in
+            #if canImport(KokoroSwift)
             guard #available(iOS 18.0, *) else {
-                promise.resolve(false)
+                promise.reject(NSError(domain: "KokoroTTS", code: 0,
+                    userInfo: [NSLocalizedDescriptionKey: "Kokoro TTS requires iOS 18+"]))
                 return
             }
             let provider = KokoroTTSProvider()
@@ -83,6 +106,10 @@ public class ExpoCustomPipelineModule: Module {
                 case .failure(let err): promise.reject(err)
                 }
             }
+            #else
+            promise.reject(NSError(domain: "KokoroTTS", code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "Kokoro TTS is not available in this build. The KokoroSwift package needs to be added to the project."]))
+            #endif
         }
     }
 }

--- a/modules/expo-custom-pipeline/ios/Pipeline/BargeInDetector.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/BargeInDetector.swift
@@ -1,0 +1,96 @@
+import AVFoundation
+
+class BargeInDetector {
+    private var audioEngine: AVAudioEngine?
+    private var isMonitoring = false
+    private var onBargeIn: (() -> Void)?
+
+    // Tunable thresholds
+    private let powerThresholdDb: Float = -25.0
+    private let sustainedDuration: TimeInterval = 0.15
+    private var aboveThresholdSince: CFAbsoluteTime?
+
+    func startMonitoring(onBargeIn: @escaping () -> Void) {
+        guard !isMonitoring else { return }
+
+        self.onBargeIn = onBargeIn
+
+        let engine = AVAudioEngine()
+        audioEngine = engine
+
+        let inputNode = engine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+
+        guard format.sampleRate > 0 else {
+            print("[BargeInDetector] Invalid audio format — no mic available")
+            return
+        }
+
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            self?.processBuffer(buffer)
+        }
+
+        engine.prepare()
+        do {
+            try engine.start()
+            isMonitoring = true
+            print("[BargeInDetector] Started monitoring (threshold: \(powerThresholdDb) dB, duration: \(sustainedDuration)s)")
+        } catch {
+            print("[BargeInDetector] Failed to start: \(error.localizedDescription)")
+            cleanup()
+        }
+    }
+
+    func stopMonitoring() {
+        guard isMonitoring else { return }
+        print("[BargeInDetector] Stopped monitoring")
+        cleanup()
+    }
+
+    // MARK: - Helpers
+
+    private func processBuffer(_ buffer: AVAudioPCMBuffer) {
+        let db = rmsDb(buffer)
+
+        if db > powerThresholdDb {
+            let now = CFAbsoluteTimeGetCurrent()
+            if aboveThresholdSince == nil {
+                aboveThresholdSince = now
+            } else if now - aboveThresholdSince! >= sustainedDuration {
+                print("[BargeInDetector] Voice detected (\(String(format: "%.1f", db)) dB) — triggering barge-in")
+                DispatchQueue.main.async { [weak self] in
+                    self?.stopMonitoring()
+                    self?.onBargeIn?()
+                }
+            }
+        } else {
+            aboveThresholdSince = nil
+        }
+    }
+
+    private func rmsDb(_ buffer: AVAudioPCMBuffer) -> Float {
+        guard let data = buffer.floatChannelData else { return -100 }
+        let samples = data.pointee
+        let count = Int(buffer.frameLength)
+        guard count > 0 else { return -100 }
+
+        var sum: Float = 0
+        for i in 0..<count {
+            sum += samples[i] * samples[i]
+        }
+
+        let rms = sqrt(sum / Float(count))
+        return 20 * log10(max(rms, 1e-10))
+    }
+
+    private func cleanup() {
+        if let engine = audioEngine, engine.isRunning {
+            engine.stop()
+            engine.inputNode.removeTap(onBus: 0)
+        }
+        audioEngine = nil
+        isMonitoring = false
+        aboveThresholdSince = nil
+        onBargeIn = nil
+    }
+}

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleSTTProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleSTTProvider.swift
@@ -11,7 +11,7 @@ class AppleSTTProvider: STTProvider {
     private let speechRecognizer: SFSpeechRecognizer?
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
-    private var audioEngine = AVAudioEngine()
+    private var audioEngine: AVAudioEngine?
     private var listenStartTime: CFAbsoluteTime = 0
     private var hasReceivedFirstResult = false
     private var silenceTimer: Timer?
@@ -30,7 +30,8 @@ class AppleSTTProvider: STTProvider {
         onPartialResult: @escaping (String) -> Void,
         onFinalResult: @escaping (String) -> Void
     ) {
-        guard !isListening else { return }
+        print("[AppleSTTProvider] startListening called — isListening: \(isListening), audioEngine: \(audioEngine != nil)")
+        guard !isListening else { print("[AppleSTTProvider] BLOCKED: already listening"); return }
 
         requestAuthorizationIfNeeded { [weak self] authorized in
             guard let self = self else { return }
@@ -49,19 +50,27 @@ class AppleSTTProvider: STTProvider {
     }
 
     func stopListening() {
-        guard isListening else { return }
+        print("[AppleSTTProvider] stopListening called — isListening: \(isListening)")
+        guard isListening else { print("[AppleSTTProvider] stopListening: not listening, skipping"); return }
 
         silenceTimer?.invalidate()
         silenceTimer = nil
-        audioEngine.stop()
-        audioEngine.inputNode.removeTap(onBus: 0)
+        if let engine = audioEngine {
+            print("[AppleSTTProvider] stopListening: engine isRunning=\(engine.isRunning)")
+            if engine.isRunning {
+                engine.stop()
+                engine.inputNode.removeTap(onBus: 0)
+            }
+        }
         recognitionRequest?.endAudio()
         recognitionTask?.cancel()
 
+        audioEngine = nil
         recognitionRequest = nil
         recognitionTask = nil
         isListening = false
         lastPartialText = ""
+        print("[AppleSTTProvider] stopListening complete — cleaned up")
     }
 
     // MARK: - Helpers
@@ -76,7 +85,17 @@ class AppleSTTProvider: STTProvider {
         }
 
         // Clean up any previous session
+        print("[AppleSTTProvider] beginRecognition — cleaning up previous session")
         stopListening()
+
+        // Configure audio session BEFORE creating recognition task
+        print("[AppleSTTProvider] beginRecognition — configuring audio session")
+        configureAudioSession()
+
+        // Create a fresh AVAudioEngine each time — reusing after stop() is unreliable
+        print("[AppleSTTProvider] beginRecognition — creating fresh AVAudioEngine")
+        let engine = AVAudioEngine()
+        audioEngine = engine
 
         let request = SFSpeechAudioBufferRecognitionRequest()
         request.shouldReportPartialResults = true
@@ -129,13 +148,12 @@ class AppleSTTProvider: STTProvider {
             }
         }
 
-        configureAudioSession()
         installAudioTap(for: request)
 
-        audioEngine.prepare()
+        engine.prepare()
 
         do {
-            try audioEngine.start()
+            try engine.start()
             isListening = true
             print("[AppleSTTProvider] Audio engine started, listening...")
         } catch {
@@ -163,12 +181,14 @@ class AppleSTTProvider: STTProvider {
 
     private func configureAudioSession() {
         let audioSession = AVAudioSession.sharedInstance()
+        print("[AppleSTTProvider] Audio session BEFORE config — category: \(audioSession.category.rawValue), mode: \(audioSession.mode.rawValue), sampleRate: \(audioSession.sampleRate), isOtherAudioPlaying: \(audioSession.isOtherAudioPlaying)")
         do {
             try audioSession.setCategory(
                 .playAndRecord, mode: .voiceChat,
                 options: [.defaultToSpeaker, .allowBluetooth]
             )
             try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+            print("[AppleSTTProvider] Audio session configured OK — category: \(audioSession.category.rawValue), mode: \(audioSession.mode.rawValue)")
         } catch {
             print("[AppleSTTProvider] Failed to configure audio session: \(error.localizedDescription)")
         }
@@ -191,6 +211,7 @@ class AppleSTTProvider: STTProvider {
     }
 
     private func installAudioTap(for request: SFSpeechAudioBufferRecognitionRequest) {
+        guard let audioEngine = audioEngine else { return }
         let inputNode = audioEngine.inputNode
         let recordingFormat = inputNode.outputFormat(forBus: 0)
 

--- a/modules/expo-custom-pipeline/src/ExpoCustomPipeline.types.ts
+++ b/modules/expo-custom-pipeline/src/ExpoCustomPipeline.types.ts
@@ -16,4 +16,5 @@ export type ExpoCustomPipelineModuleEvents = {
   onTTSStart: () => void
   onTTSComplete: () => void
   onError: (event: PipelineErrorEvent) => void
+  onBargeIn: () => void
 }

--- a/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule.ts
+++ b/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule.ts
@@ -9,6 +9,9 @@ declare class ExpoCustomPipelineModule extends NativeModule<ExpoCustomPipelineMo
   stopListening(): void
   speak(text: string): void
   stopSpeaking(): void
+  startBargeInDetection(): void
+  stopBargeInDetection(): void
+  isKokoroAvailable(): boolean
   isKokoroModelReady(): boolean
   prepareKokoroModel(): Promise<boolean>
 }


### PR DESCRIPTION
## Summary
- **Barge-in via VAD**: New `BargeInDetector` monitors mic audio power levels during TTS playback. When user voice is detected (sustained audio above -25dB for 150ms), cancels LLM stream + TTS and restarts STT immediately
- **Tap-to-interrupt**: Mic button during custom pipeline calls now triggers interrupt — stops TTS/LLM and starts listening
- **Multi-turn STT fix**: Recreates AVAudioEngine each turn (reusing after stop() is unreliable), configures audio session before recognition task
- **Kokoro availability fix**: Added `isKokoroAvailable()` compile-time check with proper UI state for unavailable builds

## Test plan
- [ ] Start custom pipeline call, speak, verify assistant responds
- [ ] After response plays, verify STT restarts and second turn works
- [ ] During assistant response, speak loudly — VAD should detect voice and interrupt TTS
- [ ] During assistant response, tap mic button — should interrupt TTS and start listening
- [ ] Verify Kokoro download button shows "not available" message instead of error

🤖 Generated with [Claude Code](https://claude.com/claude-code)