### PR TITLE
Langfuse tracing (NAN-622) — scaffold + soft-disable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 .yarn/
+dist/
 
 # macOS
 .DS_Store

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -913,6 +913,10 @@ export default function ChatScreen() {
     const volumeStr = await getSetting('realtime_volume')
     const volume = volumeStr ? parseFloat(volumeStr) : 2.0
     const systemPrompt = (await getSetting('system_prompt')) || ''
+    const tracingPref = await getSetting('tracing_enabled')
+    const tracingEnabled = tracingPref === null || tracingPref === undefined
+      ? __DEV__
+      : tracingPref === 'true'
 
     if (!apiKey) {
       await addMessage(conversationId, 'assistant', 'Please configure your API key in the Realtime settings first.')
@@ -952,6 +956,7 @@ export default function ChatScreen() {
       },
       instructionsOverride: systemPrompt || undefined,
       conversationHistory: recentMessages.length > 0 ? recentMessages : undefined,
+      tracingEnabled,
     })
 
     return true

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -91,6 +91,9 @@ export default function SettingsScreen() {
   // Show latency
   const [showLatency, setShowLatencyState] = useState(false)
 
+  // Langfuse tracing — defaults on in dev builds, off in release
+  const [tracingEnabled, setTracingEnabled] = useState<boolean>(__DEV__)
+
   // Kokoro model download state
   const [kokoroStatus, setKokoroStatus] = useState<'checking' | 'ready' | 'not-downloaded' | 'downloading' | 'error' | 'unavailable'>('checking')
 
@@ -230,6 +233,9 @@ export default function SettingsScreen() {
       if (dm === 'true') setDebugMode(true)
       const sl = await getSetting('show_latency')
       if (sl === 'true') setShowLatencyState(true)
+      const tr = await getSetting('tracing_enabled')
+      if (tr === 'true') setTracingEnabled(true)
+      else if (tr === 'false') setTracingEnabled(false)
 
       loadedRef.current = true
     })()
