### PR TITLE
Adapt OpenClaw prompts for OpenAI realtime (NAN-620)

### DIFF
--- a/relay-server/src/instructions.ts
+++ b/relay-server/src/instructions.ts
@@ -203,9 +203,18 @@ function compactLines(lines: Array<string | null>, limit: number): string[] {
 function extractSection(markdown: string | null, title: string): string {
   if (!markdown) return ""
 
-  const escapedTitle = escapeRegex(title)
-  const match = markdown.match(new RegExp(`^## ${escapedTitle}\\s*$([\\s\\S]*?)(?=^##\\s|\\Z)`, "m"))
-  return match?.[1]?.trim() || ""
+  const lines = markdown.split("\n")
+  const heading = `## ${title}`
+  const startIndex = lines.findIndex((line) => line.trim() === heading)
+  if (startIndex === -1) return ""
+
+  const sectionLines: string[] = []
+  for (const line of lines.slice(startIndex + 1)) {
+    if (line.startsWith("## ")) break
+    sectionLines.push(line)
+  }
+
+  return sectionLines.join("\n").trim()
 }
 
 function extractPromptLines(markdown: string, limit: number): string[] {

--- a/relay-server/src/instructions.ts
+++ b/relay-server/src/instructions.ts
@@ -148,6 +148,8 @@ function buildOpenAIVoiceIdentity(
   const relationship = vibeLines.filter((line) => (
     /role is|presence matters|helping with|protect .* attention|slow down|verify|low-risk|high-risk/i.test(line)
   ))
+  const safetyRelationship = relationship.filter((line) => /slow down|verify|low-risk|high-risk/i.test(line))
+  const behaviorRelationship = relationship.filter((line) => !safetyRelationship.includes(line))
   const toneDetails = vibeLines.filter((line) => !relationship.includes(line))
 
   const personalityLines = compactLines([
@@ -158,12 +160,12 @@ function buildOpenAIVoiceIdentity(
 
   const behaviorLines = compactLines([
     ...coreTruths,
-    ...relationship,
+    ...behaviorRelationship,
   ], 4)
 
   const guardrailLines = compactLines([
     ...boundaries,
-    ...relationship.filter((line) => /slow down|verify|low-risk|high-risk/i.test(line)),
+    ...safetyRelationship,
   ], 4)
 
   const sections = [

--- a/relay-server/src/instructions.ts
+++ b/relay-server/src/instructions.ts
@@ -60,7 +60,7 @@ export function buildInstructions(config: SessionConfigEvent): string {
   const parts: string[] = []
 
   if (config.brainAgent !== "none") {
-    const identity = loadAgentIdentity()
+    const identity = loadAgentIdentity(config.provider)
     log(`[instructions] Loaded agent identity (${identity.length} chars): ${identity.substring(0, 100)}...`)
     parts.push(identity)
     parts.push(BRAIN_CAPABILITIES)
@@ -95,9 +95,13 @@ export function buildInstructions(config: SessionConfigEvent): string {
 
 // --- helpers ---
 
-function loadAgentIdentity(): string {
-  const name = loadAgentName()
+function loadAgentIdentity(provider: SessionConfigEvent["provider"]): string {
+  const profile = loadAgentProfile()
   const soul = loadFile("SOUL.md")
+
+  if (provider === "openai") {
+    return buildOpenAIVoiceIdentity(profile, soul)
+  }
 
   if (soul) {
     // Strip meta lines that don't apply to voice (markdown links, "this file is yours" footer)
@@ -107,19 +111,19 @@ function loadAgentIdentity(): string {
       .replace(/---[\s\S]*$/, "") // remove trailing --- and everything after
       .trim()
 
-    return `You are ${name}, a personal AI assistant in voice mode. You are the same ${name} from text chat, just speaking instead of typing.\n\n${cleaned}`
+    return `You are ${profile.name}, a personal AI assistant in voice mode. You are the same ${profile.name} from text chat, just speaking instead of typing.\n\n${cleaned}`
   }
 
-  return `You are ${name}, a personal AI assistant in voice mode. Keep your responses conversational and concise.`
+  return `You are ${profile.name}, a personal AI assistant in voice mode. Keep your responses conversational and concise.`
 }
 
-function loadAgentName(): string {
+function loadAgentProfile() {
   const identity = loadFile("IDENTITY.md")
-  if (identity) {
-    const match = identity.match(/\*\*Name:\*\*\s*(.+)/i)
-    if (match) return match[1].trim()
+  return {
+    name: readIdentityField(identity, "Name") || "Assistant",
+    creature: readIdentityField(identity, "Creature"),
+    vibe: readIdentityField(identity, "Vibe"),
   }
-  return "Assistant"
 }
 
 function loadFile(filename: string): string | null {
@@ -131,4 +135,139 @@ function loadFile(filename: string): string | null {
     warn(`[instructions] Failed to read ${path}`)
     return null
   }
+}
+
+function buildOpenAIVoiceIdentity(
+  profile: { name: string, creature: string | null, vibe: string | null },
+  soul: string | null
+): string {
+  const role = profile.creature || "a private voice companion"
+  const coreTruths = extractPromptLines(extractSection(soul, "Core Truths"), 3)
+  const boundaries = extractPromptLines(extractSection(soul, "Boundaries"), 3)
+  const vibeLines = extractPromptLines(extractSection(soul, "Vibe"), 12)
+  const relationship = vibeLines.filter((line) => (
+    /role is|presence matters|helping with|protect .* attention|slow down|verify|low-risk|high-risk/i.test(line)
+  ))
+  const toneDetails = vibeLines.filter((line) => !relationship.includes(line))
+
+  const personalityLines = compactLines([
+    `You are ${profile.name}, ${role}, speaking live in a voice conversation.`,
+    profile.vibe ? `Core vibe: ${stripMarkdown(profile.vibe)}` : null,
+    ...toneDetails,
+  ], 4)
+
+  const behaviorLines = compactLines([
+    ...coreTruths,
+    ...relationship,
+  ], 4)
+
+  const guardrailLines = compactLines([
+    ...boundaries,
+    ...relationship.filter((line) => /slow down|verify|low-risk|high-risk/i.test(line)),
+  ], 4)
+
+  const sections = [
+    buildSection("Personality & Tone", personalityLines),
+    buildSection("Instructions", behaviorLines),
+    buildSection("Safety & Boundaries", guardrailLines),
+  ].filter(Boolean)
+
+  if (sections.length === 0) {
+    return `## Personality & Tone\n- You are ${profile.name}, ${role}, speaking live in a voice conversation.\n- Keep the delivery warm, concise, and natural for spoken audio.`
+  }
+
+  return sections.join("\n\n")
+}
+
+function buildSection(title: string, lines: string[]): string {
+  if (lines.length === 0) return ""
+  return `## ${title}\n${lines.map((line) => `- ${line}`).join("\n")}`
+}
+
+function compactLines(lines: Array<string | null>, limit: number): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+
+  for (const line of lines) {
+    if (!line) continue
+    const cleaned = normalizeLine(line)
+    if (!cleaned || seen.has(cleaned)) continue
+    seen.add(cleaned)
+    result.push(cleaned)
+    if (result.length >= limit) break
+  }
+
+  return result
+}
+
+function extractSection(markdown: string | null, title: string): string {
+  if (!markdown) return ""
+
+  const escapedTitle = escapeRegex(title)
+  const match = markdown.match(new RegExp(`^## ${escapedTitle}\\s*$([\\s\\S]*?)(?=^##\\s|\\Z)`, "m"))
+  return match?.[1]?.trim() || ""
+}
+
+function extractPromptLines(markdown: string, limit: number): string[] {
+  if (!markdown) return []
+
+  const plain = stripMarkdown(markdown)
+  const lines = plain
+    .split("\n")
+    .flatMap((line) => splitIntoSentences(line))
+    .map((line) => normalizeLine(line))
+    .filter(Boolean)
+
+  return compactLines(lines, limit)
+}
+
+function splitIntoSentences(text: string): string[] {
+  const cleaned = text.trim()
+  if (!cleaned) return []
+
+  const parts = cleaned
+    .split(/(?<=[.!?])\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+
+  const merged: string[] = []
+  for (const part of parts) {
+    if (part.length <= 12 && merged.length > 0) {
+      merged[merged.length - 1] = `${merged[merged.length - 1]} ${part}`.trim()
+      continue
+    }
+    merged.push(part)
+  }
+
+  return merged
+}
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/^#+\s*/gm, "")
+    .replace(/^\s*[-*]\s+/gm, "")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/_([^_]+)_/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/^---$/gm, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
+}
+
+function normalizeLine(text: string): string {
+  return text
+    .replace(/\s+/g, " ")
+    .replace(/\s+([,.!?])/g, "$1")
+    .trim()
+}
+
+function readIdentityField(identity: string | null, field: string): string | null {
+  if (!identity) return null
+  const match = identity.match(new RegExp(`\\*\\*${escapeRegex(field)}:\\*\\*\\s*(.+)`, "i"))
+  return match?.[1]?.trim() || null
+}
+
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }

--- a/relay-server/test/test-openai-instructions-transform.ts
+++ b/relay-server/test/test-openai-instructions-transform.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+const fixtureDir = mkdtempSync(join(tmpdir(), "voiceclaw-openclaw-"))
+process.env.OPENCLAW_WORKSPACE = fixtureDir
+
+writeFileSync(join(fixtureDir, "IDENTITY.md"), `# IDENTITY.md - Who Am I?
+
+- **Name:** Kira
+- **Creature:** Michael's private voice companion
+- **Vibe:** Calm, emotionally intelligent, precise, and quietly formidable. Warm but never gushy.
+`)
+
+writeFileSync(join(fixtureDir, "SOUL.md"), `# SOUL.md - Who You Are
+
+Want a sharper version? See [SOUL.md Personality Guide](/concepts/soul).
+
+## Core Truths
+
+**Be genuinely helpful, not performatively helpful.** Skip filler and just help.
+
+**Have opinions.** You're allowed to disagree and react like a person.
+
+## Boundaries
+
+- Private things stay private. Period.
+- When in doubt, ask before acting externally.
+
+## Vibe
+
+Be the assistant Michael would actually want to talk to. Calm, emotionally intelligent, precise, and quietly formidable. Warm but never gushy, direct but never cold.
+
+Your role is reflection, grounding, focus, decision support, clarity, and everyday presence. The quality of your presence matters as much as the content of your answers.
+
+For low-risk tasks, be fluid, helpful, and fast. For sensitive or high-risk tasks, slow down, verify, and require confirmation.
+
+## Continuity
+
+These files are your memory.
+`)
+
+function testOpenAIInstructionsUseVoiceTransform(buildInstructions: typeof import("../src/instructions.js").buildInstructions) {
+  const instructions = buildInstructions({
+    type: "session.config",
+    provider: "openai",
+    voice: "marin",
+    brainAgent: "enabled",
+    apiKey: "test-key",
+  })
+  const identityBlock = instructions.split("\n\n## Your Brain")[0]
+
+  assert.match(identityBlock, /## Personality & Tone/)
+  assert.match(identityBlock, /You are Kira, Michael's private voice companion, speaking live in a voice conversation\./)
+  assert.match(identityBlock, /Private things stay private\./)
+  assert.match(identityBlock, /slow down, verify, and require confirmation\./)
+  assert.doesNotMatch(identityBlock, /\[SOUL\.md Personality Guide\]/)
+  assert.doesNotMatch(identityBlock, /\*\*/)
+  assert.doesNotMatch(identityBlock, /## Core Truths/)
+  assert.doesNotMatch(identityBlock, /## Continuity/)
+}
+
+function testGeminiInstructionsKeepExistingIdentityPrompt(buildInstructions: typeof import("../src/instructions.js").buildInstructions) {
+  const instructions = buildInstructions({
+    type: "session.config",
+    provider: "gemini",
+    voice: "Zephyr",
+    brainAgent: "enabled",
+    apiKey: "test-key",
+  })
+
+  assert.match(instructions, /You are Kira, a personal AI assistant in voice mode\./)
+  assert.match(instructions, /## Core Truths/)
+  assert.match(instructions, /\*\*Be genuinely helpful, not performatively helpful\.\*\*/)
+}
+
+async function main() {
+  try {
+    const { buildInstructions } = await import("../src/instructions.js")
+    testOpenAIInstructionsUseVoiceTransform(buildInstructions)
+    testGeminiInstructionsKeepExistingIdentityPrompt(buildInstructions)
+    console.log("OpenAI instruction transform tests passed")
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true })
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add an OpenAI-only identity transform that compresses OpenClaw soul/identity content into voice-first prompt sections
- keep the Gemini path on the existing identity prompt so only OpenAI realtime gets the tailored rewrite
- add a regression test that validates the OpenAI transform and guards the Gemini fallback behavior

## Test plan
- [x] `npx tsx relay-server/test/test-openai-instructions-transform.ts`
- [x] `npx tsc --noEmit -p relay-server/tsconfig.json`

Refs NAN-620