### PR TITLE
Latency capture and display improvements (NAN-592)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button'
 import { Icon } from '@/components/ui/icon'
 import { Input } from '@/components/ui/input'
 import { Text } from '@/components/ui/text'
-import { addMessage, createConversation, getLatestConversation, getMessages, getSetting, setSetting, type Message, type LatencyData } from '@/db'
+import { addMessage, createConversation, getLatestConversation, getMessages, getSetting, type Message, type LatencyData, type ProviderInfo } from '@/db'
 import { getApiConfig, streamCompletion } from '@/lib/chat'
 import { compactMessages } from '@/lib/compact'
 import { useConversationContext } from '@/lib/conversation-context'
@@ -16,7 +16,7 @@ import ExpoCustomPipelineModule from '@/modules/expo-custom-pipeline/src/ExpoCus
 import ExpoVapiModule from '@/modules/expo-vapi'
 import type { FunctionCallEvent, SpeechEvent, TranscriptEvent } from '@/modules/expo-vapi'
 import { Stack } from 'expo-router'
-import { MicIcon, MicOffIcon, PhoneOffIcon, PlusIcon, RefreshCwIcon, SendIcon, TimerIcon, XIcon } from 'lucide-react-native'
+import { MicIcon, MicOffIcon, PhoneOffIcon, PlusIcon, RefreshCwIcon, SendIcon, XIcon } from 'lucide-react-native'
 import { useColorScheme } from 'nativewind'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ActivityIndicator, Animated, FlatList, Image, KeyboardAvoidingView, Platform, Pressable, View } from 'react-native'
