### PR TITLE
Use default system audio route for voice I/O

### DIFF
--- a/mobile/modules/expo-custom-pipeline/ios/Pipeline/AudioCoordinator.swift
+++ b/mobile/modules/expo-custom-pipeline/ios/Pipeline/AudioCoordinator.swift
@@ -49,7 +49,7 @@ class AudioCoordinator {
             try session.setCategory(
                 .playAndRecord,
                 mode: .voiceChat,
-                options: [.defaultToSpeaker, .allowBluetooth]
+                options: [.allowBluetooth]
             )
             try session.setActive(true, options: .notifyOthersOnDeactivation)
         } catch {

--- a/mobile/modules/expo-custom-pipeline/ios/Pipeline/BargeInDetector.swift
+++ b/mobile/modules/expo-custom-pipeline/ios/Pipeline/BargeInDetector.swift
@@ -56,8 +56,8 @@ class BargeInDetector {
     private func configureAudioSession() {
         let session = AVAudioSession.sharedInstance()
         do {
-            // voiceChat mode enables AEC so TTS echo is suppressed
-            try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.defaultToSpeaker, .allowBluetooth])
+            // voiceChat mode enables AEC so TTS echo is suppressed while still following the system route
+            try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.allowBluetooth])
             try session.setActive(true, options: .notifyOthersOnDeactivation)
             print("[BargeInDetector] Audio session configured with AEC (voiceChat mode)")
         } catch {

--- a/mobile/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleSTTProvider.swift
+++ b/mobile/modules/expo-custom-pipeline/ios/Pipeline/Providers/AppleSTTProvider.swift
@@ -194,7 +194,7 @@ class AppleSTTProvider: STTProvider {
         do {
             try audioSession.setCategory(
                 .playAndRecord, mode: .voiceChat,
-                options: [.defaultToSpeaker, .allowBluetooth]
+                options: [.allowBluetooth]
             )
             try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
             print("[AppleSTTProvider] Audio session configured OK — category: \(audioSession.category.rawValue), mode: \(audioSession.mode.rawValue)")

--- a/mobile/modules/expo-custom-pipeline/ios/Pipeline/Providers/ElevenLabsTTSProvider.swift
+++ b/mobile/modules/expo-custom-pipeline/ios/Pipeline/Providers/ElevenLabsTTSProvider.swift
@@ -215,7 +215,7 @@ private extension ElevenLabsTTSProvider {
         do {
             try audioSession.setCategory(
                 .playAndRecord, mode: .voiceChat,
-                options: [.defaultToSpeaker, .allowBluetooth]
+                options: [.allowBluetooth]
             )
             try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
             logger.debug("[ElevenLabs] Audio session configured for playback")

--- a/mobile/modules/expo-realtime-audio/ios/RealtimeAudioManager.swift
+++ b/mobile/modules/expo-realtime-audio/ios/RealtimeAudioManager.swift
@@ -49,8 +49,7 @@ class RealtimeAudioManager {
         guard !isCapturing else { return }
 
         let session = AVAudioSession.sharedInstance()
-        try session.setCategory(.playAndRecord, mode: .videoChat, options: [.defaultToSpeaker, .allowBluetooth])
-        try session.overrideOutputAudioPort(.speaker)
+        try session.setCategory(.playAndRecord, mode: .videoChat, options: [.allowBluetooth])
         try session.setActive(true)
 
         // AEC without .voiceChat's aggressive speaker AGC
@@ -163,8 +162,6 @@ class RealtimeAudioManager {
         }
 
         try engine.start()
-        // Re-assert speaker routing after engine start (iOS may reset it)
-        try? session.overrideOutputAudioPort(.speaker)
         playerNode.play()
 
         self.audioEngine = engine


### PR DESCRIPTION
## Summary
- stop forcing speaker output in the iOS voice audio paths
- let VoiceClaw follow the current system audio route for output and microphone input
- keep existing voice chat / bluetooth session behavior intact

## Testing
- reviewed diff with Claude Code
- validated branch push and patch shape

## Notes
- this changes route behavior to follow the system default instead of always pushing audio to speaker