### PR TITLE
Hide debug UI behind a Debug Mode toggle in Settings

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -104,6 +104,7 @@ export default function ChatScreen() {
   const [isConnecting, setIsConnecting] = useState(false)
   const [streamingText, setStreamingText] = useState<string | null>(null)
   const [showLatency, setShowLatency] = useState(false)
+  const [debugMode, setDebugMode] = useState(false)
   const [streamingRole, setStreamingRole] = useState<'user' | 'assistant'>('assistant')
   const flatListRef = useRef<FlatList<Message>>(null)
   const hasScrolledRef = useRef(false)
@@ -539,6 +540,7 @@ export default function ChatScreen() {
 
   useEffect(() => {
     getSetting('show_latency').then((v) => { if (v === 'true') setShowLatency(true) }).catch(() => {})
+    getSetting('debug_mode').then((v) => { if (v === 'true') setDebugMode(true) }).catch(() => {})
   }, [])
 
   useEffect(() => { loadMessages() }, [loadMessages])
@@ -934,7 +936,7 @@ export default function ChatScreen() {
         </View>
       )}
 
-      {__DEV__ && isCallActive && activeVoiceModeRef.current === 'custom' && (
+      {debugMode && isCallActive && activeVoiceModeRef.current === 'custom' && (
         <View testID="pipeline-debug-panel" className="gap-2 border-t border-dashed border-border bg-background px-4 py-3">
           <Text testID="pipeline-debug-phase" className="text-xs text-muted-foreground">
             phase:{pipelineDebugState.phase}

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -3,13 +3,13 @@ import { Card } from '@/components/ui/card'
 import { Icon } from '@/components/ui/icon'
 import { Input } from '@/components/ui/input'
 import { Text } from '@/components/ui/text'
-import { getSetting, getLatencyAverages, clearLatencyData, type LatencyAverages } from '@/db'
+import { getSetting, setSetting, getLatencyAverages, clearLatencyData, type LatencyAverages } from '@/db'
 import { runPipelineTests, type TestResult } from '@/lib/pipeline-test-runner'
 import { useAutoSave, type SaveStatus } from '@/lib/use-auto-save'
 import ExpoCustomPipelineModule from '@/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule'
 import { CheckIcon, EyeIcon, EyeOffIcon, PlayIcon, RefreshCwIcon, Trash2Icon } from 'lucide-react-native'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { ActivityIndicator, Alert, Animated, KeyboardAvoidingView, Platform, Pressable, ScrollView, TextInput, View } from 'react-native'
+import { ActivityIndicator, Alert, Animated, KeyboardAvoidingView, Platform, Pressable, ScrollView, Switch, TextInput, View } from 'react-native'
 
 type VoiceMode = 'vapi' | 'custom'
 type STTProviderValue = 'apple' | 'deepgram'
@@ -34,6 +34,9 @@ export default function SettingsScreen() {
   const [elevenlabsVoiceId, setElevenlabsVoiceId] = useState('Awx8TeMHHpDzbm42nIB6')
   const [openaiTtsApiKey, setOpenaiTtsApiKey] = useState('')
   const [openaiTtsVoice, setOpenaiTtsVoice] = useState<typeof OPENAI_TTS_VOICES[number]>('alloy')
+
+  // Debug mode
+  const [debugMode, setDebugMode] = useState(false)
 
   // Kokoro model download state
   const [kokoroStatus, setKokoroStatus] = useState<'checking' | 'ready' | 'not-downloaded' | 'downloading' | 'error' | 'unavailable'>('checking')
@@ -130,6 +133,8 @@ export default function SettingsScreen() {
       if (oaiVoice && (OPENAI_TTS_VOICES as readonly string[]).includes(oaiVoice)) {
         setOpenaiTtsVoice(oaiVoice as typeof OPENAI_TTS_VOICES[number])
       }
+      const dm = await getSetting('debug_mode')
+      if (dm === 'true') setDebugMode(true)
 
       loadedRef.current = true
     })()
@@ -207,6 +212,11 @@ export default function SettingsScreen() {
     setOpenaiTtsApiKey(v)
     if (loadedRef.current) saveDebounced('openai_tts_api_key', v)
   }, [saveDebounced])
+
+  const toggleDebugMode = useCallback((v: boolean) => {
+    setDebugMode(v)
+    setSetting('debug_mode', v ? 'true' : 'false')
+  }, [])
 
   return (
     <KeyboardAvoidingView
@@ -391,6 +401,22 @@ export default function SettingsScreen() {
               value={openclawApiKey}
               onChangeText={updateOpenclawApiKey}
               placeholder="Enter your OpenClaw API key"
+            />
+          </View>
+        </Card>
+
+        <Card testID="debug-mode-card" className="gap-2 p-4">
+          <View className="flex-row items-center justify-between">
+            <View className="flex-1">
+              <Text className="text-lg font-semibold text-foreground">Debug Mode</Text>
+              <Text className="text-sm text-muted-foreground">
+                Show pipeline debug panel and event counters during calls
+              </Text>
+            </View>
+            <Switch
+              testID="debug-mode-toggle"
+              value={debugMode}
+              onValueChange={toggleDebugMode}
             />
           </View>
         </Card>


### PR DESCRIPTION
## Summary
- Add a "Debug Mode" toggle in Settings (default: OFF) that controls visibility of the pipeline debug panel during custom pipeline calls
- When OFF: clean chat UI with no debug info (phase indicator, event counters, raw message pipeline, test buttons, and the entire pipeline-debug-panel are hidden)
- When ON: shows all debug output as it does today
- Setting persists via `debug_mode` key in the settings store, separate from "Show Latency"

## Test plan
- [ ] Open Settings, verify "Debug Mode" card appears before "Pipeline Tests"
- [ ] Toggle Debug Mode ON, start a custom pipeline call, verify debug panel with counters and test buttons appears
- [ ] Toggle Debug Mode OFF, start a custom pipeline call, verify debug panel is hidden
- [ ] Kill and relaunch the app, verify the toggle state persists
- [ ] Verify "Show Latency" toggle still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)