@@ -118,6 +118,7 @@ export default function ChatScreen() {
   const lastAssistantIdRef = useRef<string | null>(null)
   const pendingLatencyRef = useRef<LatencyData | null>(null)
   const activeVoiceModeRef = useRef<'vapi' | 'custom'>('vapi')
+  const activeProvidersRef = useRef<ProviderInfo | null>(null)
   const [pipelineDebugState, setPipelineDebugState] = useState(INITIAL_PIPELINE_DEBUG_STATE)
   const conversationIdRef = useRef<number | null>(null)
   conversationIdRef.current = conversationId
@@ -182,7 +183,7 @@ export default function ChatScreen() {
       }))
       const convId = conversationIdRef.current
       if (convId) {
-        addMessage(convId, 'user', text).then(() => {
+        addMessage(convId, 'user', text, undefined, activeProvidersRef.current ?? undefined).then(() => {
           loadMessagesRef.current()
           maybeGenerateTitle(convId)
         })
@@ -220,7 +221,7 @@ export default function ChatScreen() {
       }))
       const convId = conversationIdRef.current
       if (convId && text) {
-        addMessage(convId, 'assistant', text, pendingLatencyRef.current ?? undefined).then(() => {
+        addMessage(convId, 'assistant', text, pendingLatencyRef.current ?? undefined, activeProvidersRef.current ?? undefined).then(() => {
           pendingLatencyRef.current = null
           loadMessagesRef.current()
         })
@@ -280,7 +281,7 @@ export default function ChatScreen() {
       // Attach latency data to assistant messages from Custom Pipeline
       const latency = role === 'assistant' ? pendingLatencyRef.current ?? undefined : undefined
       if (role === 'assistant') pendingLatencyRef.current = null
-      await addMessage(conversationId, role, text, latency)
+      await addMessage(conversationId, role, text, latency, activeProvidersRef.current ?? undefined)
       await loadMessages()
       maybeGenerateTitle(conversationId)
     } catch (err) {
@@ -381,7 +382,7 @@ export default function ChatScreen() {
             console.log('[Chat] Flushing buffered transcript on call end:', role, text.substring(0, 50))
             const latency = role === 'assistant' ? pendingLatencyRef.current ?? undefined : undefined
             if (role === 'assistant') pendingLatencyRef.current = null
-            await addMessage(conversationId, role, text, latency)
+            await addMessage(conversationId, role, text, latency, activeProvidersRef.current ?? undefined)
           }
           if (pending.length > 0) {
             loadMessages()
@@ -395,6 +396,7 @@ export default function ChatScreen() {
         setIsConnecting(false)
         wasCallActiveRef.current = false
         userInitiatedEndRef.current = false
+        activeProvidersRef.current = null
         soundsRef.current.stopThinking()
 
         if (wasActive && !wasUserInitiated) {
@@ -735,6 +737,13 @@ export default function ChatScreen() {
     lastAssistantIdRef.current = assistantId
     lastCallOverridesRef.current = callOverrides ?? null
 
+    // Store active providers for message tagging
+    activeProvidersRef.current = {
+      sttProvider: 'vapi',
+      llmProvider: model || 'vapi',
+      ttsProvider: 'vapi',
+    }
+
     // Safety timeout: reset isConnecting if onCallStart never fires
     if (connectingTimeoutRef.current) clearTimeout(connectingTimeoutRef.current)
     connectingTimeoutRef.current = setTimeout(() => {
@@ -751,7 +760,7 @@ export default function ChatScreen() {
   const startCustomPipelineCall = useCallback(async (): Promise<boolean> => {
     if (!conversationId) return false
 
-    const { apiKey, apiUrl } = await getApiConfig()
+    const { apiKey, apiUrl, model } = await getApiConfig()
     if (!apiKey || !apiUrl) {
       await addMessage(conversationId, 'assistant', 'Please configure your OpenClaw API URL and key in Settings first.')
       await loadMessages()
@@ -761,6 +770,13 @@ export default function ChatScreen() {
     // Read STT/TTS provider settings
     const sttProvider = (await getSetting('stt_provider')) || 'apple'
     const ttsProvider = (await getSetting('tts_provider')) || 'apple'
+
+    // Store active providers for message tagging
+    activeProvidersRef.current = {
+      sttProvider,
+      llmProvider: model,
+      ttsProvider,
+    }
 
     // Configure STT provider
     const sttConfig: Record<string, string> = {}
@@ -800,6 +816,7 @@ export default function ChatScreen() {
 
   const stopCustomPipeline = useCallback(() => {
     pipeline.stop()
+    activeProvidersRef.current = null
     setIsCallActive(false)
     setIsMuted(false)
     setIsThinking(false)
@@ -825,18 +842,12 @@ export default function ChatScreen() {
 
   let displayMessages = messages as Message[]
   if (streamingText !== null) {
-    displayMessages = [...messages, { id: -1, conversation_id: conversationId ?? 0, role: streamingRole, content: streamingText, created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null }]
+    displayMessages = [...messages, { id: -1, conversation_id: conversationId ?? 0, role: streamingRole, content: streamingText, created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null, stt_provider: null, llm_provider: null, tts_provider: null }]
   } else if (isThinking) {
-    displayMessages = [...messages, { id: THINKING_MESSAGE_ID, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: '', created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null }]
+    displayMessages = [...messages, { id: THINKING_MESSAGE_ID, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: '', created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null, stt_provider: null, llm_provider: null, tts_provider: null }]
   }
 
   const { partials } = transcriptBuffer
-
-  const toggleLatencyDisplay = useCallback(async () => {
-    const next = !showLatency
-    setShowLatency(next)
-    await setSetting('show_latency', next ? 'true' : 'false')
-  }, [showLatency])
 
   return (
     <KeyboardAvoidingView
@@ -848,9 +859,6 @@ export default function ChatScreen() {
         options={{
           headerRight: () => (
             <View className="mr-2 flex-row items-center">
-              <Pressable testID="latency-toggle-button" onPress={toggleLatencyDisplay} className="p-2">
-                <TimerIcon size={20} color={showLatency ? '#f59e0b' : (colorScheme === 'dark' ? '#666' : '#999')} />
-              </Pressable>
               <Pressable testID="new-conversation-button" onPress={startNewConversation} className="p-2">
                 <PlusIcon size={22} color={colorScheme === 'dark' ? '#fff' : '#000'} />
               </Pressable>

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -3,14 +3,14 @@ import { Card } from '@/components/ui/card'
 import { Icon } from '@/components/ui/icon'
 import { Input } from '@/components/ui/input'
 import { Text } from '@/components/ui/text'
-import { getSetting, setSetting, getLatencyAverages, clearLatencyData, type LatencyAverages } from '@/db'
+import { getSetting, setSetting, getLatencyAverages, type LatencyAverages } from '@/db'
 import { runPipelineTests, type TestResult } from '@/lib/pipeline-test-runner'
 import { useAutoSave, type SaveStatus } from '@/lib/use-auto-save'
 import { validateApiKey, type Provider, type ValidationStatus } from '@/lib/validate-api-key'
 import ExpoCustomPipelineModule from '@/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule'
-import { AlertCircleIcon, CheckIcon, EyeIcon, EyeOffIcon, PlayIcon, RefreshCwIcon, Trash2Icon } from 'lucide-react-native'
+import { AlertCircleIcon, CheckIcon, EyeIcon, EyeOffIcon, PlayIcon, RefreshCwIcon } from 'lucide-react-native'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { ActivityIndicator, Alert, Animated, KeyboardAvoidingView, Platform, Pressable, ScrollView, Switch, TextInput, View } from 'react-native'
+import { ActivityIndicator, Animated, KeyboardAvoidingView, Platform, Pressable, ScrollView, Switch, TextInput, View } from 'react-native'
 
 type VoiceMode = 'vapi' | 'custom'
 type STTProviderValue = 'apple' | 'deepgram'
@@ -38,6 +38,9 @@ export default function SettingsScreen() {
 
   // Debug mode
   const [debugMode, setDebugMode] = useState(false)
+
+  // Show latency
+  const [showLatency, setShowLatencyState] = useState(false)
 
   // Kokoro model download state
   const [kokoroStatus, setKokoroStatus] = useState<'checking' | 'ready' | 'not-downloaded' | 'downloading' | 'error' | 'unavailable'>('checking')
@@ -152,6 +155,8 @@ export default function SettingsScreen() {
       }
       const dm = await getSetting('debug_mode')
       if (dm === 'true') setDebugMode(true)
+      const sl = await getSetting('show_latency')
+      if (sl === 'true') setShowLatencyState(true)
 
       loadedRef.current = true
     })()
@@ -255,6 +260,11 @@ export default function SettingsScreen() {
   const toggleDebugMode = useCallback((v: boolean) => {
     setDebugMode(v)
     setSetting('debug_mode', v ? 'true' : 'false')
+  }, [])
+
+  const toggleShowLatency = useCallback((v: boolean) => {
+    setShowLatencyState(v)
+    setSetting('show_latency', v ? 'true' : 'false')
   }, [])
 
   return (
@@ -472,6 +482,22 @@ export default function SettingsScreen() {
           </View>
         </Card>
 
+        <Card testID="show-latency-card" className="gap-2 p-4">
+          <View className="flex-row items-center justify-between">
+            <View className="flex-1">
+              <Text className="text-lg font-semibold text-foreground">Show Latency</Text>
+              <Text className="text-sm text-muted-foreground">
+                Display STT, LLM, and TTS latency badges on chat messages
+              </Text>
+            </View>
+            <Switch
+              testID="show-latency-toggle"
+              value={showLatency}
+              onValueChange={toggleShowLatency}
+            />
+          </View>
+        </Card>
+
         <Card testID="pipeline-test-card" className="gap-4 p-4">
           <Text className="text-lg font-semibold text-foreground">Pipeline Tests</Text>
           <Button
@@ -516,35 +542,9 @@ export default function SettingsScreen() {
         <Card testID="latency-stats-card" className="gap-4 p-4">
           <View className="flex-row items-center justify-between">
             <Text className="text-lg font-semibold text-foreground">Latency Stats</Text>
-            <View className="flex-row items-center gap-2">
-              <Pressable onPress={loadLatencyStats} className="p-2" disabled={loadingStats}>
-                <Icon as={RefreshCwIcon} size={18} className="text-muted-foreground" />
-              </Pressable>
-              {latencyStats && latencyStats.turnCount > 0 && (
-                <Pressable
-                  onPress={() => {
-                    Alert.alert(
-                      'Clear Latency Data',
-                      'This will remove all latency measurements from messages. The messages themselves will not be deleted.',
-                      [
-                        { text: 'Cancel', style: 'cancel' },
-                        {
-                          text: 'Clear',
-                          style: 'destructive',
-                          onPress: async () => {
-                            await clearLatencyData()
-                            await loadLatencyStats()
-                          },
-                        },
-                      ]
-                    )
-                  }}
-                  className="p-2"
-                >
-                  <Icon as={Trash2Icon} size={18} className="text-destructive" />
-                </Pressable>
-              )}
-            </View>
+            <Pressable onPress={loadLatencyStats} className="p-2" disabled={loadingStats}>
+              <Icon as={RefreshCwIcon} size={18} className="text-muted-foreground" />
+            </Pressable>
           </View>
           {loadingStats ? (
             <ActivityIndicator size="small" color="#888" />

--- a/db/index.ts
+++ b/db/index.ts
@@ -14,5 +14,5 @@ export { getSummary, saveSummary, deleteSummaries } from './summaries'
 export { runMigrations } from './migrations'
 
 export type { Conversation, ConversationWithPreview } from './conversations'
-export type { Message, LatencyData, LatencyAverages } from './messages'
+export type { Message, LatencyData, LatencyAverages, ProviderInfo } from './messages'
 export type { ConversationSummary } from './summaries'

--- a/db/messages.ts
+++ b/db/messages.ts
@@ -9,12 +9,21 @@ export type Message = {
   stt_latency_ms: number | null
   llm_latency_ms: number | null
   tts_latency_ms: number | null
+  stt_provider: string | null
+  llm_provider: string | null
+  tts_provider: string | null
 }
 
 export type LatencyData = {
   sttLatencyMs?: number
   llmLatencyMs?: number
   ttsLatencyMs?: number
+}
+
+export type ProviderInfo = {
+  sttProvider?: string
+  llmProvider?: string
+  ttsProvider?: string
 }
 
 export type LatencyAverages = {
@@ -37,16 +46,20 @@ export async function addMessage(
   conversationId: number,
   role: 'user' | 'assistant',
   content: string,
-  latency?: LatencyData
+  latency?: LatencyData,
+  providers?: ProviderInfo
 ): Promise<Message> {
   const now = Date.now()
   const stt = latency?.sttLatencyMs ?? null
   const llm = latency?.llmLatencyMs ?? null
   const tts = latency?.ttsLatencyMs ?? null
+  const sttProv = providers?.sttProvider ?? null
+  const llmProv = providers?.llmProvider ?? null
+  const ttsProv = providers?.ttsProvider ?? null
 
   const result = await db.runAsync(
-    'INSERT INTO messages (conversation_id, role, content, created_at, stt_latency_ms, llm_latency_ms, tts_latency_ms) VALUES (?, ?, ?, ?, ?, ?, ?)',
-    [conversationId, role, content, now, stt, llm, tts]
+    'INSERT INTO messages (conversation_id, role, content, created_at, stt_latency_ms, llm_latency_ms, tts_latency_ms, stt_provider, llm_provider, tts_provider) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+    [conversationId, role, content, now, stt, llm, tts, sttProv, llmProv, ttsProv]
   )
 
   await db.runAsync('UPDATE conversations SET updated_at = ? WHERE id = ?', [now, conversationId])
@@ -60,6 +73,9 @@ export async function addMessage(
     stt_latency_ms: stt,
     llm_latency_ms: llm,
     tts_latency_ms: tts,
+    stt_provider: sttProv,
+    llm_provider: llmProv,
+    tts_provider: ttsProv,
   }
 }
 

--- a/db/migrations.ts
+++ b/db/migrations.ts
@@ -5,6 +5,7 @@ export async function runMigrations() {
   await db.execAsync(CREATE_TABLES)
   await addVapiColumns()
   await addLatencyColumns()
+  await addProviderColumns()
 }
 
 // --- Migration Helpers ---
@@ -14,6 +15,17 @@ async function addLatencyColumns() {
   for (const col of columns) {
     try {
       await db.execAsync(`ALTER TABLE messages ADD COLUMN ${col} REAL`)
+    } catch {
+      // Column already exists
+    }
+  }
+}
+
+async function addProviderColumns() {
+  const columns = ['stt_provider', 'llm_provider', 'tts_provider']
+  for (const col of columns) {
+    try {
+      await db.execAsync(`ALTER TABLE messages ADD COLUMN ${col} TEXT`)
     } catch {
       // Column already exists
     }

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -19,7 +19,10 @@ export const CREATE_TABLES = `
     created_at INTEGER NOT NULL,
     stt_latency_ms REAL,
     llm_latency_ms REAL,
-    tts_latency_ms REAL
+    tts_latency_ms REAL,
+    stt_provider TEXT,
+    llm_provider TEXT,
+    tts_provider TEXT
   );
 
   CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id);

--- a/lib/use-pipeline.ts
+++ b/lib/use-pipeline.ts
@@ -172,6 +172,14 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
             console.log('[Pipeline] LLM onDone — pendingTTS:', pendingTTSCountRef.current, 'isActive:', isActiveRef.current)
             if (!isActiveRef.current) return
             callbacksRef.current.onLLMComplete?.(text)
+            // Emit latency with STT+LLM data BEFORE onAssistantResponse
+            // so the message is saved with latency attached. TTS latency
+            // may still be zero here; a second update fires when TTS completes.
+            callbacksRef.current.onLatencyUpdate?.({
+              sttLatencyMs: sttLatencyMsRef.current,
+              llmLatencyMs: llmLatencyMsRef.current,
+              ttsLatencyMs: ttsLatencyMsRef.current,
+            })
             callbacksRef.current.onAssistantResponse?.(text)
             isStreamCompleteRef.current = true
             flushSentenceBuffer()


### PR DESCRIPTION
## Summary
- **Latency on every assistant response**: Emit latency data (STT + LLM timing) before `onAssistantResponse` fires, ensuring the first turn's message is saved with latency attached. A second update still fires when TTS completes.
- **Move latency toggle to Settings**: Removed the timer icon from the chat header. Added a "Show Latency" toggle in Settings (matching Debug Mode toggle pattern). The `show_latency` setting key is preserved.
- **Remove trash icon from Latency Stats**: Removed the delete/clear button and Alert confirmation. Stats now accumulate without user-initiated clearing.
- **Store provider settings per message**: Added `stt_provider`, `llm_provider`, `tts_provider` TEXT columns to the messages table with a migration for existing DBs. `addMessage()` accepts optional `ProviderInfo`, and both Custom Pipeline and Vapi call paths set `activeProvidersRef` at call start.

## Test plan
- [ ] Start a Custom Pipeline call, speak one turn, verify the assistant message has latency badges (STT, LLM, and/or TTS) visible when Show Latency is enabled in Settings
- [ ] Verify the first turn of a new call shows latency data (not just subsequent turns)
- [ ] Open Settings, toggle "Show Latency" on/off, return to Chat, confirm badges appear/disappear
- [ ] Confirm the timer icon is no longer in the chat header
- [ ] Open Settings > Latency Stats, confirm the trash icon is gone and only the refresh icon remains
- [ ] After a call, inspect the SQLite DB to verify `stt_provider`, `llm_provider`, `tts_provider` columns are populated on messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)