### PR TITLE
Fix STT latency measurement and document timing points

### DIFF
--- a/lib/use-pipeline.ts
+++ b/lib/use-pipeline.ts
@@ -44,8 +44,18 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
   const isActiveRef = useRef(false)
   const bargeInActiveRef = useRef(false)
 
-  // Latency tracking
-  const finalTranscriptTimeRef = useRef<number | null>(null)
+  // ── Latency tracking ──────────────────────────────────────────────
+  //
+  // STT latency:  time from startListening() call → onFinalTranscript event
+  //               (mic opens → user utterance fully recognised)
+  //
+  // LLM latency:  time from API request sent → first streamed token received
+  //               (network + model time-to-first-token)
+  //
+  // TTS latency:  time from speak() call → onTTSStart event
+  //               (synthesis request → first audio begins playing)
+  // ────────────────────────────────────────────────────────────────────
+  const listenStartTimeRef = useRef<number | null>(null)
   const firstTokenTimeRef = useRef<number | null>(null)
   const speakStartTimesRef = useRef<number[]>([])
   const sttLatencyMsRef = useRef<number>(0)
@@ -75,6 +85,7 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
 
   const speakSentence = useCallback((sentence: string) => {
     pendingTTSCountRef.current += 1
+    // TTS latency start: record the moment we call speak()
     speakStartTimesRef.current.push(Date.now())
     callbacksRef.current.onSpeakRequested?.(sentence)
     ExpoCustomPipelineModule.speak(sentence)
@@ -126,6 +137,7 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
         : [{ role: 'user', content: userText }]
 
       let fullResponse = ''
+      // LLM latency start: right before the streaming request is sent
       const llmStartTime = Date.now()
 
       stopCompletionRef.current = streamCompletion(
@@ -139,7 +151,7 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
           onToken: (text) => {
             if (!isActiveRef.current) return
 
-            // Track LLM latency (time to first token)
+            // LLM latency end: first streamed token received
             if (firstTokenTimeRef.current === null) {
               llmLatencyMsRef.current = Date.now() - llmStartTime
               firstTokenTimeRef.current = Date.now()
@@ -178,12 +190,14 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
     console.log('[Pipeline] startListening called — isActive:', isActiveRef.current)
     if (!isActiveRef.current) { console.log('[Pipeline] startListening BLOCKED: not active'); return }
 
-    // Reset latency for new turn
-    finalTranscriptTimeRef.current = null
+    // Reset latency accumulators for the new turn
     firstTokenTimeRef.current = null
     sttLatencyMsRef.current = 0
     llmLatencyMsRef.current = 0
     ttsLatencyMsRef.current = 0
+
+    // STT latency start: record the moment we open the mic
+    listenStartTimeRef.current = Date.now()
 
     console.log('[Pipeline] Calling ExpoCustomPipelineModule.startListening()')
     ExpoCustomPipelineModule.startListening()
@@ -208,11 +222,17 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
       ExpoCustomPipelineModule.addListener(
         'onFinalTranscript',
         (event: FinalTranscriptEvent) => {
+          // STT latency end: final transcript has arrived
           const now = Date.now()
-          if (finalTranscriptTimeRef.current != null) {
-            sttLatencyMsRef.current = now - finalTranscriptTimeRef.current
+          if (listenStartTimeRef.current != null) {
+            sttLatencyMsRef.current = now - listenStartTimeRef.current
           }
-          finalTranscriptTimeRef.current = now
+          listenStartTimeRef.current = null
+
+          // Final transcripts end the current listen turn. Stop the active
+          // recognizer explicitly so the next restart is never blocked on
+          // lingering native STT state.
+          ExpoCustomPipelineModule.stopListening()
 
           // Barge-in: cancel any in-progress LLM stream and TTS playback
           console.log('[Pipeline] onFinalTranscript — cancelling pending LLM/TTS for barge-in')
@@ -232,7 +252,7 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
         }
       ),
       ExpoCustomPipelineModule.addListener('onTTSStart', () => {
-        // TTS latency: time from speak() call to onTTSStart
+        // TTS latency end: first audio begins playing
         const speakTime = speakStartTimesRef.current.shift()
         if (speakTime != null) {
           ttsLatencyMsRef.current = Date.now() - speakTime
@@ -287,8 +307,8 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
       }),
     ]
 
-    // Mark the start-listening time for STT latency
-    finalTranscriptTimeRef.current = Date.now()
+    // STT latency start: record the moment we open the mic for the first turn
+    listenStartTimeRef.current = Date.now()
     ExpoCustomPipelineModule.startListening()
   }, [callAPI, restartSTTIfReady])
 

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleSTTProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleSTTProvider.swift
@@ -2,6 +2,14 @@ import Foundation
 import Speech
 import AVFoundation
 
+/// Apple on-device Speech-to-Text provider using SFSpeechRecognizer.
+///
+/// Latency measurement (native-side, informational):
+///   Start  – recognition task created (`listenStartTime`)
+///   End    – first partial result received (`hasReceivedFirstResult`)
+/// The authoritative STT latency is measured in use-pipeline.ts:
+///   Start  – `startListening()` call (mic opens)
+///   End    – `onFinalTranscript` event (complete utterance recognised)
 class AppleSTTProvider: STTProvider {
     let name = "apple"
 
@@ -129,6 +137,7 @@ class AppleSTTProvider: STTProvider {
                     self.silenceTimer = nil
                     onFinalResult(text)
                     self.lastPartialText = ""
+                    self.stopListening()
                 } else {
                     print("[AppleSTTProvider] Partial: \(text.prefix(50))")
                     self.lastPartialText = text

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleTTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleTTSProvider.swift
@@ -1,5 +1,13 @@
 import AVFoundation
 
+/// Apple AVSpeechSynthesizer TTS provider.
+///
+/// Latency measurement (native-side, informational):
+///   Start  – `speak()` called (`speakStartTime`)
+///   End    – `didStart` delegate callback (first audio frame playing)
+/// The authoritative TTS latency is measured in use-pipeline.ts:
+///   Start  – `speakSentence()` records `Date.now()` into `speakStartTimesRef`
+///   End    – `onTTSStart` event fires (maps to the native `didStart` callback)
 class AppleTTSProvider: NSObject, TTSProvider {
     let name = "Apple TTS"
     private(set) var isSpeaking = false


### PR DESCRIPTION
## Summary
- **Fixed STT latency bug**: On turns after the first, `startListening()` was resetting `finalTranscriptTimeRef` to `null`, causing the `onFinalTranscript` handler to find a null start timestamp and record 0ms. Renamed the ref to `listenStartTimeRef` and now set it to `Date.now()` on every `startListening()` call so every turn has a valid start timestamp.
- **Added explicit `stopListening()` call** on final transcript in both the TS orchestration layer and the native `AppleSTTProvider.swift`, preventing lingering native STT state from blocking the next listening turn.
- **Documented all three latency measurement points** (STT, LLM, TTS) with inline comments in `use-pipeline.ts` and doc comments on the native Apple providers.

### Measurement point definitions
| Component | Start | End |
|-----------|-------|-----|
| STT | `startListening()` call (mic opens) | `onFinalTranscript` event |
| LLM | `streamCompletion()` request sent | First streamed token received |
| TTS | `speak()` called | `onTTSStart` event (first audio plays) |

## Test plan
- [ ] Start a custom pipeline conversation, verify STT latency shows a non-zero value on the first turn
- [ ] Continue the conversation for 2+ turns, verify STT latency remains non-zero on subsequent turns
- [ ] Verify LLM and TTS latency values remain correct and non-zero
- [ ] Verify barge-in still works correctly (interrupting during TTS playback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)