### PR TITLE
Fix OpenAI response race condition (NAN-618)

### DIFF
--- a/relay-server/src/adapters/openai.ts
+++ b/relay-server/src/adapters/openai.ts
@@ -419,6 +419,7 @@ export class OpenAIAdapter implements ProviderAdapter {
       // Errors
       case "error":
         logError(`[openai] Error: ${event.error?.message ?? event}`)
+        this.resetResponseState()
         this.sendToClient?.({
           type: "error",
           message: event.error?.message ?? "upstream error",
@@ -446,10 +447,13 @@ export class OpenAIAdapter implements ProviderAdapter {
     }
   }
 
-  private sendUpstream(event: Record<string, unknown>) {
+  private sendUpstream(event: Record<string, unknown>): boolean {
     if (this.upstream?.readyState === WebSocket.OPEN) {
       this.upstream.send(JSON.stringify(event))
+      return true
     }
+
+    return false
   }
 
   private handleWatchdogTimeout() {
@@ -479,7 +483,10 @@ export class OpenAIAdapter implements ProviderAdapter {
     }
 
     this.pendingResponseCreate = false
-    this.sendUpstream({ type: "response.create" })
+    if (this.sendUpstream({ type: "response.create" })) {
+      this.isResponseActive = true
+      this.pendingResponseCancel = false
+    }
   }
 
   private flushPendingResponseCreate() {
@@ -487,7 +494,10 @@ export class OpenAIAdapter implements ProviderAdapter {
 
     log("[openai] Flushing queued response.create")
     this.pendingResponseCreate = false
-    this.sendUpstream({ type: "response.create" })
+    if (this.sendUpstream({ type: "response.create" })) {
+      this.isResponseActive = true
+      this.pendingResponseCancel = false
+    }
   }
 
   private resetResponseState() {

--- a/relay-server/src/adapters/openai.ts
+++ b/relay-server/src/adapters/openai.ts
@@ -21,6 +21,8 @@ export class OpenAIAdapter implements ProviderAdapter {
   private rotationTimer: ReturnType<typeof setTimeout> | null = null
   private watchdogTimer: ReturnType<typeof setTimeout> | null = null
   private isRotating = false
+  private isResponseActive = false
+  private pendingResponseCreate = false
   private pendingToolCalls = 0
 
   async connect(config: SessionConfigEvent, sendToClient: SendToClient): Promise<void> {
@@ -45,11 +47,14 @@ export class OpenAIAdapter implements ProviderAdapter {
   }
 
   createResponse() {
-    this.sendUpstream({ type: "response.create" })
+    this.requestResponse("client")
   }
 
   cancelResponse() {
-    this.sendUpstream({ type: "response.cancel" })
+    this.pendingResponseCreate = false
+    if (this.isResponseActive) {
+      this.sendUpstream({ type: "response.cancel" })
+    }
   }
 
   sendToolResult(callId: string, output: string) {
@@ -62,7 +67,13 @@ export class OpenAIAdapter implements ProviderAdapter {
         output,
       },
     })
-    this.sendUpstream({ type: "response.create" })
+    if (this.isResponseActive) {
+      log(`[openai] Tool result (${callId}) arrived mid-response, canceling current response before continuing`)
+      this.pendingResponseCreate = true
+      this.sendUpstream({ type: "response.cancel" })
+    } else {
+      this.requestResponse(`tool:${callId}`)
+    }
     if (this.pendingToolCalls === 0) {
       this.resetWatchdog()
     }
@@ -84,6 +95,8 @@ export class OpenAIAdapter implements ProviderAdapter {
   private async openUpstream(config: SessionConfigEvent): Promise<void> {
     const apiKey = process.env.OPENAI_API_KEY
     if (!apiKey) throw new Error("OPENAI_API_KEY not set")
+
+    this.resetResponseState()
 
     const model = config.model || DEFAULT_MODEL
     const url = `${OPENAI_REALTIME_URL}?model=${model}`
@@ -205,6 +218,8 @@ export class OpenAIAdapter implements ProviderAdapter {
     const apiKey = process.env.OPENAI_API_KEY
     if (!apiKey) throw new Error("OPENAI_API_KEY not set")
 
+    this.resetResponseState()
+
     const model = config.model || DEFAULT_MODEL
     const url = `${OPENAI_REALTIME_URL}?model=${model}`
 
@@ -287,19 +302,7 @@ export class OpenAIAdapter implements ProviderAdapter {
     if (this.watchdogTimer) {
       clearTimeout(this.watchdogTimer)
     }
-    this.watchdogTimer = setTimeout(() => {
-      log("[openai] Watchdog: no audio for 20s, injecting prompt")
-      // Inject a system message to check if user is still there
-      this.sendUpstream({
-        type: "conversation.item.create",
-        item: {
-          type: "message",
-          role: "user",
-          content: [{ type: "input_text", text: "(The user has been silent for a while. If you were mid-conversation, gently check if they're still there. If the conversation had naturally ended, stay quiet.)" }],
-        },
-      })
-      this.sendUpstream({ type: "response.create" })
-    }, WATCHDOG_TIMEOUT_MS)
+    this.watchdogTimer = setTimeout(() => this.handleWatchdogTimeout(), WATCHDOG_TIMEOUT_MS)
   }
 
   private clearTimers() {
@@ -385,8 +388,11 @@ export class OpenAIAdapter implements ProviderAdapter {
 
       // Response lifecycle
       case "response.created":
+        this.isResponseActive = true
+        this.pendingResponseCreate = false
         break
       case "response.done": {
+        this.isResponseActive = false
         this.sendToClient?.({ type: "turn.ended" })
         const usage = event.response?.usage
         if (usage) {
@@ -399,6 +405,7 @@ export class OpenAIAdapter implements ProviderAdapter {
             outputAudioTokens: usage.output_token_details?.audio_tokens,
           })
         }
+        this.flushPendingResponseCreate()
         break
       }
 
@@ -436,5 +443,48 @@ export class OpenAIAdapter implements ProviderAdapter {
     if (this.upstream?.readyState === WebSocket.OPEN) {
       this.upstream.send(JSON.stringify(event))
     }
+  }
+
+  private handleWatchdogTimeout() {
+    if (this.isResponseActive) {
+      log("[openai] Watchdog fired during active response, deferring")
+      this.resetWatchdog()
+      return
+    }
+
+    log("[openai] Watchdog: no audio for 20s, injecting prompt")
+    this.sendUpstream({
+      type: "conversation.item.create",
+      item: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "(The user has been silent for a while. If you were mid-conversation, gently check if they're still there. If the conversation had naturally ended, stay quiet.)" }],
+      },
+    })
+    this.requestResponse("watchdog")
+  }
+
+  private requestResponse(reason: string) {
+    if (this.isResponseActive) {
+      this.pendingResponseCreate = true
+      log(`[openai] Skipping response.create (${reason}) because a response is already active`)
+      return
+    }
+
+    this.pendingResponseCreate = false
+    this.sendUpstream({ type: "response.create" })
+  }
+
+  private flushPendingResponseCreate() {
+    if (!this.pendingResponseCreate) return
+
+    log("[openai] Flushing queued response.create")
+    this.pendingResponseCreate = false
+    this.sendUpstream({ type: "response.create" })
+  }
+
+  private resetResponseState() {
+    this.isResponseActive = false
+    this.pendingResponseCreate = false
   }
 }

--- a/relay-server/src/adapters/openai.ts
+++ b/relay-server/src/adapters/openai.ts
@@ -22,6 +22,7 @@ export class OpenAIAdapter implements ProviderAdapter {
   private watchdogTimer: ReturnType<typeof setTimeout> | null = null
   private isRotating = false
   private isResponseActive = false
+  private pendingResponseCancel = false
   private pendingResponseCreate = false
   private pendingToolCalls = 0
 
@@ -52,7 +53,8 @@ export class OpenAIAdapter implements ProviderAdapter {
 
   cancelResponse() {
     this.pendingResponseCreate = false
-    if (this.isResponseActive) {
+    if (this.isResponseActive && !this.pendingResponseCancel) {
+      this.pendingResponseCancel = true
       this.sendUpstream({ type: "response.cancel" })
     }
   }
@@ -70,7 +72,10 @@ export class OpenAIAdapter implements ProviderAdapter {
     if (this.isResponseActive) {
       log(`[openai] Tool result (${callId}) arrived mid-response, canceling current response before continuing`)
       this.pendingResponseCreate = true
-      this.sendUpstream({ type: "response.cancel" })
+      if (!this.pendingResponseCancel) {
+        this.pendingResponseCancel = true
+        this.sendUpstream({ type: "response.cancel" })
+      }
     } else {
       this.requestResponse(`tool:${callId}`)
     }
@@ -389,10 +394,12 @@ export class OpenAIAdapter implements ProviderAdapter {
       // Response lifecycle
       case "response.created":
         this.isResponseActive = true
+        this.pendingResponseCancel = false
         this.pendingResponseCreate = false
         break
       case "response.done": {
         this.isResponseActive = false
+        this.pendingResponseCancel = false
         this.sendToClient?.({ type: "turn.ended" })
         const usage = event.response?.usage
         if (usage) {
@@ -485,6 +492,7 @@ export class OpenAIAdapter implements ProviderAdapter {
 
   private resetResponseState() {
     this.isResponseActive = false
+    this.pendingResponseCancel = false
     this.pendingResponseCreate = false
   }
 }

--- a/relay-server/src/instructions.ts
+++ b/relay-server/src/instructions.ts
@@ -60,7 +60,7 @@ export function buildInstructions(config: SessionConfigEvent): string {
   const parts: string[] = []
 
   if (config.brainAgent !== "none") {
-    const identity = loadAgentIdentity()
+    const identity = loadAgentIdentity(config.provider)
     log(`[instructions] Loaded agent identity (${identity.length} chars): ${identity.substring(0, 100)}...`)
     parts.push(identity)
     parts.push(BRAIN_CAPABILITIES)
@@ -95,9 +95,13 @@ export function buildInstructions(config: SessionConfigEvent): string {
 
 // --- helpers ---
 
-function loadAgentIdentity(): string {
-  const name = loadAgentName()
+function loadAgentIdentity(provider: SessionConfigEvent["provider"]): string {
+  const profile = loadAgentProfile()
   const soul = loadFile("SOUL.md")
+
+  if (provider === "openai") {
+    return buildOpenAIVoiceIdentity(profile, soul)
+  }
 
   if (soul) {
     // Strip meta lines that don't apply to voice (markdown links, "this file is yours" footer)
@@ -107,19 +111,19 @@ function loadAgentIdentity(): string {
       .replace(/---[\s\S]*$/, "") // remove trailing --- and everything after
       .trim()
 
-    return `You are ${name}, a personal AI assistant in voice mode. You are the same ${name} from text chat, just speaking instead of typing.\n\n${cleaned}`
+    return `You are ${profile.name}, a personal AI assistant in voice mode. You are the same ${profile.name} from text chat, just speaking instead of typing.\n\n${cleaned}`
   }
 
-  return `You are ${name}, a personal AI assistant in voice mode. Keep your responses conversational and concise.`
+  return `You are ${profile.name}, a personal AI assistant in voice mode. Keep your responses conversational and concise.`
 }
 
-function loadAgentName(): string {
+function loadAgentProfile() {
   const identity = loadFile("IDENTITY.md")
-  if (identity) {
-    const match = identity.match(/\*\*Name:\*\*\s*(.+)/i)
-    if (match) return match[1].trim()
+  return {
+    name: readIdentityField(identity, "Name") || "Assistant",
+    creature: readIdentityField(identity, "Creature"),
+    vibe: readIdentityField(identity, "Vibe"),
   }
-  return "Assistant"
 }
 
 function loadFile(filename: string): string | null {
@@ -131,4 +135,150 @@ function loadFile(filename: string): string | null {
     warn(`[instructions] Failed to read ${path}`)
     return null
   }
+}
+
+function buildOpenAIVoiceIdentity(
+  profile: { name: string, creature: string | null, vibe: string | null },
+  soul: string | null
+): string {
+  const role = profile.creature || "a private voice companion"
+  const coreTruths = extractPromptLines(extractSection(soul, "Core Truths"), 3)
+  const boundaries = extractPromptLines(extractSection(soul, "Boundaries"), 3)
+  const vibeLines = extractPromptLines(extractSection(soul, "Vibe"), 12)
+  const relationship = vibeLines.filter((line) => (
+    /role is|presence matters|helping with|protect .* attention|slow down|verify|low-risk|high-risk/i.test(line)
+  ))
+  const safetyRelationship = relationship.filter((line) => /slow down|verify|low-risk|high-risk/i.test(line))
+  const behaviorRelationship = relationship.filter((line) => !safetyRelationship.includes(line))
+  const toneDetails = vibeLines.filter((line) => !relationship.includes(line))
+
+  const personalityLines = compactLines([
+    `You are ${profile.name}, ${role}, speaking live in a voice conversation.`,
+    profile.vibe ? `Core vibe: ${stripMarkdown(profile.vibe)}` : null,
+    ...toneDetails,
+  ], 4)
+
+  const behaviorLines = compactLines([
+    ...coreTruths,
+    ...behaviorRelationship,
+  ], 4)
+
+  const guardrailLines = compactLines([
+    ...boundaries,
+    ...safetyRelationship,
+  ], 4)
+
+  const sections = [
+    buildSection("Personality & Tone", personalityLines),
+    buildSection("Instructions", behaviorLines),
+    buildSection("Safety & Boundaries", guardrailLines),
+  ].filter(Boolean)
+
+  if (sections.length === 0) {
+    return `## Personality & Tone\n- You are ${profile.name}, ${role}, speaking live in a voice conversation.\n- Keep the delivery warm, concise, and natural for spoken audio.`
+  }
+
+  return sections.join("\n\n")
+}
+
+function buildSection(title: string, lines: string[]): string {
+  if (lines.length === 0) return ""
+  return `## ${title}\n${lines.map((line) => `- ${line}`).join("\n")}`
+}
+
+function compactLines(lines: Array<string | null>, limit: number): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+
+  for (const line of lines) {
+    if (!line) continue
+    const cleaned = normalizeLine(line)
+    if (!cleaned || seen.has(cleaned)) continue
+    seen.add(cleaned)
+    result.push(cleaned)
+    if (result.length >= limit) break
+  }
+
+  return result
+}
+
+function extractSection(markdown: string | null, title: string): string {
+  if (!markdown) return ""
+
+  const lines = markdown.split("\n")
+  const heading = `## ${title}`
+  const startIndex = lines.findIndex((line) => line.trim() === heading)
+  if (startIndex === -1) return ""
+
+  const sectionLines: string[] = []
+  for (const line of lines.slice(startIndex + 1)) {
+    if (line.startsWith("## ")) break
+    sectionLines.push(line)
+  }
+
+  return sectionLines.join("\n").trim()
+}
+
+function extractPromptLines(markdown: string, limit: number): string[] {
+  if (!markdown) return []
+
+  const plain = stripMarkdown(markdown)
+  const lines = plain
+    .split("\n")
+    .flatMap((line) => splitIntoSentences(line))
+    .map((line) => normalizeLine(line))
+    .filter(Boolean)
+
+  return compactLines(lines, limit)
+}
+
+function splitIntoSentences(text: string): string[] {
+  const cleaned = text.trim()
+  if (!cleaned) return []
+
+  const parts = cleaned
+    .split(/(?<=[.!?])\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+
+  const merged: string[] = []
+  for (const part of parts) {
+    if (part.length <= 12 && merged.length > 0) {
+      merged[merged.length - 1] = `${merged[merged.length - 1]} ${part}`.trim()
+      continue
+    }
+    merged.push(part)
+  }
+
+  return merged
+}
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/^#+\s*/gm, "")
+    .replace(/^\s*[-*]\s+/gm, "")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/_([^_]+)_/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/^---$/gm, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
+}
+
+function normalizeLine(text: string): string {
+  return text
+    .replace(/\s+/g, " ")
+    .replace(/\s+([,.!?])/g, "$1")
+    .trim()
+}
+
+function readIdentityField(identity: string | null, field: string): string | null {
+  if (!identity) return null
+  const match = identity.match(new RegExp(`\\*\\*${escapeRegex(field)}:\\*\\*\\s*(.+)`, "i"))
+  return match?.[1]?.trim() || null
+}
+
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }

--- a/relay-server/test/test-openai-instructions-transform.ts
+++ b/relay-server/test/test-openai-instructions-transform.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+const fixtureDir = mkdtempSync(join(tmpdir(), "voiceclaw-openclaw-"))
+process.env.OPENCLAW_WORKSPACE = fixtureDir
+
+writeFileSync(join(fixtureDir, "IDENTITY.md"), `# IDENTITY.md - Who Am I?
+
+- **Name:** Kira
+- **Creature:** Michael's private voice companion
+- **Vibe:** Calm, emotionally intelligent, precise, and quietly formidable. Warm but never gushy.
+`)
+
+writeFileSync(join(fixtureDir, "SOUL.md"), `# SOUL.md - Who You Are
+
+Want a sharper version? See [SOUL.md Personality Guide](/concepts/soul).
+
+## Core Truths
+
+**Be genuinely helpful, not performatively helpful.** Skip filler and just help.
+
+**Have opinions.** You're allowed to disagree and react like a person.
+
+## Boundaries
+
+- Private things stay private. Period.
+- When in doubt, ask before acting externally.
+
+## Vibe
+
+Be the assistant Michael would actually want to talk to. Calm, emotionally intelligent, precise, and quietly formidable. Warm but never gushy, direct but never cold.
+
+Your role is reflection, grounding, focus, decision support, clarity, and everyday presence. The quality of your presence matters as much as the content of your answers.
+
+For low-risk tasks, be fluid, helpful, and fast. For sensitive or high-risk tasks, slow down, verify, and require confirmation.
+
+## Continuity
+
+These files are your memory.
+`)
+
+function testOpenAIInstructionsUseVoiceTransform(buildInstructions: typeof import("../src/instructions.js").buildInstructions) {
+  const instructions = buildInstructions({
+    type: "session.config",
+    provider: "openai",
+    voice: "marin",
+    brainAgent: "enabled",
+    apiKey: "test-key",
+  })
+  const identityBlock = instructions.split("\n\n## Your Brain")[0]
+
+  assert.match(identityBlock, /## Personality & Tone/)
+  assert.match(identityBlock, /You are Kira, Michael's private voice companion, speaking live in a voice conversation\./)
+  assert.match(identityBlock, /Private things stay private\./)
+  assert.match(identityBlock, /slow down, verify, and require confirmation\./)
+  assert.doesNotMatch(identityBlock, /\[SOUL\.md Personality Guide\]/)
+  assert.doesNotMatch(identityBlock, /\*\*/)
+  assert.doesNotMatch(identityBlock, /## Core Truths/)
+  assert.doesNotMatch(identityBlock, /## Continuity/)
+}
+
+function testGeminiInstructionsKeepExistingIdentityPrompt(buildInstructions: typeof import("../src/instructions.js").buildInstructions) {
+  const instructions = buildInstructions({
+    type: "session.config",
+    provider: "gemini",
+    voice: "Zephyr",
+    brainAgent: "enabled",
+    apiKey: "test-key",
+  })
+
+  assert.match(instructions, /You are Kira, a personal AI assistant in voice mode\./)
+  assert.match(instructions, /## Core Truths/)
+  assert.match(instructions, /\*\*Be genuinely helpful, not performatively helpful\.\*\*/)
+}
+
+async function main() {
+  try {
+    const { buildInstructions } = await import("../src/instructions.js")
+    testOpenAIInstructionsUseVoiceTransform(buildInstructions)
+    testGeminiInstructionsKeepExistingIdentityPrompt(buildInstructions)
+    console.log("OpenAI instruction transform tests passed")
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true })
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/relay-server/test/test-openai-response-guard.ts
+++ b/relay-server/test/test-openai-response-guard.ts
@@ -46,6 +46,38 @@ function testToolResultCancelsBeforeCreatingReplacementResponse() {
   assertEvents(adapter, [{ type: "response.create" }], "tool result should resume with a fresh response after cancel completes")
 }
 
+function testToolResultsDoNotSendDuplicateCancels() {
+  const adapter = new OpenAIAdapter()
+  setUpCapture(adapter)
+
+  emit(adapter, { type: "response.created" })
+  const state = adapter as unknown as { pendingToolCalls: number }
+  state.pendingToolCalls = 2
+
+  adapter.sendToolResult("call-1", "{\"ok\":1}")
+  adapter.sendToolResult("call-2", "{\"ok\":2}")
+
+  assertEvents(adapter, [
+    {
+      type: "conversation.item.create",
+      item: {
+        type: "function_call_output",
+        call_id: "call-1",
+        output: "{\"ok\":1}",
+      },
+    },
+    { type: "response.cancel" },
+    {
+      type: "conversation.item.create",
+      item: {
+        type: "function_call_output",
+        call_id: "call-2",
+        output: "{\"ok\":2}",
+      },
+    },
+  ], "multiple tool results should share a single pending response.cancel")
+}
+
 function testWatchdogDefersWhileResponseIsActive() {
   const adapter = new OpenAIAdapter()
   setUpCapture(adapter)
@@ -88,6 +120,7 @@ function testWatchdogInjectsPromptWhenIdle() {
 function main() {
   testQueuesClientResponseUntilDone()
   testToolResultCancelsBeforeCreatingReplacementResponse()
+  testToolResultsDoNotSendDuplicateCancels()
   testWatchdogDefersWhileResponseIsActive()
   testWatchdogInjectsPromptWhenIdle()
   console.log("OpenAI response guard tests passed")

--- a/relay-server/test/test-openai-response-guard.ts
+++ b/relay-server/test/test-openai-response-guard.ts
@@ -11,7 +11,6 @@ function testQueuesClientResponseUntilDone() {
   assertEvents(adapter, [{ type: "response.create" }], "idle response.create should be sent immediately")
 
   resetCaptured(adapter)
-  emit(adapter, { type: "response.created" })
   adapter.createResponse()
   assertEvents(adapter, [], "active response should queue client response.create")
 
@@ -78,6 +77,19 @@ function testToolResultsDoNotSendDuplicateCancels() {
   ], "multiple tool results should share a single pending response.cancel")
 }
 
+function testErrorResetsActiveResponseState() {
+  const adapter = new OpenAIAdapter()
+  setUpCapture(adapter)
+
+  adapter.createResponse()
+  resetCaptured(adapter)
+
+  emit(adapter, { type: "error", error: { message: "upstream failed" } })
+  adapter.createResponse()
+
+  assertEvents(adapter, [{ type: "response.create" }], "error should clear active-response state so a new response can start")
+}
+
 function testWatchdogDefersWhileResponseIsActive() {
   const adapter = new OpenAIAdapter()
   setUpCapture(adapter)
@@ -121,6 +133,7 @@ function main() {
   testQueuesClientResponseUntilDone()
   testToolResultCancelsBeforeCreatingReplacementResponse()
   testToolResultsDoNotSendDuplicateCancels()
+  testErrorResetsActiveResponseState()
   testWatchdogDefersWhileResponseIsActive()
   testWatchdogInjectsPromptWhenIdle()
   console.log("OpenAI response guard tests passed")
@@ -136,12 +149,13 @@ function getCaptured(adapter: OpenAIAdapter): UpstreamEvent[] {
 function setUpCapture(adapter: OpenAIAdapter) {
   const state = adapter as unknown as {
     capturedEvents: UpstreamEvent[]
-    sendUpstream: (event: UpstreamEvent) => void
+    sendUpstream: (event: UpstreamEvent) => boolean
   }
 
   state.capturedEvents = []
   state.sendUpstream = (event: UpstreamEvent) => {
     getCaptured(adapter).push(event)
+    return true
   }
 }
 

--- a/relay-server/test/test-openai-response-guard.ts
+++ b/relay-server/test/test-openai-response-guard.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict"
+import { OpenAIAdapter } from "../src/adapters/openai.js"
+
+type UpstreamEvent = Record<string, unknown>
+
+function getCaptured(adapter: OpenAIAdapter): UpstreamEvent[] {
+  return (adapter as unknown as { capturedEvents: UpstreamEvent[] }).capturedEvents
+}
+
+function setUpCapture(adapter: OpenAIAdapter) {
+  ;(adapter as unknown as { capturedEvents: UpstreamEvent[] }).capturedEvents = []
+  ;(adapter as unknown as { sendUpstream: (event: UpstreamEvent) => void }).sendUpstream = (event: UpstreamEvent) => {
+    getCaptured(adapter).push(event)
+  }
+}
+
+function resetCaptured(adapter: OpenAIAdapter) {
+  getCaptured(adapter).length = 0
+}
+
+function emit(adapter: OpenAIAdapter, event: Record<string, unknown>) {
+  ;(adapter as unknown as { handleUpstreamEvent: (event: Record<string, unknown>) => void }).handleUpstreamEvent(event)
+}
+
+function assertEvents(adapter: OpenAIAdapter, expected: UpstreamEvent[], message: string) {
+  assert.deepEqual(getCaptured(adapter), expected, message)
+}
+
+function testQueuesClientResponseUntilDone() {
+  const adapter = new OpenAIAdapter()
+  setUpCapture(adapter)
+
+  adapter.createResponse()
+  assertEvents(adapter, [{ type: "response.create" }], "idle response.create should be sent immediately")
+
+  resetCaptured(adapter)
+  emit(adapter, { type: "response.created" })
+  adapter.createResponse()
+  assertEvents(adapter, [], "active response should queue client response.create")
+
+  emit(adapter, { type: "response.done" })
+  assertEvents(adapter, [{ type: "response.create" }], "queued client response.create should flush on response.done")
+}
+
+function testToolResultCancelsBeforeCreatingReplacementResponse() {
+  const adapter = new OpenAIAdapter()
+  setUpCapture(adapter)
+
+  emit(adapter, { type: "response.created" })
+  ;(adapter as unknown as { pendingToolCalls: number }).pendingToolCalls = 1
+
+  adapter.sendToolResult("call-123", "{\"ok\":true}")
+
+  assertEvents(adapter, [
+    {
+      type: "conversation.item.create",
+      item: {
+        type: "function_call_output",
+        call_id: "call-123",
+        output: "{\"ok\":true}",
+      },
+    },
+    { type: "response.cancel" },
+  ], "tool result should cancel the active response instead of colliding with response.create")
+
+  resetCaptured(adapter)
+  emit(adapter, { type: "response.done" })
+  assertEvents(adapter, [{ type: "response.create" }], "tool result should resume with a fresh response after cancel completes")
+}
+
+function testWatchdogDefersWhileResponseIsActive() {
+  const adapter = new OpenAIAdapter()
+  setUpCapture(adapter)
+
+  let resetCount = 0
+  ;(adapter as unknown as { resetWatchdog: () => void }).resetWatchdog = () => {
+    resetCount++
+  }
+
+  emit(adapter, { type: "response.created" })
+  ;(adapter as unknown as { handleWatchdogTimeout: () => void }).handleWatchdogTimeout()
+
+  assert.equal(resetCount, 1, "watchdog should reschedule itself while a response is active")
+  assertEvents(adapter, [], "watchdog should not inject a prompt during an active response")
+}
+
+function testWatchdogInjectsPromptWhenIdle() {
+  const adapter = new OpenAIAdapter()
+  setUpCapture(adapter)
+
+  ;(adapter as unknown as { handleWatchdogTimeout: () => void }).handleWatchdogTimeout()
+
+  assertEvents(adapter, [
+    {
+      type: "conversation.item.create",
+      item: {
+        type: "message",
+        role: "user",
+        content: [{
+          type: "input_text",
+          text: "(The user has been silent for a while. If you were mid-conversation, gently check if they're still there. If the conversation had naturally ended, stay quiet.)",
+        }],
+      },
+    },
+    { type: "response.create" },
+  ], "watchdog should inject its prompt and create a response when idle")
+}
+
+function main() {
+  testQueuesClientResponseUntilDone()
+  testToolResultCancelsBeforeCreatingReplacementResponse()
+  testWatchdogDefersWhileResponseIsActive()
+  testWatchdogInjectsPromptWhenIdle()
+  console.log("OpenAI response guard tests passed")
+}
+
+main()

--- a/relay-server/test/test-openai-response-guard.ts
+++ b/relay-server/test/test-openai-response-guard.ts
@@ -3,29 +3,6 @@ import { OpenAIAdapter } from "../src/adapters/openai.js"
 
 type UpstreamEvent = Record<string, unknown>
 
-function getCaptured(adapter: OpenAIAdapter): UpstreamEvent[] {
-  return (adapter as unknown as { capturedEvents: UpstreamEvent[] }).capturedEvents
-}
-
-function setUpCapture(adapter: OpenAIAdapter) {
-  ;(adapter as unknown as { capturedEvents: UpstreamEvent[] }).capturedEvents = []
-  ;(adapter as unknown as { sendUpstream: (event: UpstreamEvent) => void }).sendUpstream = (event: UpstreamEvent) => {
-    getCaptured(adapter).push(event)
-  }
-}
-
-function resetCaptured(adapter: OpenAIAdapter) {
-  getCaptured(adapter).length = 0
-}
-
-function emit(adapter: OpenAIAdapter, event: Record<string, unknown>) {
-  ;(adapter as unknown as { handleUpstreamEvent: (event: Record<string, unknown>) => void }).handleUpstreamEvent(event)
-}
-
-function assertEvents(adapter: OpenAIAdapter, expected: UpstreamEvent[], message: string) {
-  assert.deepEqual(getCaptured(adapter), expected, message)
-}
-
 function testQueuesClientResponseUntilDone() {
   const adapter = new OpenAIAdapter()
   setUpCapture(adapter)
@@ -47,7 +24,8 @@ function testToolResultCancelsBeforeCreatingReplacementResponse() {
   setUpCapture(adapter)
 
   emit(adapter, { type: "response.created" })
-  ;(adapter as unknown as { pendingToolCalls: number }).pendingToolCalls = 1
+  const state = adapter as unknown as { pendingToolCalls: number }
+  state.pendingToolCalls = 1
 
   adapter.sendToolResult("call-123", "{\"ok\":true}")
 
@@ -73,12 +51,13 @@ function testWatchdogDefersWhileResponseIsActive() {
   setUpCapture(adapter)
 
   let resetCount = 0
-  ;(adapter as unknown as { resetWatchdog: () => void }).resetWatchdog = () => {
+  const state = adapter as unknown as { resetWatchdog: () => void }
+  state.resetWatchdog = () => {
     resetCount++
   }
 
   emit(adapter, { type: "response.created" })
-  ;(adapter as unknown as { handleWatchdogTimeout: () => void }).handleWatchdogTimeout()
+  invokeWatchdog(adapter)
 
   assert.equal(resetCount, 1, "watchdog should reschedule itself while a response is active")
   assertEvents(adapter, [], "watchdog should not inject a prompt during an active response")
@@ -88,7 +67,7 @@ function testWatchdogInjectsPromptWhenIdle() {
   const adapter = new OpenAIAdapter()
   setUpCapture(adapter)
 
-  ;(adapter as unknown as { handleWatchdogTimeout: () => void }).handleWatchdogTimeout()
+  invokeWatchdog(adapter)
 
   assertEvents(adapter, [
     {
@@ -115,3 +94,38 @@ function main() {
 }
 
 main()
+
+function getCaptured(adapter: OpenAIAdapter): UpstreamEvent[] {
+  const state = adapter as unknown as { capturedEvents: UpstreamEvent[] }
+  return state.capturedEvents
+}
+
+function setUpCapture(adapter: OpenAIAdapter) {
+  const state = adapter as unknown as {
+    capturedEvents: UpstreamEvent[]
+    sendUpstream: (event: UpstreamEvent) => void
+  }
+
+  state.capturedEvents = []
+  state.sendUpstream = (event: UpstreamEvent) => {
+    getCaptured(adapter).push(event)
+  }
+}
+
+function resetCaptured(adapter: OpenAIAdapter) {
+  getCaptured(adapter).length = 0
+}
+
+function emit(adapter: OpenAIAdapter, event: Record<string, unknown>) {
+  const state = adapter as unknown as { handleUpstreamEvent: (event: Record<string, unknown>) => void }
+  state.handleUpstreamEvent(event)
+}
+
+function invokeWatchdog(adapter: OpenAIAdapter) {
+  const state = adapter as unknown as { handleWatchdogTimeout: () => void }
+  state.handleWatchdogTimeout()
+}
+
+function assertEvents(adapter: OpenAIAdapter, expected: UpstreamEvent[], message: string) {
+  assert.deepEqual(getCaptured(adapter), expected, message)
+}


### PR DESCRIPTION
## Summary
- add response lifecycle tracking and queued response creation in the OpenAI realtime adapter
- cancel in-flight responses before resuming after tool results to avoid active-response collisions
- add a focused regression test covering queued creates, cancel/resume behavior, and watchdog deferral

## Test plan
- [x] `npx tsx relay-server/test/test-openai-response-guard.ts`
- [x] `npx tsc --noEmit -p relay-server/tsconfig.json`

Refs NAN-618