### PR TITLE
Harden Gemini session resumption against rotation edge cases

### DIFF
--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -13,8 +13,18 @@ const WATCHDOG_TIMEOUT_MS = 20_000
 const SETUP_TIMEOUT_MS = 15_000
 const MAX_RECONNECT_ATTEMPTS = 2
 const RECONNECT_BACKOFF_MS = 500
-// Close codes that warrant a transparent reconnect (vs. surfacing to the client)
-const RECONNECTABLE_CLOSE_CODES = new Set([1001, 1006, 1011, 1012, 1013])
+// Close codes that warrant a transparent reconnect (vs. surfacing to the client).
+// Gemini's graceful end-of-session path is goAway → we reconnect proactively
+// before the close lands. These codes cover transport-level drops (network,
+// server restart, rate limit). 1011 is intentionally excluded: it usually
+// signals a server error that's not helped by replaying the resumption handle.
+const RECONNECTABLE_CLOSE_CODES = new Set([1001, 1006, 1012, 1013])
+// Bounded send queues for the reconnect window.
+// Audio: ~1s at 50Hz — older chunks are dropped first since stale audio
+// smears VAD. Control: small buffer for toolResponse / clientContent which
+// MUST reach the upstream to unblock the model.
+const MAX_PENDING_AUDIO = 50
+const MAX_PENDING_CONTROL = 20
 
 const GEMINI_VOICES = ["Puck", "Charon", "Kore", "Fenrir", "Aoede", "Leda", "Orus", "Zephyr"]
 
@@ -46,9 +56,15 @@ export class GeminiAdapter implements ProviderAdapter {
 
   // Session resumption state
   private resumptionHandle: string | null = null
+  private currentlyResumable = true
+  private rotateAfterToolCalls = false
   private isReconnecting = false
   private disconnected = false
   private wsUrlOverride: string | null = null // for tests to point at a mock server
+  // Bounded queues for messages written during the reconnect window.
+  // Flushed on the resumed connection's setupComplete.
+  private pendingAudio: string[] = []
+  private pendingControl: string[] = []
 
   async connect(config: SessionConfigEvent, sendToClient: SendToClient): Promise<void> {
     this.sendToClient = sendToClient
@@ -76,54 +92,79 @@ export class GeminiAdapter implements ProviderAdapter {
 
     return new Promise((resolve, reject) => {
       let settled = false
-      const finish = (err?: Error) => {
-        if (settled) return
-        settled = true
-        clearTimeout(timeoutHandle)
-        if (err) reject(err)
-        else resolve()
-      }
 
-      const timeoutHandle = setTimeout(() => finish(new Error("Gemini setup timed out")), SETUP_TIMEOUT_MS)
-
-      ws.on("open", () => {
+      const onOpen = () => {
         const resuming = this.resumptionHandle !== null
         log(`[gemini] WebSocket connected, sending setup (model=${model}${resuming ? ", resuming" : ""})`)
-        this.sendSetup(this.config!, model)
-      })
+        try {
+          this.sendSetup(this.config!, model)
+        } catch (err) {
+          finish(err instanceof Error ? err : new Error(String(err)))
+        }
+      }
 
-      ws.on("message", (raw) => {
+      const onMessage = (raw: WebSocket.RawData) => {
         try {
           const msg = JSON.parse(String(raw))
-
-          // Setup complete is the first response — resolve the connect promise
           if (msg.setupComplete !== undefined) {
             log("[gemini] Setup complete")
             this.resetWatchdog()
             finish()
+            // Flush AFTER finish() so any waiters see a fully-established
+            // connection before queued sends begin landing on the wire.
+            this.flushPending()
             return
           }
-
           this.handleServerMessage(msg)
         } catch (err) {
           logError("[gemini] Failed to parse message:", err)
         }
-      })
+      }
 
-      ws.on("error", (err) => {
+      const onError = (err: Error) => {
         logError("[gemini] WebSocket error:", err.message)
         finish(err)
-      })
+      }
 
-      ws.on("close", (code, reason) => {
+      const onClose = (code: number, reason: Buffer) => {
         log(`[gemini] WebSocket closed: ${code} ${String(reason)}`)
-        // If we haven't finished the setup promise yet, this is a hard failure
         if (!settled) {
           finish(new Error(`WebSocket closed during setup: ${code}`))
           return
         }
         this.handleUpstreamClose(code)
-      })
+      }
+
+      const finish = (err?: Error) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeoutHandle)
+        if (err) {
+          // Detach our handlers so the abandoned socket can't fire a spurious
+          // handleUpstreamClose. Swap in no-op error/close first so any follow-on
+          // events after close() don't become uncaught.
+          ws.off("open", onOpen)
+          ws.off("message", onMessage)
+          ws.off("error", onError)
+          ws.off("close", onClose)
+          ws.on("error", () => { /* discard */ })
+          ws.on("close", () => { /* discard */ })
+          if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+            try { ws.close(1011, "setup failed") } catch { /* ignore */ }
+          }
+          if (this.upstream === ws) this.upstream = null
+          reject(err)
+        } else {
+          resolve()
+        }
+      }
+
+      const timeoutHandle = setTimeout(() => finish(new Error("Gemini setup timed out")), SETUP_TIMEOUT_MS)
+
+      ws.on("open", onOpen)
+      ws.on("message", onMessage)
+      ws.on("error", onError)
+      ws.on("close", onClose)
     })
   }
 
