### PR TITLE
Add x-openclaw-session-key header for warm sessions (NAN-597)

### DIFF
--- a/lib/chat.ts
+++ b/lib/chat.ts
@@ -39,17 +39,19 @@ async function fetchCompletionFallback(
   apiUrl: string,
   conversationId: number
 ): Promise<string> {
+  const sessionKey = `voiceclaw:${conversationId}`
   const response = await fetch(apiUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${apiKey}`,
+      'x-openclaw-session-key': sessionKey,
     },
     body: JSON.stringify({
       model,
       messages: chatMessages,
       stream: false,
-      user: `voiceclaw:${conversationId}`,
+      user: sessionKey,
     }),
   })
 
@@ -84,13 +86,15 @@ export function streamCompletion(
     ...messages,
   ]
 
+  const sessionKey = `voiceclaw:${conversationId}`
   const es = new EventSource(apiUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${apiKey}`,
+      'x-openclaw-session-key': sessionKey,
     },
-    body: JSON.stringify({ model, messages: chatMessages, stream: true, user: `voiceclaw:${conversationId}` }),
+    body: JSON.stringify({ model, messages: chatMessages, stream: true, user: sessionKey }),
     pollingInterval: 0,
     timeoutBeforeConnection: 0,
   })


### PR DESCRIPTION
## Summary
- Adds `x-openclaw-session-key` header to all LLM API requests in `lib/chat.ts` (both `streamCompletion` and `fetchCompletionFallback`)
- The header value is `voiceclaw:${conversationId}`, matching the existing `user` field in the request body
- This allows the OpenClaw API to reuse warm sessions for voice mode calls, eliminating cold session creation on every turn

## Context
Both chat mode and voice mode go through `streamCompletion` in `lib/chat.ts`, and both already pass a valid `conversationId`. The missing piece was the `x-openclaw-session-key` HTTP header that tells the OpenClaw API to reuse an existing warm session rather than spinning up a new cold one.

## Test plan
- [ ] Verify chat mode still works correctly (text input sends messages, receives streamed responses)
- [ ] Verify voice mode (custom pipeline) works correctly with warm session reuse
- [ ] Check network requests to confirm `x-openclaw-session-key` header is present on LLM API calls
- [ ] Confirm voice mode latency improves due to warm session reuse

🤖 Generated with [Claude Code](https://claude.com/claude-code)