### PR TITLE
Add API key validation on Settings page (NAN-593)

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -378,9 +378,6 @@ export default function SettingsScreen() {
                 value={vapiPublicKey}
                 onChangeText={updateVapiPublicKey}
                 placeholder="Enter your Vapi public key"
-                validationStatus={validationStatus.vapi}
-                validationError={validationErrors.vapi}
-                onTest={() => testApiKey('vapi', vapiPublicKey)}
               />
             </View>
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -6,8 +6,9 @@ import { Text } from '@/components/ui/text'
 import { getSetting, getLatencyAverages, clearLatencyData, type LatencyAverages } from '@/db'
 import { runPipelineTests, type TestResult } from '@/lib/pipeline-test-runner'
 import { useAutoSave, type SaveStatus } from '@/lib/use-auto-save'
+import { validateApiKey, type Provider, type ValidationStatus } from '@/lib/validate-api-key'
 import ExpoCustomPipelineModule from '@/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule'
-import { CheckIcon, EyeIcon, EyeOffIcon, PlayIcon, RefreshCwIcon, Trash2Icon } from 'lucide-react-native'
+import { AlertCircleIcon, CheckIcon, EyeIcon, EyeOffIcon, PlayIcon, RefreshCwIcon, Trash2Icon } from 'lucide-react-native'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ActivityIndicator, Alert, Animated, KeyboardAvoidingView, Platform, Pressable, ScrollView, TextInput, View } from 'react-native'
 
@@ -46,6 +47,22 @@ export default function SettingsScreen() {
   // Latency stats state
   const [latencyStats, setLatencyStats] = useState<LatencyAverages | null>(null)
   const [loadingStats, setLoadingStats] = useState(true)
+
+  // API key validation state
+  const [validationStatus, setValidationStatus] = useState<Record<Provider, ValidationStatus>>({
+    openclaw: 'idle',
+    elevenlabs: 'idle',
+    deepgram: 'idle',
+    openai_tts: 'idle',
+    vapi: 'idle',
+  })
+  const [validationErrors, setValidationErrors] = useState<Record<Provider, string | undefined>>({
+    openclaw: undefined,
+    elevenlabs: undefined,
+    deepgram: undefined,
+    openai_tts: undefined,
+    vapi: undefined,
+  })
 
   // Auto-save: guard against saving during initial load
   const loadedRef = useRef(false)
@@ -135,6 +152,22 @@ export default function SettingsScreen() {
     })()
   }, [])
 
