### PR TITLE
Add auth headers to title generation API requests

### DIFF
--- a/lib/title.ts
+++ b/lib/title.ts
@@ -55,11 +55,14 @@ async function generateTitle(
     max_tokens: 30,
   }
 
+  const sessionKey = `voiceclaw:${messages.length > 0 ? 'titles' : '0'}`
   const response = await fetch(apiUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${apiKey}`,
+      'x-openclaw-session-key': sessionKey,
+      'x-openclaw-scopes': 'operator.read,operator.write',
     },
     body: JSON.stringify(body),
   })


### PR DESCRIPTION
## Summary
- Extends the gateway authentication fix from PR #45 to the title generation path
- Title generation was missing `x-openclaw-session-key` and `x-openclaw-scopes` headers
- Fixes 403 forbidden errors when auto-generating conversation titles

## Test plan
- [ ] Start a new conversation and send a few messages
- [ ] Verify that the conversation title auto-generates correctly (no 403 error in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)