@@ -136,6 +177,18 @@ export class GeminiAdapter implements ProviderAdapter {
     if (this.disconnected) return // we initiated the close
     if (code === 1000) return // clean close — nothing to do
     if (this.isReconnecting) return // a reconnect is already in flight
+
+    // If the socket closes while a tool call is in flight or we were waiting
+    // for a post-tool resumable handle, the call is lost — our stored handle
+    // is from before the call and the new session wouldn't recognize the
+    // callId. Surface the error rather than silently resuming into a broken state.
+    if (this.pendingToolCalls > 0 || this.rotateAfterToolCalls) {
+      logError(`[gemini] upstream closed mid-tool-call — cannot safely resume (pending=${this.pendingToolCalls}, deferred=${this.rotateAfterToolCalls})`)
+      this.pendingToolCalls = 0
+      this.rotateAfterToolCalls = false
+      this.sendToClient?.({ type: "error", message: "upstream connection closed mid-tool-call", code: 502 })
+      return
+    }
 
     if (!RECONNECTABLE_CLOSE_CODES.has(code) || !this.resumptionHandle) {
       this.sendToClient?.({ type: "error", message: "upstream connection closed", code: 502 })
@@ -160,6 +213,10 @@ export class GeminiAdapter implements ProviderAdapter {
     }
 
     this.isReconnecting = true
+    // Reset session-scoped state — the new upstream gets its own resumable flag
+    // from its first sessionResumptionUpdate.
+    this.currentlyResumable = true
+    this.rotateAfterToolCalls = false
     log(`[gemini] Reconnecting (${reason}, handle=${this.resumptionHandle.slice(0, 8)}…)`)
     this.sendToClient?.({ type: "session.rotating" })
     this.pauseWatchdog()
@@ -201,7 +258,7 @@ export class GeminiAdapter implements ProviderAdapter {
           mimeType: "audio/pcm;rate=16000",
         },
       },
-    })
+    }, "audio")
     this.resetWatchdog()
   }
 
@@ -305,7 +362,11 @@ export class GeminiAdapter implements ProviderAdapter {
     }
 
     log(`[gemini] Setup: model=${model}, voice=${voice}, tools=${tools.length}`)
-    this.sendUpstream({ setup })
+    // Bypass the reconnect queue — the setup message IS the handshake that
+    // ends the reconnect window. Queuing it would deadlock.
+    if (this.upstream?.readyState === WebSocket.OPEN) {
+      this.upstream.send(JSON.stringify({ setup }))
+    }
   }
 
   // --- server message handling ---
