### PR TITLE
Add prosodic context to TTS via previous_text

### DIFF
--- a/modules/expo-custom-pipeline/ios/Pipeline/AudioCoordinator.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/AudioCoordinator.swift
@@ -28,6 +28,8 @@ class AudioCoordinator {
     // TTS speak queue — ensures sentences play sequentially
     private var speakQueue: [String] = []
     private var isSpeakingCurrent = false
+    // Tracks recently spoken text so providers can use it for prosodic context
+    private var spokenHistory = ""
 
     // MARK: - Provider setup
 
@@ -83,6 +85,7 @@ class AudioCoordinator {
     func stopSpeaking() {
         speakQueue.removeAll()
         isSpeakingCurrent = false
+        spokenHistory = ""
         ttsProvider?.stop()
     }
 
@@ -113,10 +116,12 @@ private extension AudioCoordinator {
         guard !isSpeakingCurrent, !speakQueue.isEmpty else { return }
 
         let text = speakQueue.removeFirst()
+        let previousText = spokenHistory.isEmpty ? nil : spokenHistory
         isSpeakingCurrent = true
 
         ttsProvider?.speak(
             text: text,
+            previousText: previousText,
             onStart: { [weak self] in
                 guard let self = self else { return }
                 self.delegate?.audioCoordinatorDidStartTTS()
@@ -126,6 +131,7 @@ private extension AudioCoordinator {
             },
             onComplete: { [weak self] in
                 guard let self = self else { return }
+                self.spokenHistory += (self.spokenHistory.isEmpty ? "" : " ") + text
                 self.isSpeakingCurrent = false
                 self.delegate?.audioCoordinatorDidCompleteTTS()
                 self.speakNextIfIdle()
@@ -155,9 +161,10 @@ private extension AudioCoordinator {
     func handleBargeIn() {
         print("[AudioCoordinator] Barge-in — atomic: stopTTS -> stopVAD -> startSTT -> emit")
 
-        // 1. Clear queue and stop current playback
+        // 1. Clear queue, history, and stop current playback
         speakQueue.removeAll()
         isSpeakingCurrent = false
+        spokenHistory = ""
         ttsProvider?.stop()
 
         // 2. Stop VAD monitoring

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleTTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleTTSProvider.swift
@@ -27,7 +27,7 @@ class AppleTTSProvider: NSObject, TTSProvider {
 
     // MARK: - TTSProvider
 
-    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void, onError: @escaping (String) -> Void) {
+    func speak(text: String, previousText: String? = nil, onStart: @escaping () -> Void, onComplete: @escaping () -> Void, onError: @escaping (String) -> Void) {
         onStartCallback = onStart
         onCompleteCallback = onComplete
 

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/ElevenLabsTTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/ElevenLabsTTSProvider.swift
@@ -38,7 +38,7 @@ class ElevenLabsTTSProvider: NSObject, TTSProvider, URLSessionDataDelegate {
 
     // MARK: - TTSProvider
 
-    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void, onError: @escaping (String) -> Void) {
+    func speak(text: String, previousText: String? = nil, onStart: @escaping () -> Void, onComplete: @escaping () -> Void, onError: @escaping (String) -> Void) {
         logger.debug("[ElevenLabs] speak() called with text: \(text.prefix(50))")
         guard !apiKey.isEmpty else {
             logger.error("[ElevenLabs] API key not configured")
@@ -63,10 +63,13 @@ class ElevenLabsTTSProvider: NSObject, TTSProvider, URLSessionDataDelegate {
         request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        let body: [String: Any] = [
+        var body: [String: Any] = [
             "text": text,
             "model_id": modelId
         ]
+        if let previousText = previousText, !previousText.isEmpty {
+            body["previous_text"] = previousText
+        }
 
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/KokoroTTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/KokoroTTSProvider.swift
@@ -39,6 +39,7 @@ class KokoroTTSProvider: TTSProvider {
 
     func speak(
         text: String,
+        previousText: String? = nil,
         onStart: @escaping () -> Void,
         onComplete: @escaping () -> Void,
         onError: @escaping (String) -> Void
@@ -518,6 +519,7 @@ class KokoroTTSProvider: TTSProvider {
 
     func speak(
         text: String,
+        previousText: String? = nil,
         onStart: @escaping () -> Void,
         onComplete: @escaping () -> Void,
         onError: @escaping (String) -> Void

--- a/modules/expo-custom-pipeline/ios/Pipeline/Providers/OpenAITTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/Providers/OpenAITTSProvider.swift
@@ -35,7 +35,7 @@ class OpenAITTSProvider: NSObject, TTSProvider, URLSessionDataDelegate {
 
     // MARK: - TTSProvider
 
-    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void, onError: @escaping (String) -> Void) {
+    func speak(text: String, previousText: String? = nil, onStart: @escaping () -> Void, onComplete: @escaping () -> Void, onError: @escaping (String) -> Void) {
         guard !apiKey.isEmpty else {
             onError("OpenAI TTS: API key not configured")
             onComplete()

--- a/modules/expo-custom-pipeline/ios/Pipeline/TTSProvider.swift
+++ b/modules/expo-custom-pipeline/ios/Pipeline/TTSProvider.swift
@@ -4,6 +4,9 @@ protocol TTSProvider {
     var name: String { get }
     var isSpeaking: Bool { get }
     var latencyMs: Double { get }
-    func speak(text: String, onStart: @escaping () -> Void, onComplete: @escaping () -> Void, onError: @escaping (String) -> Void)
+    /// Synthesize and play `text`. `previousText` provides the text that was
+    /// spoken immediately before this utterance so providers that support it
+    /// (e.g. ElevenLabs `previous_text`) can maintain prosodic continuity.
+    func speak(text: String, previousText: String?, onStart: @escaping () -> Void, onComplete: @escaping () -> Void, onError: @escaping (String) -> Void)
     func stop()
 }


### PR DESCRIPTION
## Summary
- Adds `previousText` parameter to `TTSProvider` protocol for prosodic continuity across sentences
- `AudioCoordinator` tracks spoken history and passes it to each `speak()` call
- **ElevenLabs**: sends `previous_text` in the API body so the model knows what came before — "But on the bright side..." sounds bittersweet after "I got fired" instead of standalone cheerful
- **OpenAI, Kokoro, Apple**: accept but ignore the parameter (no API support)

## Context
When we split streaming LLM output into sentences for sequential TTS playback, each sentence is synthesized in isolation. This loses emotional arc — the tone of sentence N should be influenced by sentence N-1. ElevenLabs's `previous_text` parameter solves this for cloud TTS with zero added latency.

## Test plan
- [ ] ElevenLabs: send an emotionally complex response (e.g. bad news followed by silver lining) and verify the second sentence sounds contextually appropriate
- [ ] Other providers: verify no regression — speech still works normally
- [ ] Barge-in: verify history is cleared and next response starts fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)