@@ -411,6 +417,11 @@ export default function SettingsScreen() {
   const toggleShowLatency = useCallback((v: boolean) => {
     setShowLatencyState(v)
     setSetting('show_latency', v ? 'true' : 'false')
+  }, [])
+
+  const toggleTracing = useCallback((v: boolean) => {
+    setTracingEnabled(v)
+    setSetting('tracing_enabled', v ? 'true' : 'false')
   }, [])
 
   return (
@@ -831,6 +842,24 @@ export default function SettingsScreen() {
               testID="show-latency-toggle"
               value={showLatency}
               onValueChange={toggleShowLatency}
+            />
+          </View>
+        </Card>
+
+        <Card testID="tracing-card" className="gap-2 p-4">
+          <View className="flex-row items-center justify-between">
+            <View className="flex-1">
+              <Text className="text-lg font-semibold text-foreground">Send Latency Traces</Text>
+              <Text className="text-sm text-muted-foreground">
+                Post per-turn latency measurements to the relay so they
+                show up in Langfuse. Dev builds default on; release
+                builds default off.
+              </Text>
+            </View>
+            <Switch
+              testID="tracing-toggle"
+              value={tracingEnabled}
+              onValueChange={toggleTracing}
             />
           </View>
         </Card>

--- a/mobile/lib/use-realtime.ts
+++ b/mobile/lib/use-realtime.ts
@@ -42,10 +42,10 @@ export interface RealtimeControls {
   sessionId: string | null
 }
 
-// Gate mobile telemetry forwarding. Defaults off so production/TestFlight
-// builds never phone home with latency measurements — dev machines opt in
-// by setting EXPO_PUBLIC_ENABLE_TRACING=1.
-const TRACING_ENABLED = process.env.EXPO_PUBLIC_ENABLE_TRACING === '1'
+// Gate mobile telemetry forwarding. Defaults on in dev builds so we measure
+// latency while iterating; release builds stay silent unless explicitly
+// enabled via EXPO_PUBLIC_ENABLE_TRACING=1.
+const TRACING_ENABLED = __DEV__ || process.env.EXPO_PUBLIC_ENABLE_TRACING === '1'
 
 export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
   const wsRef = useRef<WebSocket | null>(null)

--- a/mobile/lib/use-realtime.ts
+++ b/mobile/lib/use-realtime.ts
@@ -42,15 +42,27 @@ export interface RealtimeControls {
   sessionId: string | null
 }
 
+// Gate mobile telemetry forwarding. Defaults off so production/TestFlight
+// builds never phone home with latency measurements — dev machines opt in
+// by setting EXPO_PUBLIC_ENABLE_TRACING=1.
+const TRACING_ENABLED = process.env.EXPO_PUBLIC_ENABLE_TRACING === '1'
+
 export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
   const wsRef = useRef<WebSocket | null>(null)
   const configRef = useRef<RealtimeConfig | null>(null)
   const userStoppedRef = useRef(false)
   const mutedRef = useRef(false)
+  const turnStartedAtRef = useRef<number | null>(null)
   const [isConnected, setIsConnected] = useState(false)
   const [sessionId, setSessionId] = useState<string | null>(null)
   const callbacksRef = useRef(callbacks)
   callbacksRef.current = callbacks
+
+  const sendTiming = useCallback((phase: string, ms: number) => {
+    if (!TRACING_ENABLED) return
+    if (wsRef.current?.readyState !== WebSocket.OPEN) return
+    wsRef.current.send(JSON.stringify({ type: 'client.timing', phase, ms }))
+  }, [])
 
   // Clean up on unmount
   useEffect(() => {
@@ -105,6 +117,10 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
       case 'audio.delta':
         // Forward to native module for playback
         ExpoRealtimeAudioModule.playAudio(data.data)
+        if (turnStartedAtRef.current != null) {
+          sendTiming('ttft_audio', Date.now() - turnStartedAtRef.current)
+          turnStartedAtRef.current = null
+        }
         break
 
       case 'transcript.delta':
@@ -126,6 +142,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
       case 'turn.started':
         // Barge-in: stop playback when user starts speaking
         ExpoRealtimeAudioModule.stopPlayback()
+        turnStartedAtRef.current = Date.now()
         cb.onTurnStarted?.()
         break
 

--- a/mobile/lib/use-realtime.ts
+++ b/mobile/lib/use-realtime.ts
@@ -53,15 +53,16 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
   const userStoppedRef = useRef(false)
   const mutedRef = useRef(false)
   const turnStartedAtRef = useRef<number | null>(null)
+  const turnIdRef = useRef<string | null>(null)
   const [isConnected, setIsConnected] = useState(false)
   const [sessionId, setSessionId] = useState<string | null>(null)
   const callbacksRef = useRef(callbacks)
   callbacksRef.current = callbacks
 
-  const sendTiming = useCallback((phase: string, ms: number) => {
+  const sendTiming = useCallback((phase: string, ms: number, turnId: string | null) => {
     if (!TRACING_ENABLED) return
     if (wsRef.current?.readyState !== WebSocket.OPEN) return
-    wsRef.current.send(JSON.stringify({ type: 'client.timing', phase, ms }))
+    wsRef.current.send(JSON.stringify({ type: 'client.timing', phase, ms, turnId: turnId ?? undefined }))
   }, [])
 
   // Clean up on unmount
@@ -118,7 +119,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
         // Forward to native module for playback
         ExpoRealtimeAudioModule.playAudio(data.data)
         if (turnStartedAtRef.current != null) {
-          sendTiming('ttft_audio', Date.now() - turnStartedAtRef.current)
+          sendTiming('ttft_audio', Date.now() - turnStartedAtRef.current, turnIdRef.current)
           turnStartedAtRef.current = null
         }
         break
@@ -143,6 +144,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
         // Barge-in: stop playback when user starts speaking
         ExpoRealtimeAudioModule.stopPlayback()
         turnStartedAtRef.current = Date.now()
+        turnIdRef.current = data.turnId ?? null
         cb.onTurnStarted?.()
         break
 

--- a/mobile/lib/use-realtime.ts
+++ b/mobile/lib/use-realtime.ts
@@ -19,6 +19,7 @@ export interface RealtimeConfig {
   }
   instructionsOverride?: string
   conversationHistory?: { role: 'user' | 'assistant', text: string }[]
+  tracingEnabled?: boolean
 }
 
 export interface RealtimeCallbacks {
@@ -42,11 +43,6 @@ export interface RealtimeControls {
   sessionId: string | null
 }
 
-// Gate mobile telemetry forwarding. Defaults on in dev builds so we measure
-// latency while iterating; release builds stay silent unless explicitly
-// enabled via EXPO_PUBLIC_ENABLE_TRACING=1.
-const TRACING_ENABLED = __DEV__ || process.env.EXPO_PUBLIC_ENABLE_TRACING === '1'
-
 export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
   const wsRef = useRef<WebSocket | null>(null)
   const configRef = useRef<RealtimeConfig | null>(null)
@@ -60,7 +56,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
   callbacksRef.current = callbacks
 
   const sendTiming = useCallback((phase: string, ms: number, turnId: string | null) => {
-    if (!TRACING_ENABLED) return
+    if (!configRef.current?.tracingEnabled) return
     if (wsRef.current?.readyState !== WebSocket.OPEN) return
     wsRef.current.send(JSON.stringify({ type: 'client.timing', phase, ms, turnId: turnId ?? undefined }))
   }, [])

--- a/relay-server/.env.example
+++ b/relay-server/.env.example
@@ -12,3 +12,10 @@ OPENCLAW_GATEWAY_AUTH_TOKEN=
 
 # Server port (default: 8080)
 # PORT=8080
+
+# Langfuse tracing (optional — relay runs fine without these)
+# Cloud: https://cloud.langfuse.com (EU) or https://us.cloud.langfuse.com (US)
+# Self-hosted: point at your own deployment
+# LANGFUSE_HOST=https://cloud.langfuse.com
+# LANGFUSE_PUBLIC_KEY=pk-lf-...
+# LANGFUSE_SECRET_KEY=sk-lf-...

--- a/relay-server/.env.example
+++ b/relay-server/.env.example
@@ -16,6 +16,6 @@ OPENCLAW_GATEWAY_AUTH_TOKEN=
 # Langfuse tracing (optional — relay runs fine without these)
 # Cloud: https://cloud.langfuse.com (EU) or https://us.cloud.langfuse.com (US)
 # Self-hosted: point at your own deployment
-# LANGFUSE_HOST=https://cloud.langfuse.com
+# LANGFUSE_BASE_URL=https://us.cloud.langfuse.com
 # LANGFUSE_PUBLIC_KEY=pk-lf-...
 # LANGFUSE_SECRET_KEY=sk-lf-...

--- a/relay-server/README.md
+++ b/relay-server/README.md
@@ -31,3 +31,27 @@ The relay handles:
 - Server-side tool execution (brain agent)
 - Watchdog for stale connections
 - Audio passthrough (PCM16 24kHz)
+
+## Tracing (optional)
+
+The relay can emit per-turn traces to [Langfuse](https://langfuse.com) so you
+can measure latency, inspect prompts/responses, and attribute token/audio
+cost per voice turn.
+
+Tracing is **off by default**. Set the keys in `.env` to enable:
+
+```
+LANGFUSE_BASE_URL=https://us.cloud.langfuse.com   # or EU / self-hosted
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...
+```
+
+When configured, each WebSocket connection maps to a Langfuse **session**
+and each voice turn is a **generation** span. Server-side tool calls
+(e.g. `ask_brain`) nest as tool spans; they may span multiple turns
+since async tools typically resolve on the next turn.
+
+Mobile devices can also post latency measurements via `client.timing`
+events (e.g. `ttft_audio`, turn.started → first TTS byte). Mobile
+emission is gated behind `EXPO_PUBLIC_ENABLE_TRACING=1` so release
+builds ship with no telemetry unless explicitly enabled.

--- a/relay-server/README.md
+++ b/relay-server/README.md
@@ -53,5 +53,5 @@ since async tools typically resolve on the next turn.
 
 Mobile devices can also post latency measurements via `client.timing`
 events (e.g. `ttft_audio`, turn.started → first TTS byte). Mobile
-emission is gated behind `EXPO_PUBLIC_ENABLE_TRACING=1` so release
-builds ship with no telemetry unless explicitly enabled.
+emission is on by default in dev builds (`__DEV__`) and off in release
+builds unless `EXPO_PUBLIC_ENABLE_TRACING=1` is set at build time.

--- a/relay-server/package.json
+++ b/relay-server/package.json
@@ -2,12 +2,18 @@
   "name": "relay-server",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js"
   },
   "dependencies": {
+    "@langfuse/core": "^5.1.0",
+    "@langfuse/otel": "^5.1.0",
+    "@langfuse/tracing": "^5.1.0",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/sdk-node": "^0.214.0",
     "dotenv": "^16.4.7",
     "express": "^5.1.0",
     "ws": "^8.18.2"

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -425,6 +425,15 @@ export class GeminiAdapter implements ProviderAdapter {
 
     if (msg.usageMetadata) {
       log(`[gemini] Usage: ${JSON.stringify(msg.usageMetadata)}`)
+      const u = msg.usageMetadata
+      this.sendToClient?.({
+        type: "usage.metrics",
+        promptTokens: u.promptTokenCount,
+        completionTokens: u.responseTokenCount,
+        totalTokens: u.totalTokenCount,
+        inputAudioTokens: findModalityTokens(u.promptTokensDetails, "AUDIO"),
+        outputAudioTokens: findModalityTokens(u.responseTokensDetails, "AUDIO"),
+      })
       return
     }
   }
@@ -682,4 +691,11 @@ function downsample24to16(base64Audio: string): string {
   }
 
   return outputBuf.toString("base64")
+}
+
+function findModalityTokens(
+  details: { modality?: string, tokenCount?: number }[] | undefined,
+  modality: string,
+): number | undefined {
+  return details?.find((d) => d.modality === modality)?.tokenCount
 }

--- a/relay-server/src/adapters/openai.ts
+++ b/relay-server/src/adapters/openai.ts
@@ -386,9 +386,21 @@ export class OpenAIAdapter implements ProviderAdapter {
       // Response lifecycle
       case "response.created":
         break
-      case "response.done":
+      case "response.done": {
         this.sendToClient?.({ type: "turn.ended" })
+        const usage = event.response?.usage
+        if (usage) {
+          this.sendToClient?.({
+            type: "usage.metrics",
+            promptTokens: usage.input_tokens,
+            completionTokens: usage.output_tokens,
+            totalTokens: usage.total_tokens,
+            inputAudioTokens: usage.input_token_details?.audio_tokens,
+            outputAudioTokens: usage.output_token_details?.audio_tokens,
+          })
+        }
         break
+      }
 
       // Errors
       case "error":

--- a/relay-server/src/index.ts
+++ b/relay-server/src/index.ts
@@ -33,18 +33,26 @@ wss.on("connection", (ws) => {
   new RelaySession(ws)
 })
 
-function shutdown() {
+async function shutdown() {
   log("Shutting down...")
+  // Force exit if graceful shutdown hangs
+  const forceExit = setTimeout(() => process.exit(1), 3000)
+  forceExit.unref()
+
+  // Close client sockets first so each RelaySession runs its cleanup()
+  // (endSession → adapter disconnect → transcript sync) before we tear
+  // down the OTel exporter that ships the final spans.
   wss.clients.forEach((ws) => ws.close())
   wss.close()
-  void shutdownLangfuse()
-  server.close(() => process.exit(0))
-  // Force exit if graceful shutdown takes too long
-  setTimeout(() => process.exit(1), 3000)
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+  // Drain pending spans before exiting — otherwise the last turn of every
+  // active session gets dropped on SIGTERM.
+  await shutdownLangfuse()
+  process.exit(0)
 }
 
-process.on("SIGTERM", shutdown)
-process.on("SIGINT", shutdown)
+process.on("SIGTERM", () => { void shutdown() })
+process.on("SIGINT", () => { void shutdown() })
 
 server.listen(PORT, () => {
   const lanIP = getLanIP()

--- a/relay-server/src/index.ts
+++ b/relay-server/src/index.ts
@@ -1,4 +1,9 @@
 import "dotenv/config"
+import { initLangfuse, shutdownLangfuse } from "./tracing/langfuse.js"
+// initLangfuse must run BEFORE any module that may create OTEL spans on import,
+// since the NodeSDK replaces the global TracerProvider.
+initLangfuse()
+
 import express from "express"
 import { createServer } from "node:http"
 import { networkInterfaces } from "node:os"
@@ -32,6 +37,7 @@ function shutdown() {
   log("Shutting down...")
   wss.clients.forEach((ws) => ws.close())
   wss.close()
+  void shutdownLangfuse()
   server.close(() => process.exit(0))
   // Force exit if graceful shutdown takes too long
   setTimeout(() => process.exit(1), 3000)

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -12,6 +12,7 @@ import { createAdapter } from "./adapters/index.js"
 import { handleToolCall } from "./tools/index.js"
 import { askBrain } from "./tools/brain.js"
 import { log, error as logError } from "./log.js"
+import { TurnTracer } from "./tracing/turn-tracer.js"
 const SERVER_SIDE_TOOLS = new Set(["echo_tool", "ask_brain"])
 
 export class RelaySession {
@@ -21,6 +22,7 @@ export class RelaySession {
   private config: SessionConfigEvent | null = null
   private startedAt: number = Date.now()
   private turnCount: number = 0
+  private tracer = new TurnTracer()
 
   constructor(ws: WebSocket) {
     this.ws = ws
@@ -44,6 +46,23 @@ export class RelaySession {
   }
 
   private handleRelayEvent(event: RelayEvent) {
+    // Tracing side-effects — don't alter the forwarded event stream.
+    switch (event.type) {
+      case "turn.started":
+        this.tracer.startTurn()
+        break
+      case "transcript.delta":
+        if (event.role === "user") this.tracer.appendUserText(event.text)
+        else this.tracer.appendAssistantText(event.text)
+        break
+      case "tool.call":
+        this.tracer.startToolCall(event.callId, event.name, event.arguments)
+        break
+      case "turn.ended":
+        this.tracer.endTurn()
+        break
+    }
+
     // Intercept tool calls — handle server-side tools, forward the rest to client
     if (event.type === "tool.call" && SERVER_SIDE_TOOLS.has(event.name)) {
       this.handleServerToolCall(event.callId, event.name, event.arguments)
@@ -64,6 +83,7 @@ export class RelaySession {
     // Synchronous tools
     const syncResult = handleToolCall(name, args)
     if (syncResult !== null) {
+      this.tracer.endToolCall(callId, syncResult)
       this.adapter?.sendToolResult(callId, syncResult)
       return
     }
@@ -107,11 +127,14 @@ export class RelaySession {
 
       const brainMs = Date.now() - brainStart
       log(`[session:${this.id}] ask_brain completed in ${brainMs}ms`)
+      this.tracer.endToolCall(callId, result)
       this.adapter?.sendToolResult(callId, result)
     } catch (err) {
       const message = err instanceof Error ? err.message : "brain agent call failed"
       logError(`[session:${this.id}] ask_brain error:`, message)
-      this.adapter?.sendToolResult(callId, JSON.stringify({ error: message }))
+      const errorPayload = JSON.stringify({ error: message })
+      this.tracer.endToolCall(callId, errorPayload, message)
+      this.adapter?.sendToolResult(callId, errorPayload)
     }
   }
 
@@ -141,6 +164,7 @@ export class RelaySession {
         this.adapter?.cancelResponse()
         break
       case "tool.result":
+        this.tracer.endToolCall(event.callId, event.output)
         this.adapter?.sendToolResult(event.callId, event.output)
         break
       default:
@@ -168,6 +192,7 @@ export class RelaySession {
     log(`[session:${this.id}] Auth passed, creating ${config.provider} adapter (model=${config.model || "default"})`)
     this.config = config
     this.startedAt = Date.now()
+    this.tracer.startSession(config.sessionKey ?? this.id, null, config.model ?? null)
 
     try {
       this.adapter = createAdapter(config.provider)
@@ -184,6 +209,7 @@ export class RelaySession {
 
   private cleanup() {
     log(`[session:${this.id}] Disconnecting`)
+    this.tracer.endSession()
     this.syncTranscriptToBrain()
     this.adapter?.disconnect()
     this.adapter = null

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -78,6 +78,16 @@ export class RelaySession {
       this.turnCount++
     }
 
+    // Stamp the active turnId onto outbound turn.started so the client can
+    // echo it back in client.timing events and we can attribute correctly.
+    if (event.type === "turn.started") {
+      const turnId = this.tracer.getActiveTurnId()
+      if (turnId) {
+        this.send({ ...event, turnId })
+        return
+      }
+    }
+
     this.send(event)
   }
 
@@ -172,7 +182,7 @@ export class RelaySession {
         this.adapter?.sendToolResult(event.callId, event.output)
         break
       case "client.timing":
-        this.tracer.attachClientTiming(event.phase, event.ms)
+        this.tracer.attachClientTiming(event.phase, event.ms, event.turnId)
         break
       default:
         this.sendError(`unknown event type: ${(event as { type: string }).type}`, 400)
@@ -185,6 +195,11 @@ export class RelaySession {
       log(`[session:${this.id}] Replacing existing adapter`)
       this.adapter.disconnect()
       this.adapter = null
+      // Close out any spans still attributed to the old logical session before
+      // startSession() overwrites session metadata. Otherwise leftover
+      // generations/tool spans stay open and late tool results land on the
+      // wrong session.
+      this.tracer.endSession()
     }
 
     // Validate API key

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -61,6 +61,10 @@ export class RelaySession {
       case "turn.ended":
         this.tracer.endTurn()
         break
+      case "usage.metrics":
+        this.tracer.attachUsage(event)
+        // Internal only — do not forward to client
+        return
     }
 
     // Intercept tool calls — handle server-side tools, forward the rest to client

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -167,6 +167,9 @@ export class RelaySession {
         this.tracer.endToolCall(event.callId, event.output)
         this.adapter?.sendToolResult(event.callId, event.output)
         break
+      case "client.timing":
+        this.tracer.attachClientTiming(event.phase, event.ms)
+        break
       default:
         this.sendError(`unknown event type: ${(event as { type: string }).type}`, 400)
     }

--- a/relay-server/src/test-page.ts
+++ b/relay-server/src/test-page.ts
@@ -70,9 +70,9 @@ export function getTestPageHTML(host: string): string {
   <div class="section">
     <label>Model</label>
     <select id="model">
-      <option value="gpt-realtime-mini" selected>GPT Realtime Mini</option>
-      <option value="gpt-realtime-1.5">GPT Realtime 1.5</option>
-      <option value="gemini-3.1-flash-live-preview">Gemini 3.1 Flash Live</option>
+      <option value="gpt-realtime-mini" data-provider="openai" selected>GPT Realtime Mini</option>
+      <option value="gpt-realtime-1.5" data-provider="openai">GPT Realtime 1.5</option>
+      <option value="gemini-3.1-flash-live-preview" data-provider="gemini">Gemini 3.1 Flash Live</option>
     </select>
   </div>
 
@@ -124,23 +124,38 @@ export function getTestPageHTML(host: string): string {
     const statusEl = document.getElementById("status")
     const transcriptEl = document.getElementById("transcript")
     const levelBar = document.getElementById("level-bar")
+    const providerSel = document.getElementById("provider")
     const modelSel = document.getElementById("model")
     const voiceSel = document.getElementById("voice")
 
-    function filterVoicesByModel() {
-      const provider = modelSel.value.startsWith("gemini-") ? "gemini" : "openai"
-      const defaults = { openai: "sage", gemini: "Zephyr" }
-      let currentOk = false
+    const DEFAULT_MODEL = { openai: "gpt-realtime-mini", gemini: "gemini-3.1-flash-live-preview" }
+    const DEFAULT_VOICE = { openai: "sage", gemini: "Zephyr" }
+
+    function syncForProvider() {
+      // Echo is a loopback with no upstream model/voice; treat it as openai for option visibility,
+      // since the echo adapter ignores both fields.
+      const provider = providerSel.value === "gemini" ? "gemini" : "openai"
+
+      let modelOk = false
+      for (const opt of modelSel.options) {
+        const match = opt.dataset.provider === provider
+        opt.hidden = !match
+        opt.disabled = !match
+        if (match && opt.value === modelSel.value) modelOk = true
+      }
+      if (!modelOk) modelSel.value = DEFAULT_MODEL[provider]
+
+      let voiceOk = false
       for (const opt of voiceSel.options) {
         const match = opt.dataset.provider === provider
         opt.hidden = !match
         opt.disabled = !match
-        if (match && opt.value === voiceSel.value) currentOk = true
+        if (match && opt.value === voiceSel.value) voiceOk = true
       }
-      if (!currentOk) voiceSel.value = defaults[provider]
+      if (!voiceOk) voiceSel.value = DEFAULT_VOICE[provider]
     }
-    modelSel.addEventListener("change", filterVoicesByModel)
-    filterVoicesByModel()
+    providerSel.addEventListener("change", syncForProvider)
+    syncForProvider()
 
     function setStatus(msg, type = "") {
       statusEl.textContent = msg
@@ -189,8 +204,8 @@ export function getTestPageHTML(host: string): string {
 
         ws.onopen = () => {
           setStatus("Connected, configuring session...", "ok")
-          const selectedModel = document.getElementById("model").value
-          const provider = selectedModel.startsWith("gemini-") ? "gemini" : document.getElementById("provider").value
+          const selectedModel = modelSel.value
+          const provider = providerSel.value
           ws.send(JSON.stringify({
             type: "session.config",
             provider: provider,

--- a/relay-server/src/test-page.ts
+++ b/relay-server/src/test-page.ts
@@ -40,15 +40,6 @@ export function getTestPageHTML(host: string): string {
   <p class="subtitle">Test the realtime voice pipeline from your browser</p>
 
   <div class="section">
-    <label>Provider</label>
-    <select id="provider">
-      <option value="echo">Echo (loopback test)</option>
-      <option value="openai" selected>OpenAI Realtime</option>
-      <option value="gemini">Gemini Live</option>
-    </select>
-  </div>
-
-  <div class="section">
     <label>Brain Agent</label>
     <select id="brain-agent">
       <option value="none">None</option>
@@ -65,6 +56,15 @@ export function getTestPageHTML(host: string): string {
       <label>Auth Token</label>
       <input id="auth-token" type="password" placeholder="Bearer token">
     </div>
+  </div>
+
+  <div class="section">
+    <label>Provider</label>
+    <select id="provider">
+      <option value="echo">Echo (loopback test)</option>
+      <option value="openai" selected>OpenAI Realtime</option>
+      <option value="gemini">Gemini Live</option>
+    </select>
   </div>
 
   <div class="section">

--- a/relay-server/src/test-page.ts
+++ b/relay-server/src/test-page.ts
@@ -79,22 +79,24 @@ export function getTestPageHTML(host: string): string {
   <div class="section">
     <label>Voice</label>
     <select id="voice">
-      <option value="alloy">Alloy (F)</option>
-      <option value="ash">Ash (M)</option>
-      <option value="ballad">Ballad (M)</option>
-      <option value="coral">Coral (F)</option>
-      <option value="echo">Echo (M)</option>
-      <option value="sage" selected>Sage (F)</option>
-      <option value="shimmer">Shimmer (F)</option>
-      <option value="verse">Verse (M)</option>
-      <option value="Puck">Puck (M) — Gemini</option>
-      <option value="Charon">Charon (M) — Gemini</option>
-      <option value="Kore">Kore (F) — Gemini</option>
-      <option value="Fenrir">Fenrir (M) — Gemini</option>
-      <option value="Aoede">Aoede (F) — Gemini</option>
-      <option value="Leda">Leda (F) — Gemini</option>
-      <option value="Orus">Orus (M) — Gemini</option>
-      <option value="Zephyr">Zephyr (M) — Gemini</option>
+      <option value="alloy" data-provider="openai">Alloy (N)</option>
+      <option value="ash" data-provider="openai">Ash (M)</option>
+      <option value="ballad" data-provider="openai">Ballad (M)</option>
+      <option value="coral" data-provider="openai">Coral (F)</option>
+      <option value="echo" data-provider="openai">Echo (M)</option>
+      <option value="sage" data-provider="openai" selected>Sage (F)</option>
+      <option value="shimmer" data-provider="openai">Shimmer (F)</option>
+      <option value="verse" data-provider="openai">Verse (M)</option>
+      <option value="marin" data-provider="openai">Marin (F)</option>
+      <option value="cedar" data-provider="openai">Cedar (M)</option>
+      <option value="Puck" data-provider="gemini">Puck (M, upbeat)</option>
+      <option value="Charon" data-provider="gemini">Charon (M, informative)</option>
+      <option value="Fenrir" data-provider="gemini">Fenrir (M, excitable)</option>
+      <option value="Orus" data-provider="gemini">Orus (M, firm)</option>
+      <option value="Kore" data-provider="gemini">Kore (F, firm)</option>
+      <option value="Aoede" data-provider="gemini">Aoede (F, breezy)</option>
+      <option value="Leda" data-provider="gemini">Leda (F, youthful)</option>
+      <option value="Zephyr" data-provider="gemini">Zephyr (F, bright)</option>
     </select>
   </div>
 
@@ -122,6 +124,23 @@ export function getTestPageHTML(host: string): string {
     const statusEl = document.getElementById("status")
     const transcriptEl = document.getElementById("transcript")
     const levelBar = document.getElementById("level-bar")
+    const modelSel = document.getElementById("model")
+    const voiceSel = document.getElementById("voice")
+
+    function filterVoicesByModel() {
+      const provider = modelSel.value.startsWith("gemini-") ? "gemini" : "openai"
+      const defaults = { openai: "sage", gemini: "Zephyr" }
+      let currentOk = false
+      for (const opt of voiceSel.options) {
+        const match = opt.dataset.provider === provider
+        opt.hidden = !match
+        opt.disabled = !match
+        if (match && opt.value === voiceSel.value) currentOk = true
+      }
+      if (!currentOk) voiceSel.value = defaults[provider]
+    }
+    modelSel.addEventListener("change", filterVoicesByModel)
+    filterVoicesByModel()
 
     function setStatus(msg, type = "") {
       statusEl.textContent = msg

--- a/relay-server/src/tracing/langfuse.ts
+++ b/relay-server/src/tracing/langfuse.ts
@@ -19,7 +19,7 @@ let enabled = false
 export function initLangfuse() {
   const publicKey = process.env.LANGFUSE_PUBLIC_KEY
   const secretKey = process.env.LANGFUSE_SECRET_KEY
-  const baseUrl = process.env.LANGFUSE_HOST ?? "https://cloud.langfuse.com"
+  const baseUrl = process.env.LANGFUSE_BASE_URL ?? "https://cloud.langfuse.com"
 
   if (!publicKey || !secretKey) {
     log("[langfuse] LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY not set — tracing disabled")

--- a/relay-server/src/tracing/langfuse.ts
+++ b/relay-server/src/tracing/langfuse.ts
@@ -1,0 +1,62 @@
+// Langfuse tracing initializer. Soft-disables if LANGFUSE_* envs are missing
+// so local dev without keys is still runnable.
+//
+// Trace model:
+//   Session = one relay WebSocket connection (sessionKey → Langfuse sessionId)
+//   Trace   = one voice turn (user utterance → assistant finished speaking)
+//   Observations (spans):
+//     - generation: model turn (Gemini Live / OpenAI Realtime); usage on close
+//     - agent/tool: brain tool calls
+//     - span: mobile-side timing reports (stt/llm/tts latency from the device)
+
+import { NodeSDK } from "@opentelemetry/sdk-node"
+import { LangfuseSpanProcessor } from "@langfuse/otel"
+import { log, error as logError } from "../log.js"
+
+let sdk: NodeSDK | null = null
+let enabled = false
+
+export function initLangfuse() {
+  const publicKey = process.env.LANGFUSE_PUBLIC_KEY
+  const secretKey = process.env.LANGFUSE_SECRET_KEY
+  const baseUrl = process.env.LANGFUSE_HOST ?? "https://cloud.langfuse.com"
+
+  if (!publicKey || !secretKey) {
+    log("[langfuse] LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY not set — tracing disabled")
+    return
+  }
+
+  try {
+    sdk = new NodeSDK({
+      spanProcessors: [
+        new LangfuseSpanProcessor({
+          publicKey,
+          secretKey,
+          baseUrl,
+          environment: process.env.NODE_ENV ?? "development",
+        }),
+      ],
+    })
+    sdk.start()
+    enabled = true
+    log(`[langfuse] tracing enabled (${baseUrl})`)
+  } catch (err) {
+    logError(`[langfuse] failed to initialize: ${(err as Error).message}`)
+    sdk = null
+    enabled = false
+  }
+}
+
+export function isLangfuseEnabled(): boolean {
+  return enabled
+}
+
+export async function shutdownLangfuse() {
+  if (!sdk) return
+  try {
+    await sdk.shutdown()
+    log("[langfuse] tracing shut down")
+  } catch (err) {
+    logError(`[langfuse] shutdown error: ${(err as Error).message}`)
+  }
+}

--- a/relay-server/src/tracing/turn-tracer.ts
+++ b/relay-server/src/tracing/turn-tracer.ts
@@ -1,0 +1,121 @@
+// Per-session Langfuse tracer. One instance per RelaySession.
+//
+// Maps the relay event stream to Langfuse observations:
+//   turn.started      → open a generation span for this turn
+//   transcript.delta  → accumulate input/output on the active generation
+//   turn.ended        → close the generation
+//   tool.call / result → nested tool spans
+//   client.timing     → attrs on the active generation
+//
+// All methods no-op when Langfuse is not initialized, so callers don't
+// need to guard every site.
+
+import { startObservation, type LangfuseGeneration, type LangfuseTool } from "@langfuse/tracing"
+import { isLangfuseEnabled } from "./langfuse.js"
+
+export class TurnTracer {
+  private sessionId: string | null = null
+  private userId: string | null = null
+  private model: string | null = null
+
+  private activeGeneration: LangfuseGeneration | null = null
+  private activeToolSpans = new Map<string, LangfuseTool>()
+
+  private currentUserText = ""
+  private currentAssistantText = ""
+
+  startSession(sessionId: string, userId: string | null, model: string | null) {
+    this.sessionId = sessionId
+    this.userId = userId
+    this.model = model
+  }
+
+  startTurn() {
+    if (!isLangfuseEnabled()) return
+    // Close any leftover generation (defensive — shouldn't happen if turn.ended fires)
+    this.endTurn()
+
+    this.currentUserText = ""
+    this.currentAssistantText = ""
+
+    this.activeGeneration = startObservation(
+      "voice-turn",
+      {
+        model: this.model ?? undefined,
+        metadata: {
+          langfuseSessionId: this.sessionId,
+          langfuseUserId: this.userId,
+        },
+      },
+      { asType: "generation" },
+    )
+  }
+
+  appendUserText(text: string) {
+    this.currentUserText += text
+  }
+
+  appendAssistantText(text: string) {
+    this.currentAssistantText += text
+  }
+
+  startToolCall(callId: string, name: string, args: string) {
+    if (!isLangfuseEnabled() || !this.activeGeneration) return
+    const span = this.activeGeneration.startObservation(
+      name,
+      {
+        input: safeParse(args),
+        metadata: { callId },
+      },
+      { asType: "tool" },
+    )
+    this.activeToolSpans.set(callId, span)
+  }
+
+  endToolCall(callId: string, output: string, error?: string) {
+    const span = this.activeToolSpans.get(callId)
+    if (!span) return
+    span.update({
+      output: safeParse(output),
+      ...(error ? { level: "ERROR" as const, statusMessage: error } : {}),
+    })
+    span.end()
+    this.activeToolSpans.delete(callId)
+  }
+
+  attachClientTiming(phase: string, ms: number) {
+    if (!this.activeGeneration) return
+    this.activeGeneration.update({
+      metadata: { [`client.${phase}_ms`]: ms },
+    })
+  }
+
+  endTurn(errorMessage?: string) {
+    if (!this.activeGeneration) return
+    // Any dangling tool spans mean we lost the result — mark them and close.
+    for (const [callId, span] of this.activeToolSpans) {
+      span.update({ level: "WARNING", statusMessage: "tool span closed without result" })
+      span.end()
+      this.activeToolSpans.delete(callId)
+    }
+    this.activeGeneration.update({
+      input: this.currentUserText || undefined,
+      output: this.currentAssistantText || undefined,
+      ...(errorMessage ? { level: "ERROR" as const, statusMessage: errorMessage } : {}),
+    })
+    this.activeGeneration.end()
+    this.activeGeneration = null
+  }
+
+  endSession() {
+    this.endTurn()
+  }
+}
+
+function safeParse(s: string): unknown {
+  try {
+    return JSON.parse(s)
+  } catch {
+    return s
+  }
+}

--- a/relay-server/src/tracing/turn-tracer.ts
+++ b/relay-server/src/tracing/turn-tracer.ts
@@ -97,6 +97,23 @@ export class TurnTracer {
     })
   }
 
+  attachUsage(usage: {
+    promptTokens?: number
+    completionTokens?: number
+    totalTokens?: number
+    inputAudioTokens?: number
+    outputAudioTokens?: number
+  }) {
+    if (!this.activeGeneration) return
+    const usageDetails: Record<string, number> = {}
+    if (usage.promptTokens != null) usageDetails.input = usage.promptTokens
+    if (usage.completionTokens != null) usageDetails.output = usage.completionTokens
+    if (usage.totalTokens != null) usageDetails.total = usage.totalTokens
+    if (usage.inputAudioTokens != null) usageDetails.input_audio = usage.inputAudioTokens
+    if (usage.outputAudioTokens != null) usageDetails.output_audio = usage.outputAudioTokens
+    this.activeGeneration.update({ usageDetails })
+  }
+
   endTurn(errorMessage?: string) {
     if (!this.activeGeneration) return
     // Tool spans may legitimately outlive the turn they started in — async tools

--- a/relay-server/src/tracing/turn-tracer.ts
+++ b/relay-server/src/tracing/turn-tracer.ts
@@ -10,7 +10,7 @@
 // All methods no-op when Langfuse is not initialized, so callers don't
 // need to guard every site.
 
-import { startObservation, type LangfuseGeneration, type LangfuseTool } from "@langfuse/tracing"
+import { propagateAttributes, startObservation, type LangfuseGeneration, type LangfuseTool } from "@langfuse/tracing"
 import { isLangfuseEnabled } from "./langfuse.js"
 
 export class TurnTracer {
@@ -38,16 +38,23 @@ export class TurnTracer {
     this.currentUserText = ""
     this.currentAssistantText = ""
 
-    this.activeGeneration = startObservation(
-      "voice-turn",
+    // propagateAttributes writes sessionId/userId onto the OTel context so the
+    // span created inside the callback (and its children) inherit them. Setting
+    // them via metadata.langfuseSessionId is the Langchain integration pattern
+    // and does NOT populate the trace's session field in the @langfuse/tracing
+    // direct SDK.
+    propagateAttributes(
       {
-        model: this.model ?? undefined,
-        metadata: {
-          langfuseSessionId: this.sessionId,
-          langfuseUserId: this.userId,
-        },
+        ...(this.sessionId ? { sessionId: this.sessionId } : {}),
+        ...(this.userId ? { userId: this.userId } : {}),
       },
-      { asType: "generation" },
+      () => {
+        this.activeGeneration = startObservation(
+          "voice-turn",
+          { model: this.model ?? undefined },
+          { asType: "generation" },
+        )
+      },
     )
   }
 

--- a/relay-server/src/tracing/turn-tracer.ts
+++ b/relay-server/src/tracing/turn-tracer.ts
@@ -130,7 +130,11 @@ export class TurnTracer {
     inputAudioTokens?: number
     outputAudioTokens?: number
   }, turnId?: string) {
-    const target = this.resolveTarget(turnId)
+    // Providers emit usage for the turn that just finished, not the one in
+    // progress. Prefer pendingEnd so a late usageMetadata arriving after the
+    // next turn has already started still lands on the correct generation
+    // instead of being misattributed to the new active turn.
+    const target = this.resolveUsageTarget(turnId)
     if (!target) return
     const usageDetails: Record<string, number> = {}
     if (usage.promptTokens != null) usageDetails.input = usage.promptTokens
@@ -184,6 +188,19 @@ export class TurnTracer {
     // Recently-ended turn — usage/timing from the tail of the last turn.
     if (this.pendingEnd && (!turnId || turnId === this.pendingEnd.turnId)) {
       return this.pendingEnd.generation
+    }
+    return null
+  }
+
+  private resolveUsageTarget(turnId?: string): LangfuseGeneration | null {
+    // Usage telemetry describes the turn that just completed, so prefer the
+    // just-ended generation over any new active one. This matters when a late
+    // usageMetadata lands after the user has already started the next turn.
+    if (this.pendingEnd && (!turnId || turnId === this.pendingEnd.turnId)) {
+      return this.pendingEnd.generation
+    }
+    if (this.activeGeneration && (!turnId || turnId === this.activeTurnId)) {
+      return this.activeGeneration
     }
     return null
   }

--- a/relay-server/src/tracing/turn-tracer.ts
+++ b/relay-server/src/tracing/turn-tracer.ts
@@ -92,12 +92,9 @@ export class TurnTracer {
 
   endTurn(errorMessage?: string) {
     if (!this.activeGeneration) return
-    // Any dangling tool spans mean we lost the result — mark them and close.
-    for (const [callId, span] of this.activeToolSpans) {
-      span.update({ level: "WARNING", statusMessage: "tool span closed without result" })
-      span.end()
-      this.activeToolSpans.delete(callId)
-    }
+    // Tool spans may legitimately outlive the turn they started in — async tools
+    // (e.g. ask_brain) often resolve on a later turn. Leave them open; endSession
+    // will WARNING-close anything still dangling when the socket closes.
     this.activeGeneration.update({
       input: this.currentUserText || undefined,
       output: this.currentAssistantText || undefined,
@@ -109,6 +106,11 @@ export class TurnTracer {
 
   endSession() {
     this.endTurn()
+    for (const [callId, span] of this.activeToolSpans) {
+      span.update({ level: "WARNING", statusMessage: "tool span closed without result" })
+      span.end()
+      this.activeToolSpans.delete(callId)
+    }
   }
 }
 

--- a/relay-server/src/tracing/turn-tracer.ts
+++ b/relay-server/src/tracing/turn-tracer.ts
@@ -10,6 +10,7 @@
 // All methods no-op when Langfuse is not initialized, so callers don't
 // need to guard every site.
 
+import { randomUUID } from "node:crypto"
 import { propagateAttributes, startObservation, type LangfuseGeneration, type LangfuseTool } from "@langfuse/tracing"
 import { isLangfuseEnabled } from "./langfuse.js"
 
@@ -19,10 +20,15 @@ export class TurnTracer {
   private model: string | null = null
 
   private activeGeneration: LangfuseGeneration | null = null
+  private activeTurnId: string | null = null
   private activeToolSpans = new Map<string, LangfuseTool>()
 
   private currentUserText = ""
   private currentAssistantText = ""
+
+  getActiveTurnId(): string | null {
+    return this.activeTurnId
+  }
 
   startSession(sessionId: string, userId: string | null, model: string | null) {
     this.sessionId = sessionId
@@ -43,6 +49,7 @@ export class TurnTracer {
     // them via metadata.langfuseSessionId is the Langchain integration pattern
     // and does NOT populate the trace's session field in the @langfuse/tracing
     // direct SDK.
+    this.activeTurnId = randomUUID()
     propagateAttributes(
       {
         ...(this.sessionId ? { sessionId: this.sessionId } : {}),
@@ -51,7 +58,10 @@ export class TurnTracer {
       () => {
         this.activeGeneration = startObservation(
           "voice-turn",
-          { model: this.model ?? undefined },
+          {
+            model: this.model ?? undefined,
+            metadata: { turnId: this.activeTurnId },
+          },
           { asType: "generation" },
         )
       },
@@ -59,10 +69,12 @@ export class TurnTracer {
   }
 
   appendUserText(text: string) {
+    if (!this.activeGeneration) return
     this.currentUserText += text
   }
 
   appendAssistantText(text: string) {
+    if (!this.activeGeneration) return
     this.currentAssistantText += text
   }
 
@@ -90,8 +102,11 @@ export class TurnTracer {
     this.activeToolSpans.delete(callId)
   }
 
-  attachClientTiming(phase: string, ms: number) {
+  attachClientTiming(phase: string, ms: number, turnId?: string) {
     if (!this.activeGeneration) return
+    // Drop timings for a stale turn rather than attributing them to the wrong
+    // generation. Missing turnId means legacy client — best-effort attach.
+    if (turnId && turnId !== this.activeTurnId) return
     this.activeGeneration.update({
       metadata: { [`client.${phase}_ms`]: ms },
     })
@@ -126,6 +141,7 @@ export class TurnTracer {
     })
     this.activeGeneration.end()
     this.activeGeneration = null
+    this.activeTurnId = null
   }
 
   endSession() {

--- a/relay-server/src/tracing/turn-tracer.ts
+++ b/relay-server/src/tracing/turn-tracer.ts
@@ -6,6 +6,9 @@
 //   turn.ended        → close the generation
 //   tool.call / result → nested tool spans
 //   client.timing     → attrs on the active generation
+//   usage.metrics     → attrs on the active generation (buffered briefly
+//                       after turn.ended since providers emit usage
+//                       metadata separately from the end-of-turn marker)
 //
 // All methods no-op when Langfuse is not initialized, so callers don't
 // need to guard every site.
@@ -13,6 +16,14 @@
 import { randomUUID } from "node:crypto"
 import { propagateAttributes, startObservation, type LangfuseGeneration, type LangfuseTool } from "@langfuse/tracing"
 import { isLangfuseEnabled } from "./langfuse.js"
+
+// How long to keep the generation object around after endTurn() so trailing
+// usage.metrics / client.timing events from the same turn can still attach.
+// Gemini in particular fans usageMetadata as an independent upstream message
+// that can land milliseconds after turnComplete. Keep this small — tokens
+// dropped on a 2s flush are far cheaper than blocking a turn's visibility
+// in Langfuse for seconds.
+const PENDING_FLUSH_MS = 2000
 
 export class TurnTracer {
   private sessionId: string | null = null
@@ -22,6 +33,7 @@ export class TurnTracer {
   private activeGeneration: LangfuseGeneration | null = null
   private activeTurnId: string | null = null
   private activeToolSpans = new Map<string, LangfuseTool>()
+  private pendingEnd: { generation: LangfuseGeneration, turnId: string, timer: ReturnType<typeof setTimeout> } | null = null
 
   private currentUserText = ""
   private currentAssistantText = ""
@@ -40,6 +52,9 @@ export class TurnTracer {
     if (!isLangfuseEnabled()) return
     // Close any leftover generation (defensive — shouldn't happen if turn.ended fires)
     this.endTurn()
+    // Any still-pending trailing updates from the prior turn must be flushed
+    // before a new generation takes over as the target for attach* calls.
+    this.flushPending()
 
     this.currentUserText = ""
     this.currentAssistantText = ""
@@ -103,13 +118,9 @@ export class TurnTracer {
   }
 
   attachClientTiming(phase: string, ms: number, turnId?: string) {
-    if (!this.activeGeneration) return
-    // Drop timings for a stale turn rather than attributing them to the wrong
-    // generation. Missing turnId means legacy client — best-effort attach.
-    if (turnId && turnId !== this.activeTurnId) return
-    this.activeGeneration.update({
-      metadata: { [`client.${phase}_ms`]: ms },
-    })
+    const target = this.resolveTarget(turnId)
+    if (!target) return
+    target.update({ metadata: { [`client.${phase}_ms`]: ms } })
   }
 
   attachUsage(usage: {
@@ -118,15 +129,16 @@ export class TurnTracer {
     totalTokens?: number
     inputAudioTokens?: number
     outputAudioTokens?: number
-  }) {
-    if (!this.activeGeneration) return
+  }, turnId?: string) {
+    const target = this.resolveTarget(turnId)
+    if (!target) return
     const usageDetails: Record<string, number> = {}
     if (usage.promptTokens != null) usageDetails.input = usage.promptTokens
     if (usage.completionTokens != null) usageDetails.output = usage.completionTokens
     if (usage.totalTokens != null) usageDetails.total = usage.totalTokens
     if (usage.inputAudioTokens != null) usageDetails.input_audio = usage.inputAudioTokens
     if (usage.outputAudioTokens != null) usageDetails.output_audio = usage.outputAudioTokens
-    this.activeGeneration.update({ usageDetails })
+    target.update({ usageDetails })
   }
 
   endTurn(errorMessage?: string) {
@@ -139,18 +151,48 @@ export class TurnTracer {
       output: this.currentAssistantText || undefined,
       ...(errorMessage ? { level: "ERROR" as const, statusMessage: errorMessage } : {}),
     })
-    this.activeGeneration.end()
+    // Keep the generation around briefly so trailing usage.metrics /
+    // client.timing can still attach before we call .end() and hand the
+    // span off to the exporter. Any earlier pending flushes first.
+    this.flushPending()
+    const generation = this.activeGeneration
+    const turnId = this.activeTurnId ?? ""
+    this.pendingEnd = {
+      generation,
+      turnId,
+      timer: setTimeout(() => this.flushPending(), PENDING_FLUSH_MS),
+    }
     this.activeGeneration = null
     this.activeTurnId = null
   }
 
   endSession() {
     this.endTurn()
+    this.flushPending()
     for (const [callId, span] of this.activeToolSpans) {
       span.update({ level: "WARNING", statusMessage: "tool span closed without result" })
       span.end()
       this.activeToolSpans.delete(callId)
     }
+  }
+
+  private resolveTarget(turnId?: string): LangfuseGeneration | null {
+    // Live turn — if a turnId is supplied, must match.
+    if (this.activeGeneration && (!turnId || turnId === this.activeTurnId)) {
+      return this.activeGeneration
+    }
+    // Recently-ended turn — usage/timing from the tail of the last turn.
+    if (this.pendingEnd && (!turnId || turnId === this.pendingEnd.turnId)) {
+      return this.pendingEnd.generation
+    }
+    return null
+  }
+
+  private flushPending() {
+    if (!this.pendingEnd) return
+    clearTimeout(this.pendingEnd.timer)
+    this.pendingEnd.generation.end()
+    this.pendingEnd = null
   }
 }
 

--- a/relay-server/src/types.ts
+++ b/relay-server/src/types.ts
@@ -8,6 +8,7 @@ export type ClientEvent =
   | ResponseCreateEvent
   | ResponseCancelEvent
   | ToolResultEvent
+  | ClientTimingEvent
 
 export interface SessionConfigEvent {
   type: "session.config"
@@ -50,6 +51,15 @@ export interface ToolResultEvent {
   type: "tool.result"
   callId: string
   output: string
+}
+
+// Emitted by the mobile client to attribute latency across the pipeline
+// (e.g., mic-open → first-audio-chunk, turn-started → first-tts-sample).
+// Relay attaches these to the active Langfuse generation span as metadata.
+export interface ClientTimingEvent {
+  type: "client.timing"
+  phase: string
+  ms: number
 }
 
 // Relay → Client events

--- a/relay-server/src/types.ts
+++ b/relay-server/src/types.ts
@@ -55,11 +55,14 @@ export interface ToolResultEvent {
 
 // Emitted by the mobile client to attribute latency across the pipeline
 // (e.g., mic-open → first-audio-chunk, turn-started → first-tts-sample).
-// Relay attaches these to the active Langfuse generation span as metadata.
+// Relay attaches these to the Langfuse generation span identified by turnId.
+// turnId is issued by the relay in TurnStartedEvent; echoing it back avoids
+// attributing a late-arriving timing to the wrong turn.
 export interface ClientTimingEvent {
   type: "client.timing"
   phase: string
   ms: number
+  turnId?: string
 }
 
 // Relay → Client events
@@ -115,6 +118,7 @@ export interface ToolProgressEvent {
 
 export interface TurnStartedEvent {
   type: "turn.started"
+  turnId?: string
 }
 
 export interface TurnEndedEvent {

--- a/relay-server/src/types.ts
+++ b/relay-server/src/types.ts
@@ -75,6 +75,7 @@ export type RelayEvent =
   | SessionEndedEvent
   | SessionRotatingEvent
   | SessionRotatedEvent
+  | UsageMetricsEvent
   | ErrorEvent
 
 export interface SessionReadyEvent {
@@ -134,6 +135,18 @@ export interface SessionRotatingEvent {
 export interface SessionRotatedEvent {
   type: "session.rotated"
   sessionId: string
+}
+
+// Emitted by adapters with per-turn token/audio usage. Consumed internally
+// by the tracer to attribute cost on Langfuse generations; not forwarded to
+// the mobile client.
+export interface UsageMetricsEvent {
+  type: "usage.metrics"
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+  inputAudioTokens?: number
+  outputAudioTokens?: number
 }
 
 export interface ErrorEvent {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2064,6 +2064,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@grpc/grpc-js@npm:^1.14.3":
+  version: 1.14.3
+  resolution: "@grpc/grpc-js@npm:1.14.3"
+  dependencies:
+    "@grpc/proto-loader": "npm:^0.8.0"
+    "@js-sdsl/ordered-map": "npm:^4.4.2"
+  checksum: 10c0/f41f06a311b93cca8c472d56e21387e0f7b57bb2337a91d15ea4279bac8ec4fa0de6bd0d881201229ab800c0f0c55277911ecb850e057f20a828d0ddd623551d
+  languageName: node
+  linkType: hard
+
+"@grpc/proto-loader@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@grpc/proto-loader@npm:0.8.0"
+  dependencies:
+    lodash.camelcase: "npm:^4.3.0"
+    long: "npm:^5.0.0"
+    protobufjs: "npm:^7.5.3"
+    yargs: "npm:^17.7.2"
+  bin:
+    proto-loader-gen-types: build/bin/proto-loader-gen-types.js
+  checksum: 10c0/a27da3b85d5d17bab956d536786c717287eae46ca264ea9ec774db90ff571955bae2705809f431b4622fbf3be9951d7c7bbb1360b2015ee88abe1587cf3d6fe0
+  languageName: node
+  linkType: hard
+
 "@hono/node-server@npm:^1.19.9":
   version: 1.19.11
   resolution: "@hono/node-server@npm:1.19.11"
@@ -2571,6 +2595,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@js-sdsl/ordered-map@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "@js-sdsl/ordered-map@npm:4.4.2"
+  checksum: 10c0/cc7e15dc4acf6d9ef663757279600bab70533d847dcc1ab01332e9e680bd30b77cdf9ad885cc774276f51d98b05a013571c940e5b360985af5eb798dc1a2ee2b
+  languageName: node
+  linkType: hard
+
+"@langfuse/core@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@langfuse/core@npm:5.1.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.9.0
+  checksum: 10c0/977e047312f37da6f95369e4e350425a769258252af4c5321e1be399be4b57f0a27ba8ccc01e1785f71fe7dc29f908274b668982a308ac87e20a53e91ab2d2d6
+  languageName: node
+  linkType: hard
+
+"@langfuse/otel@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@langfuse/otel@npm:5.1.0"
+  dependencies:
+    "@langfuse/core": "npm:^5.1.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.9.0
+    "@opentelemetry/core": ^2.0.1
+    "@opentelemetry/exporter-trace-otlp-http": ">=0.202.0 <1.0.0"
+    "@opentelemetry/sdk-trace-base": ^2.0.1
+  checksum: 10c0/80febd9f7f3fa51c902a9a381cba86f3afc921817986a0c3e534c7f859a2045b8fbc774f126f6afc210c4c22415aeff34d723245bf30747a5bbec0195f31ab04
+  languageName: node
+  linkType: hard
+
+"@langfuse/tracing@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@langfuse/tracing@npm:5.1.0"
+  dependencies:
+    "@langfuse/core": "npm:^5.1.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.9.0
+  checksum: 10c0/53a780a79a88a14c6025a6a2b246b1ebd66d579f7266e850b46a4203fea49c56319771d2653e85c7a7d82732c76cb59fb98ca7eab27a62e2acae9581d29378fc
+  languageName: node
+  linkType: hard
+
 "@modelcontextprotocol/sdk@npm:^1.26.0":
   version: 1.27.1
   resolution: "@modelcontextprotocol/sdk@npm:1.27.1"
@@ -2820,6 +2885,483 @@ __metadata:
   version: 2.1.0
   resolution: "@open-draft/until@npm:2.1.0"
   checksum: 10c0/61d3f99718dd86bb393fee2d7a785f961dcaf12f2055f0c693b27f4d0cd5f7a03d498a6d9289773b117590d794a43cd129366fd8e99222e4832f67b1653d54cf
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/api-logs@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/api-logs@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.3.0"
+  checksum: 10c0/414f8b824ad52ad2cc358cc2f26b709e64b0748fd7c3e6b7a613cb3b3a1138adf6c0a80d92fad8832ab4b62bbf3e1d1424bf5c707efe2f49bfd15500031ccbf7
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "@opentelemetry/api@npm:1.9.1"
+  checksum: 10c0/c608485fc8b5a91e1f7e05e843b45b509307456b31cd2ad365933d90813e40ebfedf179f1451c762037e82d7c76aa8500e95d2da3609f640a1206cde5322cd14
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/configuration@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/configuration@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.6.1"
+    yaml: "npm:^2.0.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.9.0
+  checksum: 10c0/9361d5c423b672a461a802938a79a49edf98571cb0d867bdd95c2b4473cc3fdd0cf5f8d2546448916d3e483205a9ad3edc39a96b86fc875d8412ba4fe03bd17d
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/context-async-hooks@npm:2.6.1":
+  version: 2.6.1
+  resolution: "@opentelemetry/context-async-hooks@npm:2.6.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10c0/a2923eb3116b616ec04b1590833908ea7ea4ca247743b65e75a2e66ac95ab607cf67ab27ad56009049d9bfbe5b1dbcb78213867bdf97c535f52c5c6463f4c8be
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/core@npm:2.6.1":
+  version: 2.6.1
+  resolution: "@opentelemetry/core@npm:2.6.1"
+  dependencies:
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10c0/a144749e4fc4b8aa56a67310136ae37ba446cdd84a5286d76b441206e80362d5059e496b11373909d5ada8be32cfb00fcebc5a90401b29a08a3ce34c9caacbdd
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/exporter-logs-otlp-grpc@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/exporter-logs-otlp-grpc@npm:0.214.0"
+  dependencies:
+    "@grpc/grpc-js": "npm:^1.14.3"
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/otlp-exporter-base": "npm:0.214.0"
+    "@opentelemetry/otlp-grpc-exporter-base": "npm:0.214.0"
+    "@opentelemetry/otlp-transformer": "npm:0.214.0"
+    "@opentelemetry/sdk-logs": "npm:0.214.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/6446996beb6aa23a01f8af1e96da4177c79bb121d9086d775b9be45f6da0f461ec4ad2910990acccd32b524859b12bf2847d1eaf38b5c8aae5d6e38fb4a31a91
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/exporter-logs-otlp-http@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/exporter-logs-otlp-http@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.214.0"
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/otlp-exporter-base": "npm:0.214.0"
+    "@opentelemetry/otlp-transformer": "npm:0.214.0"
+    "@opentelemetry/sdk-logs": "npm:0.214.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/2a3de6f6258c99ef6e8235bfd1a9b092657faaa8596456223a331957fddc780381fc71b9e9047cdf3e1dcb368f358000cabe6885c0731ad4d299d8aace69d173
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/exporter-logs-otlp-proto@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/exporter-logs-otlp-proto@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.214.0"
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/otlp-exporter-base": "npm:0.214.0"
+    "@opentelemetry/otlp-transformer": "npm:0.214.0"
+    "@opentelemetry/resources": "npm:2.6.1"
+    "@opentelemetry/sdk-logs": "npm:0.214.0"
+    "@opentelemetry/sdk-trace-base": "npm:2.6.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/b915dcd52349bb7d6243531e7b04ef794b8be446ae143bcb1db9b5c1a010fdbb231a45a2eef97e41909f20a5150dd70026462d715adb14aab25b68e6819e70b9
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/exporter-metrics-otlp-grpc@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/exporter-metrics-otlp-grpc@npm:0.214.0"
+  dependencies:
+    "@grpc/grpc-js": "npm:^1.14.3"
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/exporter-metrics-otlp-http": "npm:0.214.0"
+    "@opentelemetry/otlp-exporter-base": "npm:0.214.0"
+    "@opentelemetry/otlp-grpc-exporter-base": "npm:0.214.0"
+    "@opentelemetry/otlp-transformer": "npm:0.214.0"
+    "@opentelemetry/resources": "npm:2.6.1"
+    "@opentelemetry/sdk-metrics": "npm:2.6.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/59b8ba9408f74a31abb1e722910816b748dc187f2952c4857dcda655781de19b9e91e08d1ba024ba347d016051e776dee7e82640ee282736de955888e42ac282
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/exporter-metrics-otlp-http@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/exporter-metrics-otlp-http@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/otlp-exporter-base": "npm:0.214.0"
+    "@opentelemetry/otlp-transformer": "npm:0.214.0"
+    "@opentelemetry/resources": "npm:2.6.1"
+    "@opentelemetry/sdk-metrics": "npm:2.6.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/aab5d9200eb80404ed84e0aff9175c316f21a4764097e8c4e87788cb2ed191c29823ab94df146fbcd20593ca27297cc1e9837aa0a8d4c0662d76defede2890d7
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/exporter-metrics-otlp-proto@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/exporter-metrics-otlp-proto@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/exporter-metrics-otlp-http": "npm:0.214.0"
+    "@opentelemetry/otlp-exporter-base": "npm:0.214.0"
+    "@opentelemetry/otlp-transformer": "npm:0.214.0"
+    "@opentelemetry/resources": "npm:2.6.1"
+    "@opentelemetry/sdk-metrics": "npm:2.6.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/f9dc0da9f7c4798f0747187c5dd20b868747a5ce52dcc045dc7654f5ddd9b80a1c4754670c8be5d6732216569aef5b155a2977fd5dc42779e35747758224ac52
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/exporter-prometheus@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/exporter-prometheus@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/resources": "npm:2.6.1"
+    "@opentelemetry/sdk-metrics": "npm:2.6.1"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/cc069f9f765faecdeb7b635b6972e0acc8434d8ebbb5418f1200b5b406430fc4d31e6b673dbe3616a1778852b3d7edea919bd1db8a4c6732b4d18d30f4f8086b
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/exporter-trace-otlp-grpc@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/exporter-trace-otlp-grpc@npm:0.214.0"
+  dependencies:
+    "@grpc/grpc-js": "npm:^1.14.3"
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/otlp-exporter-base": "npm:0.214.0"
+    "@opentelemetry/otlp-grpc-exporter-base": "npm:0.214.0"
+    "@opentelemetry/otlp-transformer": "npm:0.214.0"
+    "@opentelemetry/resources": "npm:2.6.1"
+    "@opentelemetry/sdk-trace-base": "npm:2.6.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/b0249b4b4e03e10f771f6a0a2f94202605a01b894d051644536f647d9b1ceee4b8824372918f325e664e34dead3ff5d7094d3a7dd9021b7ee46b53c6dd98d4e3
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/exporter-trace-otlp-http@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/exporter-trace-otlp-http@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/otlp-exporter-base": "npm:0.214.0"
+    "@opentelemetry/otlp-transformer": "npm:0.214.0"
+    "@opentelemetry/resources": "npm:2.6.1"
+    "@opentelemetry/sdk-trace-base": "npm:2.6.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/9c87dd8f4639ef560a105f45811f7d0160a63f70a8bc504059b48825c587d2398bcd147d070442417419caa795296ff46f88533e04c202346fc6fbab73b4404a
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/exporter-trace-otlp-proto@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/exporter-trace-otlp-proto@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/otlp-exporter-base": "npm:0.214.0"
+    "@opentelemetry/otlp-transformer": "npm:0.214.0"
+    "@opentelemetry/resources": "npm:2.6.1"
+    "@opentelemetry/sdk-trace-base": "npm:2.6.1"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/c30a21ded08d9100e5ee5ba50ebbb3b71610346ad368ac64103c2572cfd932ad1093d7c2696a0f1c6136ebd88ecd0f2f8ab26afa7a8761fb07c461c1a8d6f774
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/exporter-zipkin@npm:2.6.1":
+  version: 2.6.1
+  resolution: "@opentelemetry/exporter-zipkin@npm:2.6.1"
+  dependencies:
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/resources": "npm:2.6.1"
+    "@opentelemetry/sdk-trace-base": "npm:2.6.1"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: 10c0/3404000a2639aec002c474ef390bc535a871705522ec4c8e820668c3d977ea91db7e4413921509b10a2aaf540fc5b74fee4f9b0f081472debaf282c2e380502f
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/instrumentation@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.214.0"
+    import-in-the-middle: "npm:^3.0.0"
+    require-in-the-middle: "npm:^8.0.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/0b0bde772a28c134d8f27c078d9b4a368b64b3b2183ffe1eea3067944f3ee711b8ce820d50b55c59a6218bf5a04722ebf6f04c27850895a7faa423cb56c99653
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/otlp-exporter-base@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/otlp-exporter-base@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/otlp-transformer": "npm:0.214.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/b94bddcb8b4580708be880fa506552e843e2f24b17a317063a3a6db9b71992464c3a0dcfbdcfe3bcb5096cefdaf26b05cf04c34eb15196201b5c31dbc7eb68fc
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/otlp-grpc-exporter-base@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/otlp-grpc-exporter-base@npm:0.214.0"
+  dependencies:
+    "@grpc/grpc-js": "npm:^1.14.3"
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/otlp-exporter-base": "npm:0.214.0"
+    "@opentelemetry/otlp-transformer": "npm:0.214.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/2f7c6647ae23b29c25e531299b87b1ee4cf76f2101cf6b788bf3c3be00466c84e1d92e30fee8d7452fb0543c98708b3b85decb59456c2dd1b21f8017d9a1b45c
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/otlp-transformer@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/otlp-transformer@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.214.0"
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/resources": "npm:2.6.1"
+    "@opentelemetry/sdk-logs": "npm:0.214.0"
+    "@opentelemetry/sdk-metrics": "npm:2.6.1"
+    "@opentelemetry/sdk-trace-base": "npm:2.6.1"
+    protobufjs: "npm:^7.0.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/dc2f6316e68def306ed4501f41379b0666bc0fa73c1ad66c3fc2ca11a0bd078f09aa8592b7b73982b99ca6f83e3ca6cce4b0816e49c297f0073790e79082f553
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/propagator-b3@npm:2.6.1":
+  version: 2.6.1
+  resolution: "@opentelemetry/propagator-b3@npm:2.6.1"
+  dependencies:
+    "@opentelemetry/core": "npm:2.6.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10c0/728eccc48f244031686405b203feb1a9ad16012de564f9a80790ada6f52dec690afd91fc47907344068c6ad324bf06d398da38e8eff066773c519b9842103b69
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/propagator-jaeger@npm:2.6.1":
+  version: 2.6.1
+  resolution: "@opentelemetry/propagator-jaeger@npm:2.6.1"
+  dependencies:
+    "@opentelemetry/core": "npm:2.6.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10c0/e59a321fed85be9373fdbe140b48ce6d44d4ded31cef8c01ce9b8a733bb5b7e8ad5b0f6d32efc4813e0191f41ba0c2e9b1b994a110f8fa24c3fb6c00397be3f0
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/resources@npm:2.6.1":
+  version: 2.6.1
+  resolution: "@opentelemetry/resources@npm:2.6.1"
+  dependencies:
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10c0/d9376881bb9dad39ed08ede591bbdbe02b79eb5ac6608b7245ebee3ec03043d33ee29bad649db4dafc61a442bbf5ad9e73cd03cbc7645ea016999b7b13aab052
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-logs@npm:0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/sdk-logs@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.214.0"
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/resources": "npm:2.6.1"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.4.0 <1.10.0"
+  checksum: 10c0/3310c0196956c25bef7f11f83c3e1ac8591170a1b8920dc4a4d0506c9e2fed4b9d00e41f44c86def1159e0fdb20ddc59a719b6797d3e560bb0c799475687646a
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-metrics@npm:2.6.1":
+  version: 2.6.1
+  resolution: "@opentelemetry/sdk-metrics@npm:2.6.1"
+  dependencies:
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/resources": "npm:2.6.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.9.0 <1.10.0"
+  checksum: 10c0/29745e1bfbdcd97cfb3201b6094c9d58550478a62d473e5b842e6705ee2419117381f3ee5d6e89a412522f6dda6b01516a69326c677eabcbc51bb38901922042
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-node@npm:^0.214.0":
+  version: 0.214.0
+  resolution: "@opentelemetry/sdk-node@npm:0.214.0"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.214.0"
+    "@opentelemetry/configuration": "npm:0.214.0"
+    "@opentelemetry/context-async-hooks": "npm:2.6.1"
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/exporter-logs-otlp-grpc": "npm:0.214.0"
+    "@opentelemetry/exporter-logs-otlp-http": "npm:0.214.0"
+    "@opentelemetry/exporter-logs-otlp-proto": "npm:0.214.0"
+    "@opentelemetry/exporter-metrics-otlp-grpc": "npm:0.214.0"
+    "@opentelemetry/exporter-metrics-otlp-http": "npm:0.214.0"
+    "@opentelemetry/exporter-metrics-otlp-proto": "npm:0.214.0"
+    "@opentelemetry/exporter-prometheus": "npm:0.214.0"
+    "@opentelemetry/exporter-trace-otlp-grpc": "npm:0.214.0"
+    "@opentelemetry/exporter-trace-otlp-http": "npm:0.214.0"
+    "@opentelemetry/exporter-trace-otlp-proto": "npm:0.214.0"
+    "@opentelemetry/exporter-zipkin": "npm:2.6.1"
+    "@opentelemetry/instrumentation": "npm:0.214.0"
+    "@opentelemetry/otlp-exporter-base": "npm:0.214.0"
+    "@opentelemetry/propagator-b3": "npm:2.6.1"
+    "@opentelemetry/propagator-jaeger": "npm:2.6.1"
+    "@opentelemetry/resources": "npm:2.6.1"
+    "@opentelemetry/sdk-logs": "npm:0.214.0"
+    "@opentelemetry/sdk-metrics": "npm:2.6.1"
+    "@opentelemetry/sdk-trace-base": "npm:2.6.1"
+    "@opentelemetry/sdk-trace-node": "npm:2.6.1"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10c0/b1eeee293c08fb6f692789ec79faefd65ebb9936b985816cdc7ed6d4f8708240f650baaabe9290268c3ec41ed07249d2508d1513e1d9158953db162a11812acd
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-trace-base@npm:2.6.1":
+  version: 2.6.1
+  resolution: "@opentelemetry/sdk-trace-base@npm:2.6.1"
+  dependencies:
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/resources": "npm:2.6.1"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10c0/4fd723d0b77cb182d8dbbaea0d7f7276756a9c6b3a1fc919417e5cb3732cc77e55703b0231d8445e7370dbf3e66006abacba93e1e79bfac0fcb987ca0cc9fc65
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-trace-node@npm:2.6.1":
+  version: 2.6.1
+  resolution: "@opentelemetry/sdk-trace-node@npm:2.6.1"
+  dependencies:
+    "@opentelemetry/context-async-hooks": "npm:2.6.1"
+    "@opentelemetry/core": "npm:2.6.1"
+    "@opentelemetry/sdk-trace-base": "npm:2.6.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10c0/60dbb98d2b459ca1286a48c865da755607a28a41250dead5ec262c674bd3f87c98d5a069af76edef5b4714779b519039fad66783c6542f7ab274804c2cefe818
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:^1.29.0":
+  version: 1.40.0
+  resolution: "@opentelemetry/semantic-conventions@npm:1.40.0"
+  checksum: 10c0/3259de0ea11b52eb70e44c12eba21448392baf9cb74c37b62071c4a5ed7fb89b61e194f3898d40ac6bfa7293617a0e132876cb6e355472b66de0cdb13c50b529
+  languageName: node
+  linkType: hard
+
+"@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/aspromise@npm:1.1.2"
+  checksum: 10c0/a83343a468ff5b5ec6bff36fd788a64c839e48a07ff9f4f813564f58caf44d011cd6504ed2147bf34835bd7a7dd2107052af755961c6b098fd8902b4f6500d0f
+  languageName: node
+  linkType: hard
+
+"@protobufjs/base64@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/base64@npm:1.1.2"
+  checksum: 10c0/eec925e681081af190b8ee231f9bad3101e189abbc182ff279da6b531e7dbd2a56f1f306f37a80b1be9e00aa2d271690d08dcc5f326f71c9eed8546675c8caf6
+  languageName: node
+  linkType: hard
+
+"@protobufjs/codegen@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@protobufjs/codegen@npm:2.0.4"
+  checksum: 10c0/26ae337c5659e41f091606d16465bbcc1df1f37cc1ed462438b1f67be0c1e28dfb2ca9f294f39100c52161aef82edf758c95d6d75650a1ddf31f7ddee1440b43
+  languageName: node
+  linkType: hard
+
+"@protobufjs/eventemitter@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/eventemitter@npm:1.1.0"
+  checksum: 10c0/1eb0a75180e5206d1033e4138212a8c7089a3d418c6dfa5a6ce42e593a4ae2e5892c4ef7421f38092badba4040ea6a45f0928869989411001d8c1018ea9a6e70
+  languageName: node
+  linkType: hard
+
+"@protobufjs/fetch@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/fetch@npm:1.1.0"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.1"
+    "@protobufjs/inquire": "npm:^1.1.0"
+  checksum: 10c0/cda6a3dc2d50a182c5865b160f72077aac197046600091dbb005dd0a66db9cce3c5eaed6d470ac8ed49d7bcbeef6ee5f0bc288db5ff9a70cbd003e5909065233
+  languageName: node
+  linkType: hard
+
+"@protobufjs/float@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@protobufjs/float@npm:1.0.2"
+  checksum: 10c0/18f2bdede76ffcf0170708af15c9c9db6259b771e6b84c51b06df34a9c339dbbeec267d14ce0bddd20acc142b1d980d983d31434398df7f98eb0c94a0eb79069
+  languageName: node
+  linkType: hard
+
+"@protobufjs/inquire@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/inquire@npm:1.1.0"
+  checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
+  languageName: node
+  linkType: hard
+
+"@protobufjs/path@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/path@npm:1.1.2"
+  checksum: 10c0/cece0a938e7f5dfd2fa03f8c14f2f1cf8b0d6e13ac7326ff4c96ea311effd5fb7ae0bba754fbf505312af2e38500250c90e68506b97c02360a43793d88a0d8b4
+  languageName: node
+  linkType: hard
+
+"@protobufjs/pool@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/pool@npm:1.1.0"
+  checksum: 10c0/eda2718b7f222ac6e6ad36f758a92ef90d26526026a19f4f17f668f45e0306a5bd734def3f48f51f8134ae0978b6262a5c517c08b115a551756d1a3aadfcf038
+  languageName: node
+  linkType: hard
+
+"@protobufjs/utf8@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/utf8@npm:1.1.0"
+  checksum: 10c0/a3fe31fe3fa29aa3349e2e04ee13dc170cc6af7c23d92ad49e3eeaf79b9766264544d3da824dba93b7855bd6a2982fb40032ef40693da98a136d835752beb487
   languageName: node
   linkType: hard
 
@@ -4108,6 +4650,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:>=13.7.0":
+  version: 25.6.0
+  resolution: "@types/node@npm:25.6.0"
+  dependencies:
+    undici-types: "npm:~7.19.0"
+  checksum: 10c0/d2d2015630ff098a201407f55f5077a20270ae4f465c739b40865cd9933b91b9c5d2b85568eadaf3db0801b91e267333ca7eb39f007428b173d1cdab4b339ac5
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^20":
   version: 20.19.39
   resolution: "@types/node@npm:20.19.39"
@@ -4531,6 +5082,15 @@ __metadata:
     mime-types: "npm:^3.0.0"
     negotiator: "npm:^1.0.0"
   checksum: 10c0/98374742097e140891546076215f90c32644feacf652db48412329de4c2a529178a81aa500fbb13dd3e6cbf6e68d829037b123ac037fc9a08bcec4b87b358eef
+  languageName: node
+  linkType: hard
+
+"acorn-import-attributes@npm:^1.9.5":
+  version: 1.9.5
+  resolution: "acorn-import-attributes@npm:1.9.5"
+  peerDependencies:
+    acorn: ^8
+  checksum: 10c0/5926eaaead2326d5a86f322ff1b617b0f698aa61dc719a5baa0e9d955c9885cc71febac3fb5bacff71bbf2c4f9c12db2056883c68c53eb962c048b952e1e013d
   languageName: node
   linkType: hard
 
@@ -5533,6 +6093,13 @@ __metadata:
   version: 3.9.0
   resolution: "ci-info@npm:3.9.0"
   checksum: 10c0/6f0109e36e111684291d46123d491bc4e7b7a1934c3a20dea28cba89f1d4a03acd892f5f6a81ed3855c38647e285a150e3c9ba062e38943bef57fee6c1554c3a
+  languageName: node
+  linkType: hard
+
+"cjs-module-lexer@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "cjs-module-lexer@npm:2.2.0"
+  checksum: 10c0/aec4ca58f87145fac221386790ecaae8b012f2e2359a45acb61d8c75ea4fa84f6ea869f17abc1a7e91a808eff0fed581209632f03540de16f72f0a28f5fd35ac
   languageName: node
   linkType: hard
 
@@ -8312,6 +8879,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"import-in-the-middle@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "import-in-the-middle@npm:3.0.1"
+  dependencies:
+    acorn: "npm:^8.15.0"
+    acorn-import-attributes: "npm:^1.9.5"
+    cjs-module-lexer: "npm:^2.2.0"
+    module-details-from-path: "npm:^1.0.4"
+  checksum: 10c0/afd314edb76764ff53d624e2868f5489a9fb81d22745da3db88121a962f422390b59be86fc5cb1158ed672025ece3b3f8a4943e5dde116bae3dac9f0ff5aff86
+  languageName: node
+  linkType: hard
+
 "imurmurhash@npm:^0.1.4":
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
@@ -9474,6 +10053,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.camelcase@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "lodash.camelcase@npm:4.3.0"
+  checksum: 10c0/fcba15d21a458076dd309fce6b1b4bf611d84a0ec252cb92447c948c533ac250b95d2e00955801ebc367e5af5ed288b996d75d37d2035260a937008e14eaf432
+  languageName: node
+  linkType: hard
+
 "lodash.debounce@npm:^4.0.8":
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
@@ -9511,6 +10097,13 @@ __metadata:
     chalk: "npm:^5.3.0"
     is-unicode-supported: "npm:^1.3.0"
   checksum: 10c0/36636cacedba8f067d2deb4aad44e91a89d9efb3ead27e1846e7b82c9a10ea2e3a7bd6ce28a7ca616bebc60954ff25c67b0f92d20a6a746bb3cc52c3701891f6
+  languageName: node
+  linkType: hard
+
+"long@npm:^5.0.0":
+  version: 5.3.2
+  resolution: "long@npm:5.3.2"
+  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
   languageName: node
   linkType: hard
 
@@ -10327,6 +10920,13 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: 10c0/46ea0f3ffa8bc6a5bc0c7081ffc3907777f0ed6516888d40a518c5111f8366d97d2678911ad1a6882bf592fa9de6c784fea32e1687bb94e1f4944170af48a5cf
+  languageName: node
+  linkType: hard
+
+"module-details-from-path@npm:^1.0.3, module-details-from-path@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "module-details-from-path@npm:1.0.4"
+  checksum: 10c0/10863413e96dab07dee917eae07afe46f7bf853065cc75a7d2a718adf67574857fb64f8a2c0c9af12ac733a9a8cf652db7ed39b95f7a355d08106cb9cc50c83b
   languageName: node
   linkType: hard
 
@@ -11535,6 +12135,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"protobufjs@npm:^7.0.0, protobufjs@npm:^7.5.3":
+  version: 7.5.4
+  resolution: "protobufjs@npm:7.5.4"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.2"
+    "@protobufjs/base64": "npm:^1.1.2"
+    "@protobufjs/codegen": "npm:^2.0.4"
+    "@protobufjs/eventemitter": "npm:^1.1.0"
+    "@protobufjs/fetch": "npm:^1.1.0"
+    "@protobufjs/float": "npm:^1.0.2"
+    "@protobufjs/inquire": "npm:^1.1.0"
+    "@protobufjs/path": "npm:^1.1.2"
+    "@protobufjs/pool": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.0"
+    "@types/node": "npm:>=13.7.0"
+    long: "npm:^5.0.0"
+  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
+  languageName: node
+  linkType: hard
+
 "proxy-addr@npm:^2.0.7":
   version: 2.0.7
   resolution: "proxy-addr@npm:2.0.7"
@@ -12099,6 +12719,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "relay-server@workspace:relay-server"
   dependencies:
+    "@langfuse/core": "npm:^5.1.0"
+    "@langfuse/otel": "npm:^5.1.0"
+    "@langfuse/tracing": "npm:^5.1.0"
+    "@opentelemetry/api": "npm:^1.9.1"
+    "@opentelemetry/sdk-node": "npm:^0.214.0"
     "@types/express": "npm:^5.0.2"
     "@types/ws": "npm:^8.18.1"
     dotenv: "npm:^16.4.7"
@@ -12120,6 +12745,16 @@ __metadata:
   version: 2.0.2
   resolution: "require-from-string@npm:2.0.2"
   checksum: 10c0/aaa267e0c5b022fc5fd4eef49d8285086b15f2a1c54b28240fdf03599cbd9c26049fee3eab894f2e1f6ca65e513b030a7c264201e3f005601e80c49fb2937ce2
+  languageName: node
+  linkType: hard
+
+"require-in-the-middle@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "require-in-the-middle@npm:8.0.1"
+  dependencies:
+    debug: "npm:^4.3.5"
+    module-details-from-path: "npm:^1.0.3"
+  checksum: 10c0/4b3d29adfff873585dceffa9ddb8f33bb6599001ddff758503e0e5ade2ae6d20d691314125bb13679fa75a19893338e11953d4702dd2fea181e95c0f8316b29b
   languageName: node
   linkType: hard
 
@@ -13790,6 +14425,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~7.19.0":
+  version: 7.19.2
+  resolution: "undici-types@npm:7.19.2"
+  checksum: 10c0/7159f10546f9f6c47d36776bb1bbf8671e87c1e587a6fee84ae1f111ae8de4f914efa8ca0dfcd224f4f4a9dfc3f6028f627ccb5ddaccf82d7fd54671b89fac3e
+  languageName: node
+  linkType: hard
+
 "unicode-canonical-property-names-ecmascript@npm:^2.0.0":
   version: 2.0.1
   resolution: "unicode-canonical-property-names-ecmascript@npm:2.0.1"
@@ -14448,7 +15090,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.6.1":
+"yaml@npm:^2.0.0, yaml@npm:^2.6.1":
   version: 2.8.3
   resolution: "yaml@npm:2.8.3"
   bin:


### PR DESCRIPTION
Refs [NAN-622](https://linear.app/nano3labs/issue/NAN-622).

Opening as **draft** — this PR is the landing strip for end-to-end tracing across device → relay → LLM. Scaffold-only in the first commit; spans, session/trace lifecycle, adapter instrumentation, and mobile timing forwarding land in subsequent commits.

## Scope (from the ticket)

- **Session** = one relay WS connection (preserved across Gemini goAway rotations)
- **Trace** = one voice turn
- **Observations** = `generation` for model calls, `agent` + nested `tool` for brain, `span` attrs for mobile-reported latencies

Langfuse *is* the dashboard — no custom UI in the relay. Openclaw/Hermes hooks are split out into NAN-623 spike.

## Commits planned on this branch

- [x] Scaffold + soft-disable (`46f9cb64`)
- [ ] Session/Trace lifecycle in `session.ts`
- [ ] Adapter instrumentation (Gemini + OpenAI Realtime) — manual because no wrapper SDK exists for Realtime WS protocols
- [ ] Mobile `client.timing` event + relay handler
- [ ] README + smoke test against a real Langfuse instance

## Test plan
- [x] `tsc --noEmit` clean
- [x] Relay starts with no `LANGFUSE_*` envs and logs `tracing disabled`
- [ ] Once keys provided: a voice turn produces a trace with nested STT/LLM/TTS spans in the Langfuse UI
- [ ] Rotation at 15-min boundary keeps the same `sessionId`

## Open question
**Cloud (US/EU) or self-hosted?** Either works — just need keys before the smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)