### PR TITLE
Update stale device UI tests for current settings flow

### DIFF
--- a/uitests/SmokeTests.swift
+++ b/uitests/SmokeTests.swift
@@ -8,7 +8,8 @@ final class SmokeTests: VoiceClawUITests {
 
   func testAppLaunches() throws {
     // The base class setUp already launches the app.
-    // Just verify the app is running by checking for the chat screen.
+    // Current app state may restore a different tab, so force Chat first.
+    ensureOnChatScreen()
     assertExists(testID: "chat-screen")
     takeScreenshot(name: "app-launched")
   }
@@ -16,6 +17,7 @@ final class SmokeTests: VoiceClawUITests {
   // MARK: - Chat Screen Elements
 
   func testChatScreenHasInputBar() throws {
+    ensureOnChatScreen()
     assertExists(testID: "input-bar")
     assertExists(testID: "chat-input")
     assertExists(testID: "send-button")
@@ -23,10 +25,12 @@ final class SmokeTests: VoiceClawUITests {
   }
 
   func testChatScreenHasMessagesList() throws {
+    ensureOnChatScreen()
     assertExists(testID: "messages-list")
   }
 
   func testChatScreenHasNewConversationButton() throws {
+    ensureOnChatScreen()
     assertExists(testID: "new-conversation-button")
   }
 
@@ -62,6 +66,7 @@ final class SmokeTests: VoiceClawUITests {
   }
 
   func testVapiCallStartsAndEnds() throws {
+    enableVapiMode()
     tap(testID: "call-button")
     assertExists(testID: "call-controls", timeout: 30)
     assertExists(testID: "mute-button", timeout: 30)

--- a/uitests/VoiceClawUITests.swift
+++ b/uitests/VoiceClawUITests.swift
@@ -123,22 +123,49 @@ class VoiceClawUITests: XCTestCase {
 
   // MARK: - Pipeline Helpers
 
-  func enableCustomPipelineMode() {
-    navigateToTab("Settings")
-
-    let customPipeline = app.descendants(matching: .any)
-      .matching(NSPredicate(format: "label == %@", "Custom Pipeline"))
-      .firstMatch
-
-    XCTAssertTrue(
-      customPipeline.waitForExistence(timeout: 10),
-      "Custom Pipeline option not found"
-    )
-    customPipeline.tap()
-
+  func ensureOnChatScreen() {
     navigateToTab("Chat")
     assertExists(testID: "chat-screen")
+  }
+
+  func startFreshConversation() {
+    ensureOnChatScreen()
     tap(testID: "new-conversation-button")
+  }
+
+  func setDebugMode(_ enabled: Bool) {
+    navigateToTab("Settings")
+    assertExists(testID: "settings-screen")
+    let toggle = waitForElement(withTestID: "debug-mode-toggle", timeout: 10)
+    let isEnabled = String(describing: toggle.value) == "1"
+    if isEnabled != enabled {
+      toggle.tap()
+    }
+  }
+
+  func setVoiceMode(_ label: String) {
+    navigateToTab("Settings")
+    assertExists(testID: "settings-screen")
+    let option = app.descendants(matching: .any)
+      .matching(NSPredicate(format: "label == %@", label))
+      .firstMatch
+    XCTAssertTrue(
+      option.waitForExistence(timeout: 10),
+      "Voice mode option '\(label)' not found"
+    )
+    option.tap()
+  }
+
+  func enableCustomPipelineMode() {
+    setVoiceMode("Custom Pipeline")
+    setDebugMode(true)
+    startFreshConversation()
+  }
+
+  func enableVapiMode() {
+    setVoiceMode("Vapi All-in-One")
+    setDebugMode(false)
+    startFreshConversation()
   }
 
   func startCustomPipelineCall() {


### PR DESCRIPTION
## Summary
- make UITests explicitly drive the current Settings state they depend on
- force Chat before launch/chat assertions instead of assuming the restored tab
- switch the Vapi smoke test into Vapi mode before starting a call

## What changed
- add helpers to set `voice_mode`, `debug_mode`, and start a fresh conversation via the Settings/Chat UI
- use those helpers from the smoke and pipeline tests

## Verification
- `npx tsc --noEmit`
- test branch logic reviewed against current `main` Settings UI

## Blocked verification
- clean worktree `--prebuild` device verification is currently blocked by an unrelated iOS build issue in `expo-vapi`: `no such module 'Daily'` during native build
- this PR only updates stale UITest assumptions; it does not change app/runtime code