@@ -331,17 +392,31 @@ export class GeminiAdapter implements ProviderAdapter {
 
     if (msg.goAway) {
       const timeLeftMs = parseTimeLeftMs(msg.goAway.timeLeft)
+      if (this.pendingToolCalls > 0 || !this.currentlyResumable) {
+        // Gemini marks the stream non-resumable while a tool call is in flight.
+        // Rotating now would resume to a checkpoint from before the call existed,
+        // and the pending toolResponse would be sent to a session that never saw
+        // the callId. Defer until we see a fresh resumable handle post-tool.
+        log(`[gemini] GoAway received — deferring rotation (pending=${this.pendingToolCalls}, resumable=${this.currentlyResumable}, timeLeft=${timeLeftMs}ms)`)
+        this.rotateAfterToolCalls = true
+        return
+      }
       log(`[gemini] GoAway received — session ending in ~${timeLeftMs}ms, rotating proactively`)
-      // Rotate now rather than waiting for the close — Gemini gave us a grace
-      // period specifically so we can swap the upstream without a user-visible gap.
       void this.reconnect("goAway")
       return
     }
 
     if (msg.sessionResumptionUpdate) {
       const update = msg.sessionResumptionUpdate
+      this.currentlyResumable = !!update.resumable
       if (update.newHandle && update.resumable) {
         this.resumptionHandle = update.newHandle
+        // If a goAway arrived during a tool call, this is our first chance to
+        // rotate safely — the new handle is post-call.
+        if (this.rotateAfterToolCalls && this.pendingToolCalls === 0) {
+          this.rotateAfterToolCalls = false
+          void this.reconnect("goAway-deferred")
+        }
       }
       return
     }
@@ -485,16 +560,56 @@ export class GeminiAdapter implements ProviderAdapter {
 
   // --- upstream comms ---
 
-  private sendUpstream(msg: Record<string, unknown>) {
-    if (this.upstream?.readyState === WebSocket.OPEN) {
-      this.upstream.send(JSON.stringify(msg))
+  private sendUpstream(msg: Record<string, unknown>, kind: "audio" | "control" = "control") {
+    const payload = JSON.stringify(msg)
+    // While rotating, always queue — the resumed socket may be OPEN before
+    // setupComplete lands, and writing between CONNECTED and SETUP would
+    // interleave with our setup message and corrupt the handshake.
+    if (this.isReconnecting) {
+      if (kind === "audio") {
+        // Oldest-drop: stale audio smears VAD and delays the next turn more
+        // than a short loss does.
+        if (this.pendingAudio.length >= MAX_PENDING_AUDIO) this.pendingAudio.shift()
+        this.pendingAudio.push(payload)
+      } else {
+        // Control messages (toolResponse, clientContent) must reach the upstream
+        // to unblock the model. If we somehow overflow, drop the newest so the
+        // original toolResponse still goes through.
+        if (this.pendingControl.length < MAX_PENDING_CONTROL) {
+          this.pendingControl.push(payload)
+        } else {
+          logError(`[gemini] control queue full (${MAX_PENDING_CONTROL}) — dropping message`)
+        }
+      }
+      return
     }
+    if (this.upstream?.readyState === WebSocket.OPEN) {
+      this.upstream.send(payload)
+    }
+  }
+
+  private flushPending() {
+    if (!this.upstream || this.upstream.readyState !== WebSocket.OPEN) return
+    // Control first so the model unblocks before we flood it with audio.
+    const control = this.pendingControl
+    const audio = this.pendingAudio
+    this.pendingControl = []
+    this.pendingAudio = []
+    if (control.length > 0 || audio.length > 0) {
+      log(`[gemini] Flushing reconnect queue (${control.length} control, ${audio.length} audio)`)
+    }
+    for (const p of control) this.upstream.send(p)
+    for (const p of audio) this.upstream.send(p)
   }
 
   // --- watchdog ---
 
   private resetWatchdog() {
     this.clearWatchdog()
+    // While a tool call is in flight, leave the watchdog paused — firing the
+    // "user silent" prompt mid-tool would inject a fake user turn into a
+    // session that's already waiting on us, corrupting the conversation.
+    if (this.pendingToolCalls > 0) return
     this.watchdogTimer = setTimeout(() => {
       log("[gemini] Watchdog: no audio for 20s, injecting prompt")
       this.sendUpstream({

--- a/relay-server/test/test-gemini-reconnect.ts
+++ b/relay-server/test/test-gemini-reconnect.ts
@@ -196,9 +196,617 @@ async function runUnrecoverableCloseTest() {
   wss.close()
 }
 
+async function runReconnectRetryTest() {
+  console.log("\nGemini Reconnect Retry Test (first attempt fails, second succeeds)")
+  console.log("===================================================================")
+
+  const MOCK_PORT = 19890
+  const clientEvents: RelayEvent[] = []
+  const receivedSetups: Record<string, unknown>[] = []
+
+  // Three WS connections expected: initial, failed-reconnect #1, successful-reconnect #2
+  const wss = new WebSocketServer({ port: MOCK_PORT })
+  let connectionIndex = 0
+  const firstSocketRef: { ws: WsSocket | null } = { ws: null }
+
+  wss.on("connection", (ws) => {
+    const myIndex = connectionIndex++
+    if (myIndex === 0) firstSocketRef.ws = ws
+
+    ws.on("message", (raw) => {
+      const msg = JSON.parse(String(raw))
+      if (!msg.setup) return
+      receivedSetups.push(msg.setup)
+
+      if (myIndex === 0) {
+        // Initial: ack setup, send a resumption handle, then close with goAway to trigger reconnect.
+        ws.send(JSON.stringify({ setupComplete: {} }))
+        setTimeout(() => {
+          ws.send(JSON.stringify({
+            sessionResumptionUpdate: { newHandle: "retry-handle", resumable: true },
+          }))
+        }, 30)
+        setTimeout(() => {
+          ws.send(JSON.stringify({ goAway: { timeLeft: "2s" } }))
+        }, 60)
+        setTimeout(() => ws.close(1011, "rotating"), 100)
+      } else if (myIndex === 1) {
+        // First reconnect attempt: close the socket before sending setupComplete (simulates setup-time failure)
+        ws.close(1011, "transient")
+      } else {
+        // Second reconnect attempt: succeed normally
+        ws.send(JSON.stringify({ setupComplete: {} }))
+      }
+    })
+  })
+
+  await new Promise((r) => wss.on("listening", () => r(null)))
+  console.log(`[1] Mock Gemini server listening on :${MOCK_PORT}`)
+
+  const config: SessionConfigEvent = {
+    type: "session.config",
+    provider: "gemini",
+    model: "gemini-3.1-flash-live-preview",
+    voice: "Zephyr",
+    apiKey: "test",
+    brainAgent: "none",
+    openclawGatewayUrl: "http://localhost:18789",
+    openclawAuthToken: "test-token",
+    deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
+  }
+
+  const adapter = new GeminiAdapter()
+  ;(adapter as unknown as { wsUrlOverride: string }).wsUrlOverride = `ws://localhost:${MOCK_PORT}`
+
+  await adapter.connect(config, (event) => clientEvents.push(event as RelayEvent))
+
+  // Wait for: handle (30ms) + goAway (60ms) + first-reconnect fail + backoff (500ms) + second-reconnect success
+  await new Promise((r) => setTimeout(r, 2500))
+
+  console.log(`    Mock received ${receivedSetups.length} setup messages`)
+  console.log(`    Client events: ${clientEvents.map((e) => e.type).join(", ")}`)
+
+  assert(receivedSetups.length === 3, "mock received 3 setups (initial + fail + success)")
+
+  const rotating = clientEvents.filter((e) => e.type === "session.rotating")
+  const rotated = clientEvents.filter((e) => e.type === "session.rotated")
+  const errors = clientEvents.filter((e) => e.type === "error")
+
+  assert(rotating.length === 1, `exactly one session.rotating (got ${rotating.length})`)
+  assert(rotated.length === 1, `exactly one session.rotated after retry succeeds (got ${rotated.length})`)
+  assert(errors.length === 0, `no error events fired during retry (got ${errors.length})`)
+
+  adapter.disconnect()
+  wss.close()
+}
+
+async function runWatchdogGatedTest() {
+  console.log("\nGemini Watchdog Gated Test (pendingToolCalls > 0 suppresses timer)")
+  console.log("===================================================================")
+
+  const adapter = new GeminiAdapter()
+  type AdapterInternals = {
+    pendingToolCalls: number
+    watchdogTimer: ReturnType<typeof setTimeout> | null
+    resetWatchdog: () => void
+  }
+  const internals = adapter as unknown as AdapterInternals
+
+  internals.pendingToolCalls = 0
+  internals.resetWatchdog()
+  assert(internals.watchdogTimer !== null, "watchdog armed when no pending tool calls")
+
+  internals.pendingToolCalls = 1
+  internals.resetWatchdog()
+  assert(internals.watchdogTimer === null, "watchdog suppressed during pending tool call")
+
+  internals.pendingToolCalls = 0
+  internals.resetWatchdog()
+  assert(internals.watchdogTimer !== null, "watchdog re-arms after tool calls drain")
+
+  adapter.disconnect()
+}
+
+async function runDeferredRotationMidToolCallTest() {
+  console.log("\nGemini Deferred Rotation Test (goAway during tool call)")
+  console.log("========================================================")
+
+  const MOCK_PORT = 19891
+  const clientEvents: RelayEvent[] = []
+  const receivedSetups: Record<string, unknown>[] = []
+  const socketOneMessages: Record<string, unknown>[] = []
+  const socketTwoMessages: Record<string, unknown>[] = []
+
+  const wss = new WebSocketServer({ port: MOCK_PORT })
+  let connectionIndex = 0
+  let socketOne: WsSocket | null = null
+
+  wss.on("connection", (ws) => {
+    const myIndex = connectionIndex++
+    if (myIndex === 0) socketOne = ws
+
+    ws.on("message", (raw) => {
+      const msg = JSON.parse(String(raw))
+      if (msg.setup) {
+        receivedSetups.push(msg.setup)
+        ws.send(JSON.stringify({ setupComplete: {} }))
+
+        if (myIndex === 0) {
+          // 1. fresh resumable handle
+          setTimeout(() => ws.send(JSON.stringify({
+            sessionResumptionUpdate: { newHandle: "pre-tool-handle", resumable: true },
+          })), 20)
+          // 2. issue a tool call (adapter → pendingToolCalls=1)
+          setTimeout(() => ws.send(JSON.stringify({
+            toolCall: { functionCalls: [{ id: "call-1", name: "ask_brain", args: { question: "hi" } }] },
+          })), 40)
+          // 3. non-resumable update (Gemini stops issuing resumable handles during a call)
+          setTimeout(() => ws.send(JSON.stringify({
+            sessionResumptionUpdate: { newHandle: "mid-tool", resumable: false },
+          })), 60)
+          // 4. goAway while call is still pending — adapter should DEFER
+          setTimeout(() => ws.send(JSON.stringify({
+            goAway: { timeLeft: "5s" },
+          })), 80)
+        }
+      } else {
+        // record non-setup messages per socket (e.g. toolResponse)
+        if (myIndex === 0) socketOneMessages.push(msg)
+        else socketTwoMessages.push(msg)
+
+        // When socket 1 receives the toolResponse, emit a fresh resumable
+        // handle post-tool — this is the signal adapter waits for.
+        if (myIndex === 0 && msg.toolResponse) {
+          setTimeout(() => ws.send(JSON.stringify({
+            sessionResumptionUpdate: { newHandle: "post-tool-handle", resumable: true },
+          })), 20)
+        }
+      }
+    })
+  })
+
+  await new Promise((r) => wss.on("listening", () => r(null)))
+
+  const config: SessionConfigEvent = {
+    type: "session.config",
+    provider: "gemini",
+    model: "gemini-3.1-flash-live-preview",
+    voice: "Zephyr",
+    apiKey: "test",
+    brainAgent: "none",
+    openclawGatewayUrl: "http://localhost:18789",
+    openclawAuthToken: "test-token",
+    deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
+  }
+
+  const adapter = new GeminiAdapter()
+  ;(adapter as unknown as { wsUrlOverride: string }).wsUrlOverride = `ws://localhost:${MOCK_PORT}`
+
+  await adapter.connect(config, (event) => {
+    clientEvents.push(event as RelayEvent)
+    // Simulate the relay delivering the tool result 150ms later
+    if ((event as { type: string }).type === "tool.call") {
+      setTimeout(() => {
+        adapter.sendToolResult("call-1", JSON.stringify({ answer: "42" }))
+      }, 150)
+    }
+  })
+
+  // Wait for full flow: handle (20) + toolCall (40) + non-resumable (60) + goAway (80)
+  // + sendToolResult (150ms after tool.call → ~190ms) + post-tool handle (+20) → reconnect
+  await new Promise((r) => setTimeout(r, 2500))
+
+  console.log(`    Mock received ${receivedSetups.length} setups`)
+  console.log(`    Socket 1 messages: ${socketOneMessages.map((m) => Object.keys(m)[0]).join(", ")}`)
+  console.log(`    Client events: ${clientEvents.map((e) => e.type).join(", ")}`)
+
+  const toolResponsesOnSocket1 = socketOneMessages.filter((m) => "toolResponse" in m)
+  const toolResponsesOnSocket2 = socketTwoMessages.filter((m) => "toolResponse" in m)
+
+  assert(toolResponsesOnSocket1.length === 1, `toolResponse went to original socket (got ${toolResponsesOnSocket1.length})`)
+  assert(toolResponsesOnSocket2.length === 0, `no toolResponse sent on resumed socket (got ${toolResponsesOnSocket2.length})`)
+
+  const rotated = clientEvents.filter((e) => e.type === "session.rotated")
+  assert(rotated.length === 1, `rotation happened after tool completed (rotated count=${rotated.length})`)
+
+  const errors = clientEvents.filter((e) => e.type === "error")
+  assert(errors.length === 0, `no error emitted (got ${errors.length})`)
+
+  const secondSetup = receivedSetups[1] as { sessionResumption?: { handle?: string } } | undefined
+  assert(
+    secondSetup?.sessionResumption?.handle === "post-tool-handle",
+    `reconnect used POST-tool handle, not stale pre-tool handle (got ${secondSetup?.sessionResumption?.handle})`,
+  )
+
+  adapter.disconnect()
+  wss.close()
+  void socketOne
+}
+
+async function runHardCloseMidToolCallTest() {
+  console.log("\nGemini Hard Close Mid-Tool-Call Test (no safe rotation)")
+  console.log("========================================================")
+
+  const MOCK_PORT = 19892
+  const clientEvents: RelayEvent[] = []
+  const socketOneMessages: Record<string, unknown>[] = []
+  const socketTwoMessages: Record<string, unknown>[] = []
+
+  const wss = new WebSocketServer({ port: MOCK_PORT })
+  let connectionIndex = 0
+
+  wss.on("connection", (ws) => {
+    const myIndex = connectionIndex++
+
+    ws.on("message", (raw) => {
+      const msg = JSON.parse(String(raw))
+      if (msg.setup) {
+        ws.send(JSON.stringify({ setupComplete: {} }))
+        if (myIndex === 0) {
+          setTimeout(() => ws.send(JSON.stringify({
+            sessionResumptionUpdate: { newHandle: "pre-tool", resumable: true },
+          })), 20)
+          setTimeout(() => ws.send(JSON.stringify({
+            toolCall: { functionCalls: [{ id: "call-2", name: "ask_brain", args: { question: "x" } }] },
+          })), 40)
+          setTimeout(() => ws.send(JSON.stringify({
+            sessionResumptionUpdate: { newHandle: "mid", resumable: false },
+          })), 60)
+          // Hard close BEFORE tool result arrives — adapter should surface error
+          setTimeout(() => ws.close(1011, "timeLeft expired"), 100)
+        }
+      } else {
+        if (myIndex === 0) socketOneMessages.push(msg)
+        else socketTwoMessages.push(msg)
+      }
+    })
+  })
+
+  await new Promise((r) => wss.on("listening", () => r(null)))
+
+  const config: SessionConfigEvent = {
+    type: "session.config",
+    provider: "gemini",
+    model: "gemini-3.1-flash-live-preview",
+    voice: "Zephyr",
+    apiKey: "test",
+    brainAgent: "none",
+    openclawGatewayUrl: "http://localhost:18789",
+    openclawAuthToken: "test-token",
+    deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
+  }
+
+  const adapter = new GeminiAdapter()
+  ;(adapter as unknown as { wsUrlOverride: string }).wsUrlOverride = `ws://localhost:${MOCK_PORT}`
+
+  await adapter.connect(config, (event) => {
+    clientEvents.push(event as RelayEvent)
+    if ((event as { type: string }).type === "tool.call") {
+      // Tool result arrives AFTER the socket closed — should not be sent anywhere
+      setTimeout(() => {
+        adapter.sendToolResult("call-2", JSON.stringify({ answer: "late" }))
+      }, 300)
+    }
+  })
+
+  await new Promise((r) => setTimeout(r, 1500))
+
+  console.log(`    Client events: ${clientEvents.map((e) => e.type).join(", ")}`)
+  console.log(`    Socket 1 messages: ${socketOneMessages.map((m) => Object.keys(m)[0]).join(", ")}`)
+  console.log(`    Socket 2 messages: ${socketTwoMessages.map((m) => Object.keys(m)[0]).join(", ")}`)
+
+  const errors = clientEvents.filter((e) => e.type === "error")
+  const rotated = clientEvents.filter((e) => e.type === "session.rotated")
+
+  assert(errors.length === 1, `hard close mid-tool surfaces exactly one error (got ${errors.length})`)
+  assert(rotated.length === 0, `no rotation attempted with stale pre-tool handle (got ${rotated.length})`)
+  assert(socketTwoMessages.length === 0, `no toolResponse sent on any resumed socket (got ${socketTwoMessages.length})`)
+
+  adapter.disconnect()
+  wss.close()
+}
+
+async function runSendQueueDrainTest() {
+  console.log("\nGemini Send Queue Drain Test (rapid sends during rotation)")
+  console.log("===========================================================")
+
+  const MOCK_PORT = 19893
+  const socketTwoMessages: Record<string, unknown>[] = []
+
+  const wss = new WebSocketServer({ port: MOCK_PORT })
+  let connectionIndex = 0
+
+  wss.on("connection", (ws) => {
+    const myIndex = connectionIndex++
+    ws.on("message", (raw) => {
+      const msg = JSON.parse(String(raw))
+      if (msg.setup) {
+        if (myIndex === 0) {
+          ws.send(JSON.stringify({ setupComplete: {} }))
+          setTimeout(() => ws.send(JSON.stringify({
+            sessionResumptionUpdate: { newHandle: "h1", resumable: true },
+          })), 20)
+          // goAway with no pending tool call → immediate reconnect
+          setTimeout(() => ws.send(JSON.stringify({ goAway: { timeLeft: "3s" } })), 40)
+          setTimeout(() => ws.close(1011, "rotating"), 80)
+        } else {
+          // Resumed socket: delay setupComplete a bit so the client has time
+          // to buffer some messages in the reconnect window.
+          setTimeout(() => ws.send(JSON.stringify({ setupComplete: {} })), 100)
+        }
+      } else if (myIndex === 1) {
+        socketTwoMessages.push(msg)
+      }
+    })
+  })
+
+  await new Promise((r) => wss.on("listening", () => r(null)))
+
+  const config: SessionConfigEvent = {
+    type: "session.config",
+    provider: "gemini",
+    model: "gemini-3.1-flash-live-preview",
+    voice: "Zephyr",
+    apiKey: "test",
+    brainAgent: "none",
+    openclawGatewayUrl: "http://localhost:18789",
+    openclawAuthToken: "test-token",
+    deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
+  }
+
+  const adapter = new GeminiAdapter()
+  ;(adapter as unknown as { wsUrlOverride: string }).wsUrlOverride = `ws://localhost:${MOCK_PORT}`
+
+  const clientEvents: RelayEvent[] = []
+  await adapter.connect(config, (event) => clientEvents.push(event as RelayEvent))
+
+  // Wait for goAway + reconnect to START (isReconnecting=true, upstream=null)
+  // Initial setup ~immediate, handle at 20ms, goAway at 40ms → reconnect begins ~40ms.
+  await new Promise((r) => setTimeout(r, 60))
+
+  // Flood with audio + a single toolResponse — all should queue
+  const floodSize = MAX_PENDING_AUDIO_FROM_ADAPTER + 10 // exceeds cap → drops oldest
+  for (let i = 0; i < floodSize; i++) {
+    // Construct valid 24kHz PCM16 base64 of 20ms (960 samples × 2 bytes = 1920B)
+    const buf = Buffer.alloc(1920)
+    buf.writeInt16LE(i % 32767, 0) // stamp chunk index in the first sample
+    adapter.sendAudio(buf.toString("base64"))
+  }
+  adapter.sendToolResult("call-x", JSON.stringify({ ok: true }))
+
+  // Wait for second socket to complete setup and flush to drain
+  await new Promise((r) => setTimeout(r, 1500))
+
+  const audioOnSocket2 = socketTwoMessages.filter((m) => "realtimeInput" in m)
+  const toolOnSocket2 = socketTwoMessages.filter((m) => "toolResponse" in m)
+
+  console.log(`    Socket 2 received: ${audioOnSocket2.length} audio, ${toolOnSocket2.length} toolResponse`)
+
+  assert(audioOnSocket2.length === MAX_PENDING_AUDIO_FROM_ADAPTER,
+    `audio capped at ${MAX_PENDING_AUDIO_FROM_ADAPTER} (got ${audioOnSocket2.length})`)
+  assert(toolOnSocket2.length === 1, `toolResponse preserved across rotation (got ${toolOnSocket2.length})`)
+
+  // Control flushes before audio — toolResponse should appear before the first audio chunk
+  const firstToolIdx = socketTwoMessages.findIndex((m) => "toolResponse" in m)
+  const firstAudioIdx = socketTwoMessages.findIndex((m) => "realtimeInput" in m)
+  assert(firstToolIdx >= 0 && firstToolIdx < firstAudioIdx,
+    `control drains before audio (toolResponse idx=${firstToolIdx}, first audio idx=${firstAudioIdx})`)
+
+  adapter.disconnect()
+  wss.close()
+}
+
+// Must mirror the adapter's MAX_PENDING_AUDIO constant
+const MAX_PENDING_AUDIO_FROM_ADAPTER = 50
+
+async function runClose1011WithHandleTest() {
+  console.log("\nGemini Close 1011 With Handle Test (server error — surface, don't resume)")
+  console.log("==========================================================================")
+
+  const MOCK_PORT = 19894
+  const clientEvents: RelayEvent[] = []
+  const receivedSetups: Record<string, unknown>[] = []
+
+  const wss = await startMockGemini({
+    receivedSetups,
+    onConnect: (ws, index) => {
+      if (index === 0) {
+        // Capture a handle, then close with 1011 (server error) — NOT goAway.
+        // Per Gemini docs, graceful rotation uses goAway; a bare 1011 is an
+        // actual server-side fault and shouldn't auto-resume.
+        setTimeout(() => ws.send(JSON.stringify({
+          sessionResumptionUpdate: { newHandle: "h-stable", resumable: true },
+        })), 20)
+        setTimeout(() => ws.close(1011, "internal error"), 50)
+      }
+    },
+  }, MOCK_PORT)
+
+  const config: SessionConfigEvent = {
+    type: "session.config",
+    provider: "gemini",
+    model: "gemini-3.1-flash-live-preview",
+    voice: "Zephyr",
+    apiKey: "test",
+    brainAgent: "none",
+    openclawGatewayUrl: "http://localhost:18789",
+    openclawAuthToken: "test-token",
+    deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
+  }
+
+  const adapter = new GeminiAdapter()
+  ;(adapter as unknown as { wsUrlOverride: string }).wsUrlOverride = `ws://localhost:${MOCK_PORT}`
+
+  await adapter.connect(config, (event) => clientEvents.push(event as RelayEvent))
+  await new Promise((r) => setTimeout(r, 500))
+
+  console.log(`    Setups received: ${receivedSetups.length}, client events: ${clientEvents.map((e) => e.type).join(", ")}`)
+
+  assert(receivedSetups.length === 1, `no reconnect attempted for 1011 (setups=${receivedSetups.length})`)
+
+  const errors = clientEvents.filter((e) => e.type === "error")
+  const rotated = clientEvents.filter((e) => e.type === "session.rotated")
+  assert(errors.length === 1, `1011 with handle surfaces error (got ${errors.length})`)
+  assert(rotated.length === 0, `no silent reconnect on 1011 (got ${rotated.length})`)
+
+  adapter.disconnect()
+  wss.close()
+}
+
+async function runReconnectExhaustedTest() {
+  console.log("\nGemini Reconnect Exhausted Test (all attempts fail → error)")
+  console.log("============================================================")
+
+  const MOCK_PORT = 19895
+  const clientEvents: RelayEvent[] = []
+  const receivedSetups: Record<string, unknown>[] = []
+
+  const wss = new WebSocketServer({ port: MOCK_PORT })
+  let connectionIndex = 0
+
+  wss.on("connection", (ws) => {
+    const myIndex = connectionIndex++
+    ws.on("message", (raw) => {
+      const msg = JSON.parse(String(raw))
+      if (!msg.setup) return
+      receivedSetups.push(msg.setup)
+      if (myIndex === 0) {
+        ws.send(JSON.stringify({ setupComplete: {} }))
+        setTimeout(() => ws.send(JSON.stringify({
+          sessionResumptionUpdate: { newHandle: "h", resumable: true },
+        })), 20)
+        setTimeout(() => ws.send(JSON.stringify({ goAway: { timeLeft: "2s" } })), 40)
+      } else {
+        // Every reconnect attempt fails: close before setupComplete
+        ws.close(1011, "persistently broken")
+      }
+    })
+  })
+
+  await new Promise((r) => wss.on("listening", () => r(null)))
+
+  const config: SessionConfigEvent = {
+    type: "session.config",
+    provider: "gemini",
+    model: "gemini-3.1-flash-live-preview",
+    voice: "Zephyr",
+    apiKey: "test",
+    brainAgent: "none",
+    openclawGatewayUrl: "http://localhost:18789",
+    openclawAuthToken: "test-token",
+    deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
+  }
+
+  const adapter = new GeminiAdapter()
+  ;(adapter as unknown as { wsUrlOverride: string }).wsUrlOverride = `ws://localhost:${MOCK_PORT}`
+
+  await adapter.connect(config, (event) => clientEvents.push(event as RelayEvent))
+  // Initial + 2 reconnect attempts + 500ms backoff + buffer
+  await new Promise((r) => setTimeout(r, 3000))
+
+  console.log(`    Setups received: ${receivedSetups.length}, events: ${clientEvents.map((e) => e.type).join(", ")}`)
+
+  // 1 initial + MAX_RECONNECT_ATTEMPTS (2) failed attempts
+  assert(receivedSetups.length === 3, `3 setup attempts total (got ${receivedSetups.length})`)
+
+  const errors = clientEvents.filter((e) => e.type === "error")
+  const rotated = clientEvents.filter((e) => e.type === "session.rotated")
+  assert(errors.length === 1, `exactly one error after exhaustion (got ${errors.length})`)
+  assert(rotated.length === 0, `no session.rotated when all attempts fail (got ${rotated.length})`)
+
+  adapter.disconnect()
+  wss.close()
+}
+
+async function runChainedGoAwayTest() {
+  console.log("\nGemini Chained GoAway Test (two rotations back-to-back)")
+  console.log("========================================================")
+
+  const MOCK_PORT = 19896
+  const clientEvents: RelayEvent[] = []
+  const receivedSetups: Record<string, unknown>[] = []
+
+  const wss = new WebSocketServer({ port: MOCK_PORT })
+  let connectionIndex = 0
+
+  wss.on("connection", (ws) => {
+    const myIndex = connectionIndex++
+    ws.on("message", (raw) => {
+      const msg = JSON.parse(String(raw))
+      if (!msg.setup) return
+      receivedSetups.push(msg.setup)
+
+      if (myIndex === 0) {
+        ws.send(JSON.stringify({ setupComplete: {} }))
+        setTimeout(() => ws.send(JSON.stringify({
+          sessionResumptionUpdate: { newHandle: "handle-gen-1", resumable: true },
+        })), 20)
+        setTimeout(() => ws.send(JSON.stringify({ goAway: { timeLeft: "2s" } })), 40)
+        setTimeout(() => ws.close(1011, "done"), 80)
+      } else if (myIndex === 1) {
+        ws.send(JSON.stringify({ setupComplete: {} }))
+        setTimeout(() => ws.send(JSON.stringify({
+          sessionResumptionUpdate: { newHandle: "handle-gen-2", resumable: true },
+        })), 20)
+        setTimeout(() => ws.send(JSON.stringify({ goAway: { timeLeft: "2s" } })), 40)
+        setTimeout(() => ws.close(1011, "done"), 80)
+      } else {
+        // Third connection — stay open, no more rotations
+        ws.send(JSON.stringify({ setupComplete: {} }))
+      }
+    })
+  })
+
+  await new Promise((r) => wss.on("listening", () => r(null)))
+
+  const config: SessionConfigEvent = {
+    type: "session.config",
+    provider: "gemini",
+    model: "gemini-3.1-flash-live-preview",
+    voice: "Zephyr",
+    apiKey: "test",
+    brainAgent: "none",
+    openclawGatewayUrl: "http://localhost:18789",
+    openclawAuthToken: "test-token",
+    deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
+  }
+
+  const adapter = new GeminiAdapter()
+  ;(adapter as unknown as { wsUrlOverride: string }).wsUrlOverride = `ws://localhost:${MOCK_PORT}`
+
+  await adapter.connect(config, (event) => clientEvents.push(event as RelayEvent))
+  await new Promise((r) => setTimeout(r, 2500))
+
+  console.log(`    Setups: ${receivedSetups.length}, events: ${clientEvents.map((e) => e.type).join(", ")}`)
+
+  assert(receivedSetups.length === 3, `3 setups across two rotations (got ${receivedSetups.length})`)
+
+  const rotating = clientEvents.filter((e) => e.type === "session.rotating")
+  const rotated = clientEvents.filter((e) => e.type === "session.rotated")
+  const errors = clientEvents.filter((e) => e.type === "error")
+  assert(rotating.length === 2, `two session.rotating events (got ${rotating.length})`)
+  assert(rotated.length === 2, `two session.rotated events (got ${rotated.length})`)
+  assert(errors.length === 0, `no errors during chained rotations (got ${errors.length})`)
+
+  const thirdSetup = receivedSetups[2] as { sessionResumption?: { handle?: string } }
+  assert(thirdSetup.sessionResumption?.handle === "handle-gen-2",
+    `third setup uses latest handle (got ${thirdSetup.sessionResumption?.handle})`)
+
+  adapter.disconnect()
+  wss.close()
+}
+
 async function main() {
   await runReconnectTest()
   await runUnrecoverableCloseTest()
+  await runReconnectRetryTest()
+  await runWatchdogGatedTest()
+  await runDeferredRotationMidToolCallTest()
+  await runHardCloseMidToolCallTest()
+  await runSendQueueDrainTest()
+  await runClose1011WithHandleTest()
+  await runReconnectExhaustedTest()
+  await runChainedGoAwayTest()
   console.log(`\nResults: ${passed} passed, ${failed} failed`)
   process.exit(failed > 0 ? 1 : 0)
 }


### PR DESCRIPTION
## Summary

Follow-up to #52 addressing six issues from the Codex review of the initial session-resumption implementation.

- **T1** — Stale sockets after `openUpstream` timeout/reject no longer trigger spurious reconnects. Named handlers + `off()` (not `removeAllListeners` — that breaks error handling), plus no-op error/close stubs during teardown.
- **T2** — Watchdog no longer rearms on the resumed connection's `setupComplete` while a tool call is pending. Would've injected a fake "user silent" prompt mid-tool.
- **T3** (blocking) — `goAway` mid-tool-call now defers rotation until a fresh *resumable* handle arrives post-tool. Previously we reconnected with a pre-call handle, then routed `toolResponse` to a session that never saw the callId → protocol error or silent drop. Hard close before the fresh handle surfaces an error instead of resuming into a broken state.
- **T4** — Bounded send queues (audio + control) drain on resumed `setupComplete`. Audio is oldest-dropped (~1s window, stale audio smears VAD); `toolResponse` gets reserved slots and flushes first so the model unblocks before the audio flood.
- **T5** — `1011` removed from `RECONNECTABLE_CLOSE_CODES`. Graceful rotation is `goAway`-driven; a bare `1011` is a server fault not fixed by replaying the handle.
- **T6** — Added coverage for: retry-then-succeed, watchdog gating, deferred rotation, hard close mid-tool, send queue drain+overflow, `1011` surfacing, exhausted attempts, chained `goAway`s.

Each fix was reviewed by Codex against the proposed approach before implementation.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx tsx test/test-gemini-reconnect.ts` — 39/39 assertions across 10 mock-server scenarios
- [x] `npx tsx test/test-gemini-unit.ts` — 9/9 (resampling unchanged)
- [ ] Device test on iPhone: 20min session crosses `goAway` boundary without dropping
- [ ] Device test: tool call mid-rotation completes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)