### PR TITLE
Add x-openclaw-scopes header to fix gateway auth

### DIFF
--- a/lib/chat.ts
+++ b/lib/chat.ts
@@ -49,6 +49,7 @@ async function fetchCompletionFallback(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${apiKey}`,
       'x-openclaw-session-key': sessionKey,
+      'x-openclaw-scopes': 'operator.read,operator.write',
     },
     body: JSON.stringify({
       model,
@@ -96,6 +97,7 @@ export function streamCompletion(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${apiKey}`,
       'x-openclaw-session-key': sessionKey,
+      'x-openclaw-scopes': 'operator.read,operator.write',
     },
     body: JSON.stringify({ model, messages: chatMessages, stream: true, user: sessionKey }),
     pollingInterval: 0,


### PR DESCRIPTION
## Summary
- Adds `x-openclaw-scopes: operator.read,operator.write` header to both streaming and non-streaming LLM request paths
- Fixes "missing scope: operator.write" forbidden error after gateway update

## Test plan
- [x] Verified on physical device — forbidden error gone, LLM responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)