### PR TITLE
Add per-message response time indicator (NAN-590)

### DIFF
--- a/components/latency-badge.tsx
+++ b/components/latency-badge.tsx
@@ -7,17 +7,20 @@ type LatencyBadgeProps = {
 }
 
 export function LatencyBadge({ message }: LatencyBadgeProps) {
+  if (message.role !== 'assistant') return null
   if (!hasLatencyData(message)) return null
 
+  const totalMs = computeTotalLatency(message)
   const parts: string[] = []
-  if (message.stt_latency_ms != null) parts.push(`STT: ${formatMs(message.stt_latency_ms)}`)
-  if (message.llm_latency_ms != null) parts.push(`LLM: ${formatMs(message.llm_latency_ms)}`)
-  if (message.tts_latency_ms != null) parts.push(`TTS: ${formatMs(message.tts_latency_ms)}`)
+  if (message.stt_latency_ms != null) parts.push(`STT ${formatMs(message.stt_latency_ms)}`)
+  if (message.llm_latency_ms != null) parts.push(`LLM ${formatMs(message.llm_latency_ms)}`)
+  if (message.tts_latency_ms != null) parts.push(`TTS ${formatMs(message.tts_latency_ms)}`)
 
   return (
-    <View className="mt-1 px-4">
+    <View className="mt-1 items-start px-4">
       <Text className="text-xs text-muted-foreground/60">
-        {parts.join(' | ')}
+        {totalMs != null ? formatMs(totalMs) : ''}
+        {parts.length > 1 && totalMs != null ? ` (${parts.join(' · ')})` : ''}
       </Text>
     </View>
   )
@@ -31,6 +34,17 @@ function hasLatencyData(message: Message): boolean {
     message.llm_latency_ms != null ||
     message.tts_latency_ms != null
   )
+}
+
+function computeTotalLatency(message: Message): number | null {
+  const values = [
+    message.stt_latency_ms,
+    message.llm_latency_ms,
+    message.tts_latency_ms,
+  ].filter((v): v is number => v != null)
+
+  if (values.length === 0) return null
+  return values.reduce((sum, v) => sum + v, 0)
 }
 
 function formatMs(ms: number): string {


### PR DESCRIPTION
## Summary
- Updated `LatencyBadge` to display total response time (STT + LLM + TTS) below each assistant message bubble, with individual breakdown in parentheses (e.g., "1.2s (STT 200ms · LLM 800ms · TTS 200ms)")
- Badge now only renders for assistant messages and aligns left to match bubble positioning
- Respects existing `showLatency` toggle in Settings

## Test plan
- [ ] Enable "Show Latency" in Settings
- [ ] Make a voice call and send messages
- [ ] Verify latency badge appears only below assistant messages (not user messages)
- [ ] Verify total time is shown with breakdown when multiple latency components exist
- [ ] Verify format: "1.2s" for >= 1s, "450ms" for < 1s
- [ ] Verify badge does not appear when "Show Latency" is OFF
- [ ] Verify badge does not appear for messages without latency data

🤖 Generated with [Claude Code](https://claude.com/claude-code)