+  // --- Validation helpers ---
+  const resetValidation = useCallback((provider: Provider) => {
+    setValidationStatus((prev) => ({ ...prev, [provider]: 'idle' }))
+    setValidationErrors((prev) => ({ ...prev, [provider]: undefined }))
+  }, [])
+
+  const testApiKey = useCallback(async (provider: Provider, apiKey: string, apiUrl?: string) => {
+    setValidationStatus((prev) => ({ ...prev, [provider]: 'testing' }))
+    setValidationErrors((prev) => ({ ...prev, [provider]: undefined }))
+    const result = await validateApiKey(provider, apiKey, apiUrl)
+    setValidationStatus((prev) => ({ ...prev, [provider]: result.status }))
+    if (result.error) {
+      setValidationErrors((prev) => ({ ...prev, [provider]: result.error }))
+    }
+  }, [])
+
   // --- Auto-saving wrappers ---
   // Immediate save for toggles/dropdowns
   const updateVoiceMode = useCallback((v: VoiceMode) => {
@@ -160,8 +193,9 @@ export default function SettingsScreen() {
   // Debounced save for text inputs
   const updateVapiPublicKey = useCallback((v: string) => {
     setVapiPublicKey(v)
+    resetValidation('vapi')
     if (loadedRef.current) saveDebounced('vapi_public_key', v)
-  }, [saveDebounced])
+  }, [saveDebounced, resetValidation])
 
   const updateAssistantId = useCallback((v: string) => {
     setAssistantId(v)
@@ -175,13 +209,15 @@ export default function SettingsScreen() {
 
   const updateOpenclawApiKey = useCallback((v: string) => {
     setOpenclawApiKey(v)
+    resetValidation('openclaw')
     if (loadedRef.current) saveDebounced('openclaw_api_key', v)
-  }, [saveDebounced])
+  }, [saveDebounced, resetValidation])
 
   const updateOpenclawApiUrl = useCallback((v: string) => {
     setOpenclawApiUrl(v)
+    resetValidation('openclaw')
     if (loadedRef.current) saveDebounced('openclaw_api_url', v)
-  }, [saveDebounced])
+  }, [saveDebounced, resetValidation])
 
   const updateSystemPrompt = useCallback((v: string) => {
     setSystemPrompt(v)
@@ -190,13 +226,15 @@ export default function SettingsScreen() {
 
   const updateDeepgramApiKey = useCallback((v: string) => {
     setDeepgramApiKey(v)
+    resetValidation('deepgram')
     if (loadedRef.current) saveDebounced('deepgram_api_key', v)
-  }, [saveDebounced])
+  }, [saveDebounced, resetValidation])
 
   const updateElevenlabsApiKey = useCallback((v: string) => {
     setElevenlabsApiKey(v)
+    resetValidation('elevenlabs')
     if (loadedRef.current) saveDebounced('elevenlabs_api_key', v)
-  }, [saveDebounced])
+  }, [saveDebounced, resetValidation])
 
   const updateElevenlabsVoiceId = useCallback((v: string) => {
     setElevenlabsVoiceId(v)
@@ -205,8 +243,9 @@ export default function SettingsScreen() {
 
   const updateOpenaiTtsApiKey = useCallback((v: string) => {
     setOpenaiTtsApiKey(v)
+    resetValidation('openai_tts')
     if (loadedRef.current) saveDebounced('openai_tts_api_key', v)
-  }, [saveDebounced])
+  }, [saveDebounced, resetValidation])
 
   return (
     <KeyboardAvoidingView
@@ -251,6 +290,9 @@ export default function SettingsScreen() {
                     value={deepgramApiKey}
                     onChangeText={updateDeepgramApiKey}
                     placeholder="Enter your Deepgram API key"
+                    validationStatus={validationStatus.deepgram}
+                    validationError={validationErrors.deepgram}
+                    onTest={() => testApiKey('deepgram', deepgramApiKey)}
                   />
                 </View>
               )}
@@ -281,6 +323,9 @@ export default function SettingsScreen() {
                       value={elevenlabsApiKey}
                       onChangeText={updateElevenlabsApiKey}
                       placeholder="Enter your ElevenLabs API key"
+                      validationStatus={validationStatus.elevenlabs}
+                      validationError={validationErrors.elevenlabs}
+                      onTest={() => testApiKey('elevenlabs', elevenlabsApiKey)}
                     />
                   </View>
                   <View className="gap-2">
@@ -304,6 +349,9 @@ export default function SettingsScreen() {
                       value={openaiTtsApiKey}
                       onChangeText={updateOpenaiTtsApiKey}
                       placeholder="Enter your OpenAI API key"
+                      validationStatus={validationStatus.openai_tts}
+                      validationError={validationErrors.openai_tts}
+                      onTest={() => testApiKey('openai_tts', openaiTtsApiKey)}
                     />
                   </View>
                   <View className="gap-2">
@@ -330,6 +378,9 @@ export default function SettingsScreen() {
                 value={vapiPublicKey}
                 onChangeText={updateVapiPublicKey}
                 placeholder="Enter your Vapi public key"
+                validationStatus={validationStatus.vapi}
+                validationError={validationErrors.vapi}
+                onTest={() => testApiKey('vapi', vapiPublicKey)}
               />
             </View>
 
@@ -391,6 +442,9 @@ export default function SettingsScreen() {
               value={openclawApiKey}
               onChangeText={updateOpenclawApiKey}
               placeholder="Enter your OpenClaw API key"
+              validationStatus={validationStatus.openclaw}
+              validationError={validationErrors.openclaw}
+              onTest={() => testApiKey('openclaw', openclawApiKey, openclawApiUrl)}
             />
           </View>
         </Card>
@@ -500,38 +554,74 @@ function SecretInput({
   value,
   onChangeText,
   placeholder,
+  validationStatus = 'idle',
+  validationError,
+  onTest,
 }: {
   value: string
   onChangeText: (text: string) => void
   placeholder: string
+  validationStatus?: ValidationStatus
+  validationError?: string
+  onTest?: () => void
 }) {
   const [visible, setVisible] = useState(false)
 
   return (
-    <View className="flex-row items-center rounded-md border border-input bg-background dark:bg-input/30">
-      <TextInput
-        className="h-10 min-w-0 flex-1 px-3 py-2 text-base text-foreground"
-        placeholder={placeholder}
-        placeholderTextColor="#888"
-        value={value}
-        onChangeText={onChangeText}
-        secureTextEntry={!visible}
-        autoCapitalize="none"
-        autoCorrect={false}
-        numberOfLines={1}
-        scrollEnabled
-      />
-      <Pressable
-        onPress={() => setVisible((prev) => !prev)}
-        className="h-10 shrink-0 items-center justify-center px-3"
-        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-      >
-        <Icon
-          as={visible ? EyeOffIcon : EyeIcon}
-          size={20}
-          className="text-muted-foreground"
-        />
-      </Pressable>
+    <View className="gap-1">
+      <View className="flex-row items-center gap-2">
+        <View className="min-w-0 flex-1 flex-row items-center rounded-md border border-input bg-background dark:bg-input/30">
+          <TextInput
+            className="h-10 min-w-0 flex-1 px-3 py-2 text-base text-foreground"
+            placeholder={placeholder}
+            placeholderTextColor="#888"
+            value={value}
+            onChangeText={onChangeText}
+            secureTextEntry={!visible}
+            autoCapitalize="none"
+            autoCorrect={false}
+            numberOfLines={1}
+            scrollEnabled
+          />
+          <Pressable
+            onPress={() => setVisible((prev) => !prev)}
+            className="h-10 shrink-0 items-center justify-center px-3"
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Icon
+              as={visible ? EyeOffIcon : EyeIcon}
+              size={20}
+              className="text-muted-foreground"
+            />
+          </Pressable>
+        </View>
+        {onTest && (
+          <Pressable
+            onPress={onTest}
+            disabled={validationStatus === 'testing' || !value.trim()}
+            className={`h-10 shrink-0 flex-row items-center justify-center rounded-md px-3 ${
+              validationStatus === 'valid'
+                ? 'bg-green-500/10'
+                : validationStatus === 'invalid'
+                  ? 'bg-destructive/10'
+                  : 'bg-secondary'
+            } ${(!value.trim() || validationStatus === 'testing') ? 'opacity-50' : ''}`}
+          >
+            {validationStatus === 'testing' ? (
+              <ActivityIndicator size="small" color="#888" />
+            ) : validationStatus === 'valid' ? (
+              <Icon as={CheckIcon} size={18} className="text-green-500" />
+            ) : validationStatus === 'invalid' ? (
+              <Icon as={AlertCircleIcon} size={18} className="text-destructive" />
+            ) : (
+              <Text className="text-sm font-medium text-foreground">Test</Text>
+            )}
+          </Pressable>
+        )}
+      </View>
+      {validationStatus === 'invalid' && validationError && (
+        <Text className="text-xs text-destructive">{validationError}</Text>
+      )}
     </View>
   )
 }

--- a/lib/validate-api-key.ts
+++ b/lib/validate-api-key.ts
@@ -1,0 +1,143 @@
+export type ValidationStatus = 'idle' | 'testing' | 'valid' | 'invalid'
+
+export type ValidationResult = {
+  status: 'valid' | 'invalid'
+  error?: string
+}
+
+export type Provider = 'openclaw' | 'elevenlabs' | 'deepgram' | 'openai_tts' | 'vapi'
+
+export async function validateApiKey(
+  provider: Provider,
+  apiKey: string,
+  apiUrl?: string,
+): Promise<ValidationResult> {
+  if (!apiKey.trim()) {
+    return { status: 'invalid', error: 'API key is empty' }
+  }
+
+  switch (provider) {
+    case 'openclaw':
+      return validateOpenClaw(apiKey, apiUrl)
+    case 'elevenlabs':
+      return validateElevenLabs(apiKey)
+    case 'deepgram':
+      return validateDeepgram(apiKey)
+    case 'openai_tts':
+      return validateOpenAI(apiKey)
+    case 'vapi':
+      return validateVapi(apiKey)
+    default:
+      return { status: 'invalid', error: 'Unknown provider' }
+  }
+}
+
+// --- Validation functions ---
+
+async function validateOpenClaw(
+  apiKey: string,
+  apiUrl?: string,
+): Promise<ValidationResult> {
+  const url = apiUrl?.trim() || 'https://openrouter.ai/api/v1/chat/completions'
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'openai/gpt-4o-mini',
+        messages: [{ role: 'user', content: 'hi' }],
+        max_tokens: 1,
+      }),
+    })
+
+    if (response.status === 401 || response.status === 403) {
+      return { status: 'invalid', error: 'Invalid API key' }
+    }
+    if (response.ok || response.status === 400) {
+      // 400 can happen with model issues but key is valid
+      return { status: 'valid' }
+    }
+    return { status: 'invalid', error: `HTTP ${response.status}` }
+  } catch (err: any) {
+    return { status: 'invalid', error: err.message || 'Network error' }
+  }
+}
+
+async function validateElevenLabs(apiKey: string): Promise<ValidationResult> {
+  try {
+    const response = await fetch('https://api.elevenlabs.io/v1/voices', {
+      method: 'GET',
+      headers: { 'xi-api-key': apiKey },
+    })
+
+    if (response.status === 401) {
+      return { status: 'invalid', error: 'Invalid API key' }
+    }
+    if (response.ok) {
+      return { status: 'valid' }
+    }
+    return { status: 'invalid', error: `HTTP ${response.status}` }
+  } catch (err: any) {
+    return { status: 'invalid', error: err.message || 'Network error' }
+  }
+}
+
+async function validateDeepgram(apiKey: string): Promise<ValidationResult> {
+  try {
+    const response = await fetch('https://api.deepgram.com/v1/projects', {
+      method: 'GET',
+      headers: { Authorization: `Token ${apiKey}` },
+    })
+
+    if (response.status === 401 || response.status === 403) {
+      return { status: 'invalid', error: 'Invalid API key' }
+    }
+    if (response.ok) {
+      return { status: 'valid' }
+    }
+    return { status: 'invalid', error: `HTTP ${response.status}` }
+  } catch (err: any) {
+    return { status: 'invalid', error: err.message || 'Network error' }
+  }
+}
+
+async function validateOpenAI(apiKey: string): Promise<ValidationResult> {
+  try {
+    const response = await fetch('https://api.openai.com/v1/models', {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${apiKey}` },
+    })
+
+    if (response.status === 401) {
+      return { status: 'invalid', error: 'Invalid API key' }
+    }
+    if (response.ok) {
+      return { status: 'valid' }
+    }
+    return { status: 'invalid', error: `HTTP ${response.status}` }
+  } catch (err: any) {
+    return { status: 'invalid', error: err.message || 'Network error' }
+  }
+}
+
+async function validateVapi(apiKey: string): Promise<ValidationResult> {
+  try {
+    const response = await fetch('https://api.vapi.ai/assistant', {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${apiKey}` },
+    })
+
+    if (response.status === 401 || response.status === 403) {
+      return { status: 'invalid', error: 'Invalid API key' }
+    }
+    if (response.ok) {
+      return { status: 'valid' }
+    }
+    return { status: 'invalid', error: `HTTP ${response.status}` }
+  } catch (err: any) {
+    return { status: 'invalid', error: err.message || 'Network error' }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a "Test" button next to each cloud API key input (OpenClaw, ElevenLabs, Deepgram, OpenAI TTS, Vapi) on the Settings page
- Each button makes a lightweight API call to verify the key is valid, showing a spinner while testing, green checkmark if valid, or red error icon with message if invalid
- Validation status resets automatically when the key value changes (cache until key changes)
- New `lib/validate-api-key.ts` module with provider-specific validation functions

## Test plan
- [ ] Open Settings, enter a valid OpenClaw API key, tap Test -- should show green checkmark
- [ ] Enter an invalid API key for any provider, tap Test -- should show red error icon and error message
- [ ] Change the API key after testing -- status should reset to "Test" button
- [ ] Test with empty key -- Test button should be disabled (dimmed)
- [ ] Verify all 5 providers: OpenClaw, ElevenLabs, Deepgram, OpenAI TTS, Vapi
- [ ] Verify the app builds successfully in iOS simulator: `npx expo run:ios --device "iPhone 16 Pro"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)