### PR TITLE
Refactor voice pipeline to hybrid TS + Swift AudioCoordinator (NAN-599)

### DIFF
--- a/lib/pipeline-test-runner.ts
+++ b/lib/pipeline-test-runner.ts
@@ -61,7 +61,7 @@ export async function runPipelineTests(
   // Cleanup
   ExpoCustomPipelineModule.stopListening()
   ExpoCustomPipelineModule.stopSpeaking()
-  ExpoCustomPipelineModule.stopBargeInDetection()
+  ExpoCustomPipelineModule.setBargeInEnabled(false)
 
   return results
 }

--- a/lib/use-pipeline.ts
+++ b/lib/use-pipeline.ts
@@ -42,20 +42,19 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
   const sentenceBufferRef = useRef('')
   const stopCompletionRef = useRef<(() => void) | null>(null)
   const isActiveRef = useRef(false)
-  const bargeInActiveRef = useRef(false)
   const activeTurnIdRef = useRef(0)
 
-  // ── Latency tracking ──────────────────────────────────────────────
+  // -- Latency tracking --------------------------------------------------
   //
-  // STT latency:  time from startListening() call → onFinalTranscript event
-  //               (mic opens → user utterance fully recognised)
+  // STT latency:  time from startListening() call -> onFinalTranscript event
+  //               (mic opens -> user utterance fully recognised)
   //
-  // LLM latency:  time from API request sent → first streamed token received
+  // LLM latency:  time from API request sent -> first streamed token received
   //               (network + model time-to-first-token)
   //
-  // TTS latency:  time from speak() call → onTTSStart event
-  //               (synthesis request → first audio begins playing)
-  // ────────────────────────────────────────────────────────────────────
+  // TTS latency:  time from speak() call -> onTTSStart event
+  //               (synthesis request -> first audio begins playing)
+  // --------------------------------------------------------------------
   const listenStartTimeRef = useRef<number | null>(null)
   const firstTokenTimeRef = useRef<number | null>(null)
   const speakStartTimesRef = useRef<number[]>([])
@@ -67,13 +66,13 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
   callbacksRef.current = callbacks
 
   const restartSTTIfReady = useCallback(() => {
-    console.log('[Pipeline] restartSTTIfReady called — isActive:', isActiveRef.current, 'isStreamComplete:', isStreamCompleteRef.current, 'pendingTTS:', pendingTTSCountRef.current)
+    console.log('[Pipeline] restartSTTIfReady called -- isActive:', isActiveRef.current, 'isStreamComplete:', isStreamCompleteRef.current, 'pendingTTS:', pendingTTSCountRef.current)
     if (!isActiveRef.current) { console.log('[Pipeline] restartSTT BLOCKED: not active'); return }
     if (!isStreamCompleteRef.current) { console.log('[Pipeline] restartSTT BLOCKED: stream not complete'); return }
 
     if (pendingTTSCountRef.current > 0) { console.log('[Pipeline] restartSTT BLOCKED: pending TTS:', pendingTTSCountRef.current); return }
 
-    console.log('[Pipeline] restartSTT — ALL CONDITIONS MET, restarting STT')
+    console.log('[Pipeline] restartSTT -- ALL CONDITIONS MET, restarting STT')
     isStreamCompleteRef.current = false
     sentenceBufferRef.current = ''
     callbacksRef.current.onLatencyUpdate?.({
@@ -169,7 +168,7 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
           },
           onDone: (text) => {
             if (turnId !== activeTurnIdRef.current) return
-            console.log('[Pipeline] LLM onDone — pendingTTS:', pendingTTSCountRef.current, 'isActive:', isActiveRef.current)
+            console.log('[Pipeline] LLM onDone -- pendingTTS:', pendingTTSCountRef.current, 'isActive:', isActiveRef.current)
             if (!isActiveRef.current) return
             callbacksRef.current.onLLMComplete?.(text)
             // Emit latency with STT+LLM data BEFORE onAssistantResponse
@@ -183,7 +182,7 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
             callbacksRef.current.onAssistantResponse?.(text)
             isStreamCompleteRef.current = true
             flushSentenceBuffer()
-            console.log('[Pipeline] After flushSentenceBuffer — pendingTTS:', pendingTTSCountRef.current)
+            console.log('[Pipeline] After flushSentenceBuffer -- pendingTTS:', pendingTTSCountRef.current)
             restartSTTIfReady()
           },
           onError: (error) => {
@@ -201,7 +200,7 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
   }, [trySpeakCompleteSentences, flushSentenceBuffer, restartSTTIfReady])
 
   const startListening = useCallback(() => {
-    console.log('[Pipeline] startListening called — isActive:', isActiveRef.current)
+    console.log('[Pipeline] startListening called -- isActive:', isActiveRef.current)
     if (!isActiveRef.current) { console.log('[Pipeline] startListening BLOCKED: not active'); return }
 
     // Reset latency accumulators for the new turn
@@ -249,15 +248,12 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
           ExpoCustomPipelineModule.stopListening()
 
           // Barge-in: cancel any in-progress LLM stream and TTS playback
-          console.log('[Pipeline] onFinalTranscript — cancelling pending LLM/TTS for barge-in')
+          console.log('[Pipeline] onFinalTranscript -- cancelling pending LLM/TTS for barge-in')
           activeTurnIdRef.current += 1
           stopCompletionRef.current?.()
           stopCompletionRef.current = null
           ExpoCustomPipelineModule.stopSpeaking()
-          if (bargeInActiveRef.current) {
-            bargeInActiveRef.current = false
-            ExpoCustomPipelineModule.stopBargeInDetection()
-          }
+          ExpoCustomPipelineModule.setBargeInEnabled(false)
           pendingTTSCountRef.current = 0
           sentenceBufferRef.current = ''
           speakStartTimesRef.current = []
@@ -272,23 +268,17 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
         if (speakTime != null) {
           ttsLatencyMsRef.current = Date.now() - speakTime
         }
-        // Start VAD once per response (not per sentence)
-        if (!bargeInActiveRef.current) {
-          bargeInActiveRef.current = true
-          ExpoCustomPipelineModule.startBargeInDetection()
-        }
+        // Enable barge-in for this response (native handles VAD start/stop)
+        ExpoCustomPipelineModule.setBargeInEnabled(true)
         callbacksRef.current.onTTSStart?.()
       }),
       ExpoCustomPipelineModule.addListener('onTTSComplete', () => {
         pendingTTSCountRef.current = Math.max(0, pendingTTSCountRef.current - 1)
-        console.log('[Pipeline] onTTSComplete — pendingTTS now:', pendingTTSCountRef.current, 'isStreamComplete:', isStreamCompleteRef.current)
+        console.log('[Pipeline] onTTSComplete -- pendingTTS now:', pendingTTSCountRef.current, 'isStreamComplete:', isStreamCompleteRef.current)
         callbacksRef.current.onTTSComplete?.()
         if (pendingTTSCountRef.current === 0) {
-          // Stop VAD when all TTS finished — STT will take over
-          if (bargeInActiveRef.current) {
-            bargeInActiveRef.current = false
-            ExpoCustomPipelineModule.stopBargeInDetection()
-          }
+          // Disable barge-in when all TTS finished -- STT will take over
+          ExpoCustomPipelineModule.setBargeInEnabled(false)
           if (isStreamCompleteRef.current) {
             callbacksRef.current.onLatencyUpdate?.({
               sttLatencyMs: sttLatencyMsRef.current,
@@ -300,24 +290,27 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
         restartSTTIfReady()
       }),
       ExpoCustomPipelineModule.addListener('onBargeIn', () => {
-        console.log('[Pipeline] onBargeIn — user voice detected, interrupting')
-        bargeInActiveRef.current = false
-        ExpoCustomPipelineModule.stopBargeInDetection()
-        // Cancel in-progress LLM and TTS
+        // Native AudioCoordinator already: stopped TTS, stopped VAD, started STT.
+        // JS only needs to cancel the in-progress LLM stream and reset state.
+        console.log('[Pipeline] onBargeIn -- user voice detected, native handled audio swap')
         activeTurnIdRef.current += 1
         stopCompletionRef.current?.()
         stopCompletionRef.current = null
-        ExpoCustomPipelineModule.stopSpeaking()
         pendingTTSCountRef.current = 0
         sentenceBufferRef.current = ''
         speakStartTimesRef.current = []
         isStreamCompleteRef.current = false
-        // Start listening for the user's speech
-        startListening()
+
+        // Reset STT latency tracking since native already started listening
+        firstTokenTimeRef.current = null
+        sttLatencyMsRef.current = 0
+        llmLatencyMsRef.current = 0
+        ttsLatencyMsRef.current = 0
+        listenStartTimeRef.current = Date.now()
       }),
       ExpoCustomPipelineModule.addListener('onError', (event) => {
         pendingTTSCountRef.current = Math.max(0, pendingTTSCountRef.current - 1)
-        console.log('[Pipeline] onError:', event.message, '— pendingTTS now:', pendingTTSCountRef.current)
+        console.log('[Pipeline] onError:', event.message, '-- pendingTTS now:', pendingTTSCountRef.current)
         callbacksRef.current.onError?.(event.message)
         restartSTTIfReady()
       }),
@@ -335,8 +328,7 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
     stopCompletionRef.current = null
     ExpoCustomPipelineModule.stopListening()
     ExpoCustomPipelineModule.stopSpeaking()
-    bargeInActiveRef.current = false
-    ExpoCustomPipelineModule.stopBargeInDetection()
+    ExpoCustomPipelineModule.setBargeInEnabled(false)
     subsRef.current.forEach((s) => s.remove())
     subsRef.current = []
     pendingTTSCountRef.current = 0
@@ -347,8 +339,8 @@ export function usePipeline(callbacks: PipelineCallbacks): PipelineControls {
 
   const interrupt = useCallback(() => {
     if (!isActiveRef.current) return
-    console.log('[Pipeline] interrupt — user tapped to interrupt')
-    ExpoCustomPipelineModule.stopBargeInDetection()
+    console.log('[Pipeline] interrupt -- user tapped to interrupt')
+    ExpoCustomPipelineModule.setBargeInEnabled(false)
     activeTurnIdRef.current += 1
     stopCompletionRef.current?.()
     stopCompletionRef.current = null

--- a/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
+++ b/modules/expo-custom-pipeline/ios/ExpoCustomPipelineModule.swift
@@ -1,11 +1,9 @@
 import ExpoModulesCore
 
 public class ExpoCustomPipelineModule: Module {
-    private var sttProvider: STTProvider?
-    private var ttsProvider: TTSProvider?
+    private let coordinator = AudioCoordinator()
     private var sttProviderName: String = ""
     private var ttsProviderName: String = ""
-    private let bargeInDetector = BargeInDetector()
 
     public func definition() -> ModuleDefinition {
         Name("ExpoCustomPipeline")
@@ -19,67 +17,45 @@ public class ExpoCustomPipelineModule: Module {
             "onBargeIn"
         )
 
+        OnCreate {
+            self.coordinator.delegate = self
+        }
+
         Function("setSTTProvider") { (name: String, config: [String: String]?) in
             self.sttProviderName = name
             print("[ExpoCustomPipeline] STT provider set to: \(name)")
-            self.sttProvider = makeSTTProvider(name: name, config: config)
+            self.coordinator.setSTTProvider(makeSTTProvider(name: name, config: config))
         }
 
         Function("setTTSProvider") { (name: String, config: [String: String]?) in
             self.ttsProviderName = name
             let configKeys = config?.keys.joined(separator: ", ") ?? "nil"
             print("[ExpoCustomPipeline] TTS provider set to: \(name), config keys: \(configKeys)")
-            self.ttsProvider = makeTTSProvider(name: name, config: config)
+            self.coordinator.setTTSProvider(makeTTSProvider(name: name, config: config))
         }
 
         Function("startListening") { () in
-            self.sttProvider?.startListening(
-                onPartialResult: { [weak self] text in
-                    self?.sendEvent("onPartialTranscript", ["text": text])
-                },
-                onFinalResult: { [weak self] text in
-                    self?.sendEvent("onFinalTranscript", ["text": text])
-                }
-            )
+            self.coordinator.startListening()
         }
 
         Function("stopListening") { () in
-            self.sttProvider?.stopListening()
+            self.coordinator.stopListening()
         }
 
         Function("speak") { (text: String) in
-            self.ttsProvider?.speak(
-                text: text,
-                onStart: { [weak self] in
-                    self?.sendEvent("onTTSStart", [:])
-                },
-                onComplete: { [weak self] in
-                    self?.sendEvent("onTTSComplete", [:])
-                },
-                onError: { [weak self] message in
-                    self?.sendEvent("onError", ["message": message])
-                }
-            )
+            self.coordinator.speak(text: text)
         }
 
         Function("stopSpeaking") { () in
-            self.ttsProvider?.stop()
+            self.coordinator.stopSpeaking()
         }
 
-        Function("startBargeInDetection") { () in
-            self.bargeInDetector.startMonitoring { [weak self] in
-                self?.sendEvent("onBargeIn", [:])
-            }
-        }
-
-        Function("stopBargeInDetection") { () in
-            self.bargeInDetector.stopMonitoring()
+        Function("setBargeInEnabled") { (enabled: Bool) in
+            self.coordinator.setBargeInEnabled(enabled)
         }
 
         Function("simulateFinalTranscript") { (text: String) in
-            print("[ExpoCustomPipeline] simulateFinalTranscript: \(text.prefix(50))")
-            self.sttProvider?.stopListening()
-            self.sendEvent("onFinalTranscript", ["text": text])
+            self.coordinator.simulateFinalTranscript(text)
         }
 
         Function("isKokoroModelReady") { () -> Bool in
@@ -117,6 +93,34 @@ public class ExpoCustomPipelineModule: Module {
                 userInfo: [NSLocalizedDescriptionKey: "Kokoro TTS is not available in this build. The KokoroSwift package needs to be added to the project."]))
             #endif
         }
+    }
+}
+
+// MARK: - AudioCoordinatorDelegate
+
+extension ExpoCustomPipelineModule: AudioCoordinatorDelegate {
+    func audioCoordinatorDidReceivePartialTranscript(_ text: String) {
+        sendEvent("onPartialTranscript", ["text": text])
+    }
+
+    func audioCoordinatorDidReceiveFinalTranscript(_ text: String) {
+        sendEvent("onFinalTranscript", ["text": text])
+    }
+
+    func audioCoordinatorDidStartTTS() {
+        sendEvent("onTTSStart", [:])
+    }
+
+    func audioCoordinatorDidCompleteTTS() {
+        sendEvent("onTTSComplete", [:])
+    }
+
+    func audioCoordinatorDidError(_ message: String) {
+        sendEvent("onError", ["message": message])
+    }
+
+    func audioCoordinatorDidBargeIn() {
+        sendEvent("onBargeIn", [:])
     }
 }
 

--- a/modules/expo-custom-pipeline/ios/Pipeline/AudioCoordinator.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/AudioCoordinator.swift
@@ -75,10 +75,6 @@ class AudioCoordinator {
             onStart: { [weak self] in
                 guard let self = self else { return }
                 self.delegate?.audioCoordinatorDidStartTTS()
-                // Auto-start VAD when TTS begins (if barge-in is enabled)
-                if self.bargeInEnabled {
-                    self.startBargeInMonitoring()
-                }
             },
             onComplete: { [weak self] in
                 self?.delegate?.audioCoordinatorDidCompleteTTS()
@@ -97,7 +93,10 @@ class AudioCoordinator {
 
     func setBargeInEnabled(_ enabled: Bool) {
         bargeInEnabled = enabled
-        if !enabled {
+        if enabled {
+            // Start monitoring immediately if TTS is already playing
+            startBargeInMonitoring()
+        } else {
             bargeInDetector.stopMonitoring()
         }
         print("[AudioCoordinator] bargeInEnabled = \(enabled)")

--- a/modules/expo-custom-pipeline/ios/Pipeline/AudioCoordinator.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/AudioCoordinator.swift
@@ -1,0 +1,142 @@
+import AVFoundation
+
+/// Callback interface for AudioCoordinator events sent back to the Expo module.
+protocol AudioCoordinatorDelegate: AnyObject {
+    func audioCoordinatorDidReceivePartialTranscript(_ text: String)
+    func audioCoordinatorDidReceiveFinalTranscript(_ text: String)
+    func audioCoordinatorDidStartTTS()
+    func audioCoordinatorDidCompleteTTS()
+    func audioCoordinatorDidError(_ message: String)
+    func audioCoordinatorDidBargeIn()
+}
+
+/// Owns the full audio lifecycle: STT, TTS, VAD/barge-in detection.
+///
+/// When barge-in fires the coordinator atomically stops TTS, stops VAD,
+/// starts STT, and emits `onBargeIn` -- no JS bridge round trip required.
+class AudioCoordinator {
+    weak var delegate: AudioCoordinatorDelegate?
+
+    private(set) var sttProvider: STTProvider?
+    private(set) var ttsProvider: TTSProvider?
+    private let bargeInDetector = BargeInDetector()
+    private var bargeInEnabled = false
+
+    // MARK: - Provider setup
+
+    func setSTTProvider(_ provider: STTProvider?) {
+        sttProvider = provider
+    }
+
+    func setTTSProvider(_ provider: TTSProvider?) {
+        ttsProvider = provider
+    }
+
+    // MARK: - Audio session
+
+    func configureAudioSession() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(
+                .playAndRecord,
+                mode: .voiceChat,
+                options: [.defaultToSpeaker, .allowBluetooth]
+            )
+            try session.setActive(true, options: .notifyOthersOnDeactivation)
+            print("[AudioCoordinator] Audio session configured (voiceChat mode)")
+        } catch {
+            print("[AudioCoordinator] Failed to configure audio session: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - STT
+
+    func startListening() {
+        configureAudioSession()
+        sttProvider?.startListening(
+            onPartialResult: { [weak self] text in
+                self?.delegate?.audioCoordinatorDidReceivePartialTranscript(text)
+            },
+            onFinalResult: { [weak self] text in
+                self?.delegate?.audioCoordinatorDidReceiveFinalTranscript(text)
+            }
+        )
+    }
+
+    func stopListening() {
+        sttProvider?.stopListening()
+    }
+
+    // MARK: - TTS
+
+    func speak(text: String) {
+        ttsProvider?.speak(
+            text: text,
+            onStart: { [weak self] in
+                guard let self = self else { return }
+                self.delegate?.audioCoordinatorDidStartTTS()
+                // Auto-start VAD when TTS begins (if barge-in is enabled)
+                if self.bargeInEnabled {
+                    self.startBargeInMonitoring()
+                }
+            },
+            onComplete: { [weak self] in
+                self?.delegate?.audioCoordinatorDidCompleteTTS()
+            },
+            onError: { [weak self] message in
+                self?.delegate?.audioCoordinatorDidError(message)
+            }
+        )
+    }
+
+    func stopSpeaking() {
+        ttsProvider?.stop()
+    }
+
+    // MARK: - Barge-in
+
+    func setBargeInEnabled(_ enabled: Bool) {
+        bargeInEnabled = enabled
+        if !enabled {
+            bargeInDetector.stopMonitoring()
+        }
+        print("[AudioCoordinator] bargeInEnabled = \(enabled)")
+    }
+
+    // MARK: - Simulate (testing support)
+
+    func simulateFinalTranscript(_ text: String) {
+        print("[AudioCoordinator] simulateFinalTranscript: \(text.prefix(50))")
+        sttProvider?.stopListening()
+        delegate?.audioCoordinatorDidReceiveFinalTranscript(text)
+    }
+}
+
+// MARK: - Helpers
+
+private extension AudioCoordinator {
+    func startBargeInMonitoring() {
+        bargeInDetector.startMonitoring { [weak self] in
+            guard let self = self else { return }
+            self.handleBargeIn()
+        }
+    }
+
+    /// Atomic barge-in: stop TTS -> stop VAD -> start STT -> emit event.
+    /// All happens on the main thread with no bridge round trip.
+    func handleBargeIn() {
+        print("[AudioCoordinator] Barge-in detected — atomic: stopTTS -> stopVAD -> startSTT -> emit")
+
+        // 1. Stop TTS playback immediately
+        ttsProvider?.stop()
+
+        // 2. Stop VAD monitoring (detector already stopped itself, but be safe)
+        bargeInDetector.stopMonitoring()
+
+        // 3. Start STT to capture the user's speech
+        startListening()
+
+        // 4. Notify JS so it can cancel LLM stream and update UI
+        delegate?.audioCoordinatorDidBargeIn()
+    }
+}

--- a/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule.ts
+++ b/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule.ts
@@ -9,8 +9,7 @@ declare class ExpoCustomPipelineModule extends NativeModule<ExpoCustomPipelineMo
   stopListening(): void
   speak(text: string): void
   stopSpeaking(): void
-  startBargeInDetection(): void
-  stopBargeInDetection(): void
+  setBargeInEnabled(enabled: boolean): void
   simulateFinalTranscript(text: string): void
   isKokoroAvailable(): boolean
   isKokoroModelReady(): boolean


### PR DESCRIPTION
## Summary
- New `AudioCoordinator` in Swift owns STT, TTS, and VAD lifecycle
- Barge-in is atomic on the native side: detect voice → stop TTS → start STT with no JS bridge round trip
- `ExpoCustomPipelineModule` delegates to AudioCoordinator instead of calling providers directly
- Replaces `startBargeInDetection/stopBargeInDetection` with single `setBargeInEnabled(bool)` 
- TS side simplified: removed `bargeInActiveRef`, `onBargeIn` handler just cancels LLM stream

## Test plan
- [ ] Single turn: speak → assistant responds → TTS plays → STT restarts
- [ ] Multi-turn: sequential turns work
- [ ] Barge-in: speak during TTS → TTS stops, STT restarts atomically
- [ ] Tap-to-interrupt: mic button stops TTS and starts listening

🤖 Generated with [Claude Code](https://claude.com/claude-code)