### PR TITLE
Cancel in-flight ask_brain when upstream cancels the tool call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ dist/
 
 # Claude Code worktrees
 .claude/worktrees/
+
+# Dev logs
+logs/

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   ],
   "scripts": {
     "dev": "concurrently --names mobile,web,server \"yarn dev:mobile\" \"yarn dev:web\" \"yarn dev:server\"",
-    "dev:server": "cd relay-server && yarn dev",
-    "dev:mobile": "cd mobile && yarn dev",
+    "dev:server": "cd relay-server && yarn dev 2>&1 | tee ../logs/relay.log",
+    "dev:mobile": "cd mobile && yarn dev 2>&1 | tee ../logs/mobile.log",
     "dev:web": "cd website && yarn dev",
     "build:web": "cd website && yarn build",
     "start:web": "cd website && yarn start",

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -372,7 +372,13 @@ export class GeminiAdapter implements ProviderAdapter {
     }
 
     if (msg.toolCallCancellation) {
-      log("[gemini] Tool call cancelled")
+      const ids: string[] = Array.isArray(msg.toolCallCancellation.ids)
+        ? msg.toolCallCancellation.ids.filter((id: unknown): id is string => typeof id === "string")
+        : []
+      log(`[gemini] Tool call cancelled: ${ids.join(", ") || "(no ids)"}`)
+      if (ids.length > 0) {
+        this.sendToClient?.({ type: "tool.cancelled", callIds: ids })
+      }
       this.pendingToolCalls = 0
       this.resetWatchdog()
       return

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -23,6 +23,7 @@ export class RelaySession {
   private startedAt: number = Date.now()
   private turnCount: number = 0
   private tracer = new TurnTracer()
+  private inFlightTools = new Map<string, AbortController>()
 
   constructor(ws: WebSocket) {
     this.ws = ws
@@ -65,6 +66,11 @@ export class RelaySession {
         this.tracer.attachUsage(event)
         // Internal only — do not forward to client
         return
+      case "tool.cancelled":
+        this.handleToolCancelled(event.callIds)
+        // Fall through — also forward to client so it can update UI
+        // (drop the "Let me check on that..." prefix, clear spinners, etc.)
+        break
     }
 
     // Intercept tool calls — handle server-side tools, forward the rest to client
@@ -113,6 +119,9 @@ export class RelaySession {
   private async handleAskBrain(callId: string, args: string) {
     if (!this.config) return
 
+    const controller = new AbortController()
+    this.inFlightTools.set(callId, controller)
+
     try {
       const parsed = JSON.parse(args)
       const query = parsed.query
@@ -137,18 +146,41 @@ export class RelaySession {
         gatewayUrl,
         authToken,
         sessionId: sessionKey,
-      }, sendToClient, callId)
+      }, sendToClient, callId, controller.signal)
 
       const brainMs = Date.now() - brainStart
       log(`[session:${this.id}] ask_brain completed in ${brainMs}ms`)
+      // If the upstream cancelled mid-flight, the callId is dead — don't echo
+      // a result back; it would be rejected and may confuse the model state.
+      if (controller.signal.aborted) {
+        log(`[session:${this.id}] ask_brain (${callId}) was cancelled — discarding result`)
+        this.tracer.endToolCall(callId, result, "cancelled")
+        return
+      }
       this.tracer.endToolCall(callId, result)
       this.adapter?.sendToolResult(callId, result)
     } catch (err) {
       const message = err instanceof Error ? err.message : "brain agent call failed"
+      if (controller.signal.aborted) {
+        log(`[session:${this.id}] ask_brain (${callId}) aborted: ${message}`)
+        this.tracer.endToolCall(callId, JSON.stringify({ error: message }), message)
+        return
+      }
       logError(`[session:${this.id}] ask_brain error:`, message)
       const errorPayload = JSON.stringify({ error: message })
       this.tracer.endToolCall(callId, errorPayload, message)
       this.adapter?.sendToolResult(callId, errorPayload)
+    } finally {
+      this.inFlightTools.delete(callId)
+    }
+  }
+
+  private handleToolCancelled(callIds: string[]) {
+    for (const callId of callIds) {
+      const controller = this.inFlightTools.get(callId)
+      if (!controller) continue
+      log(`[session:${this.id}] Aborting in-flight tool ${callId}`)
+      controller.abort(new Error("upstream cancelled tool call"))
     }
   }
 
@@ -193,6 +225,7 @@ export class RelaySession {
     // Disconnect previous adapter if session.config is sent again
     if (this.adapter) {
       log(`[session:${this.id}] Replacing existing adapter`)
+      this.abortAllInFlightTools("session replaced")
       this.adapter.disconnect()
       this.adapter = null
       // Close out any spans still attributed to the old logical session before
@@ -231,10 +264,20 @@ export class RelaySession {
 
   private cleanup() {
     log(`[session:${this.id}] Disconnecting`)
+    this.abortAllInFlightTools("session ended")
     this.tracer.endSession()
     this.syncTranscriptToBrain()
     this.adapter?.disconnect()
     this.adapter = null
+  }
+
+  private abortAllInFlightTools(reason: string) {
+    if (this.inFlightTools.size === 0) return
+    log(`[session:${this.id}] Aborting ${this.inFlightTools.size} in-flight tool(s): ${reason}`)
+    for (const controller of this.inFlightTools.values()) {
+      controller.abort(new Error(reason))
+    }
+    this.inFlightTools.clear()
   }
 
   private syncTranscriptToBrain() {
@@ -258,14 +301,49 @@ export class RelaySession {
 
     const gatewayUrl = process.env.OPENCLAW_GATEWAY_URL || "http://localhost:18789"
     const authToken = process.env.OPENCLAW_GATEWAY_AUTH_TOKEN || this.config.apiKey
-
-    log(`[session:${this.id}] Syncing transcript to brain (${transcript.length} turns, ${durationMin}min)`)
-
-    // Fire-and-forget — don't block cleanup
-    const noop: SendToClient = () => {}
     const sessionKey = this.config.sessionKey || `voiceclaw:realtime`
-    askBrain(prompt, { gatewayUrl, authToken, sessionId: sessionKey }, noop, "transcript-sync").catch((err) => {
-      logError(`[session:${this.id}] Transcript sync failed:`, err instanceof Error ? err.message : err)
-    })
+    const sessionId = this.id
+
+    log(`[session:${sessionId}] Syncing transcript to brain (${transcript.length} turns, ${durationMin}min)`)
+
+    // Fire-and-forget with bounded retries — gateway may be busy with the
+    // tail of an ask_brain call that hadn't finished when the session ended.
+    void retryTranscriptSync({ prompt, gatewayUrl, authToken, sessionKey, sessionId })
+  }
+}
+
+const TRANSCRIPT_SYNC_BACKOFF_MS = [5_000, 30_000, 120_000]
+const noopSendToClient: SendToClient = () => {}
+
+async function retryTranscriptSync(opts: {
+  prompt: string
+  gatewayUrl: string
+  authToken: string
+  sessionKey: string
+  sessionId: string
+}) {
+  const { prompt, gatewayUrl, authToken, sessionKey, sessionId } = opts
+  for (let attempt = 1; attempt <= TRANSCRIPT_SYNC_BACKOFF_MS.length + 1; attempt++) {
+    try {
+      await askBrain(
+        prompt,
+        { gatewayUrl, authToken, sessionId: sessionKey },
+        noopSendToClient,
+        "transcript-sync",
+      )
+      if (attempt > 1) {
+        log(`[session:${sessionId}] Transcript sync succeeded on attempt ${attempt}`)
+      }
+      return
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      const backoff = TRANSCRIPT_SYNC_BACKOFF_MS[attempt - 1]
+      if (backoff === undefined) {
+        logError(`[session:${sessionId}] Transcript sync gave up after ${attempt} attempts: ${message}`)
+        return
+      }
+      logError(`[session:${sessionId}] Transcript sync attempt ${attempt} failed (${message}), retrying in ${backoff}ms`)
+      await new Promise((resolve) => setTimeout(resolve, backoff))
+    }
   }
 }

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -161,11 +161,6 @@ export class RelaySession {
       this.adapter?.sendToolResult(callId, result)
     } catch (err) {
       const message = err instanceof Error ? err.message : "brain agent call failed"
-      if (controller.signal.aborted) {
-        log(`[session:${this.id}] ask_brain (${callId}) aborted: ${message}`)
-        this.tracer.endToolCall(callId, JSON.stringify({ error: message }), message)
-        return
-      }
       logError(`[session:${this.id}] ask_brain error:`, message)
       const errorPayload = JSON.stringify({ error: message })
       this.tracer.endToolCall(callId, errorPayload, message)

--- a/relay-server/src/tools/brain.ts
+++ b/relay-server/src/tools/brain.ts
@@ -66,9 +66,7 @@ export async function askBrain(
     })
   } catch (err) {
     cleanup()
-    if (err instanceof DOMException && err.name === "AbortError") {
-      const reason = controller.signal.reason
-      if (reason instanceof Error) throw reason
+    if (controller.signal.aborted) {
       return JSON.stringify({ error: "Brain agent request aborted" })
     }
     throw err
@@ -101,8 +99,6 @@ export async function askBrain(
       const elapsed = Date.now() - requestStart
       logError(`[brain] reader.read() threw after ${elapsed}ms readCount=${readCount} aborted=${controller.signal.aborted}:`, err)
       if (controller.signal.aborted) {
-        const reason = controller.signal.reason
-        if (reason instanceof Error) throw reason
         return JSON.stringify({ error: "Brain agent request aborted" })
       }
       throw err

--- a/relay-server/src/tools/brain.ts
+++ b/relay-server/src/tools/brain.ts
@@ -87,63 +87,65 @@ export async function askBrain(
   let buffer = ""
 
   let readCount = 0
-  while (true) {
-    let read: ReadableStreamReadResult<Uint8Array>
-    try {
-      read = await reader.read()
-    } catch (err) {
-      clearTimeout(timeout)
-      externalSignal?.removeEventListener("abort", onExternalAbort)
-      const elapsed = Date.now() - requestStart
-      logError(`[brain] reader.read() threw after ${elapsed}ms readCount=${readCount} aborted=${controller.signal.aborted}:`, err)
-      if (controller.signal.aborted) {
-        const reason = controller.signal.reason
-        if (reason instanceof Error) throw reason
-        return JSON.stringify({ error: "Brain agent request aborted" })
-      }
-      throw err
-    }
-    readCount++
-    const { done, value } = read
-    if (done) break
-
-    buffer += decoder.decode(value, { stream: true })
-    const lines = buffer.split("\n")
-    buffer = lines.pop() ?? ""
-
-    for (const line of lines) {
-      if (!line.startsWith("data: ")) continue
-      const data = line.slice(6).trim()
-
-      if (data === "[DONE]") continue
-
+  try {
+    while (true) {
+      let read: ReadableStreamReadResult<Uint8Array>
       try {
-        const parsed = JSON.parse(data)
-
-        // Check for step completion signals (live progress injection)
-        if (parsed.type === "step_complete" && parsed.summary) {
-          log(`[brain] Step complete: ${parsed.summary}`)
-          sendToClient({
-            type: "tool.progress",
-            callId,
-            summary: parsed.summary,
-          })
-          continue
+        read = await reader.read()
+      } catch (err) {
+        const elapsed = Date.now() - requestStart
+        logError(`[brain] reader.read() threw after ${elapsed}ms readCount=${readCount} aborted=${controller.signal.aborted}:`, err)
+        if (controller.signal.aborted) {
+          const reason = controller.signal.reason
+          if (reason instanceof Error) throw reason
+          return JSON.stringify({ error: "Brain agent request aborted" })
         }
+        throw err
+      }
+      readCount++
+      const { done, value } = read
+      if (done) break
 
-        // Standard OpenAI-compatible SSE chunk
-        const delta = parsed.choices?.[0]?.delta?.content
-        if (delta) {
-          fullResponse += delta
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split("\n")
+      buffer = lines.pop() ?? ""
+
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) continue
+        const data = line.slice(6).trim()
+
+        if (data === "[DONE]") continue
+
+        try {
+          const parsed = JSON.parse(data)
+
+          // Check for step completion signals (live progress injection)
+          if (parsed.type === "step_complete" && parsed.summary) {
+            log(`[brain] Step complete: ${parsed.summary}`)
+            sendToClient({
+              type: "tool.progress",
+              callId,
+              summary: parsed.summary,
+            })
+            continue
+          }
+
+          // Standard OpenAI-compatible SSE chunk
+          const delta = parsed.choices?.[0]?.delta?.content
+          if (delta) {
+            fullResponse += delta
+          }
+        } catch {
+          // Skip unparseable chunks
         }
-      } catch {
-        // Skip unparseable chunks
       }
     }
+  } finally {
+    reader.cancel().catch(() => {})
+    clearTimeout(timeout)
+    externalSignal?.removeEventListener("abort", onExternalAbort)
   }
 
-  clearTimeout(timeout)
-  externalSignal?.removeEventListener("abort", onExternalAbort)
   log(`[brain] Response: ${fullResponse.substring(0, 100)}...`)
   return fullResponse || JSON.stringify({ error: "Empty response from brain agent" })
 }

--- a/relay-server/src/tools/brain.ts
+++ b/relay-server/src/tools/brain.ts
@@ -1,7 +1,6 @@
 // Brain agent tool — sends queries to OpenClaw via /v1/chat/completions
 // Uses SSE streaming to get responses, signals step completions for live progress injection
 
-import type { SessionConfigEvent } from "../types.js"
 import type { SendToClient } from "../adapters/types.js"
 import { log, error as logError } from "../log.js"
 
@@ -16,13 +15,31 @@ export async function askBrain(
   config: BrainConfig,
   sendToClient: SendToClient,
   callId: string,
+  externalSignal?: AbortSignal,
 ): Promise<string> {
   const url = `${config.gatewayUrl.replace(/\/$/, "")}/v1/chat/completions`
 
   log(`[brain] Sending query to ${url}: ${query.substring(0, 80)}...`)
 
   const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 120_000) // 2 min — gateway may need exec approval
+  const timeout = setTimeout(() => controller.abort(new Error("local 120s timeout")), 120_000) // 2 min — gateway may need exec approval
+  const requestStart = Date.now()
+  const onExternalAbort = () => {
+    const reason = externalSignal?.reason
+    controller.abort(reason instanceof Error ? reason : new Error(String(reason ?? "external abort")))
+  }
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      onExternalAbort()
+    } else {
+      externalSignal.addEventListener("abort", onExternalAbort, { once: true })
+    }
+  }
+  controller.signal.addEventListener("abort", () => {
+    const reason = controller.signal.reason
+    const reasonMsg = reason instanceof Error ? `${reason.name}: ${reason.message}` : String(reason)
+    logError(`[brain] signal aborted after ${Date.now() - requestStart}ms — reason: ${reasonMsg}`)
+  })
 
   let response: Response
   try {
@@ -44,8 +61,11 @@ export async function askBrain(
     })
   } catch (err) {
     clearTimeout(timeout)
+    externalSignal?.removeEventListener("abort", onExternalAbort)
     if (err instanceof DOMException && err.name === "AbortError") {
-      return JSON.stringify({ error: "Brain agent request timed out" })
+      const reason = controller.signal.reason
+      if (reason instanceof Error) throw reason
+      return JSON.stringify({ error: "Brain agent request aborted" })
     }
     throw err
   }
@@ -66,8 +86,25 @@ export async function askBrain(
   let fullResponse = ""
   let buffer = ""
 
+  let readCount = 0
   while (true) {
-    const { done, value } = await reader.read()
+    let read: ReadableStreamReadResult<Uint8Array>
+    try {
+      read = await reader.read()
+    } catch (err) {
+      clearTimeout(timeout)
+      externalSignal?.removeEventListener("abort", onExternalAbort)
+      const elapsed = Date.now() - requestStart
+      logError(`[brain] reader.read() threw after ${elapsed}ms readCount=${readCount} aborted=${controller.signal.aborted}:`, err)
+      if (controller.signal.aborted) {
+        const reason = controller.signal.reason
+        if (reason instanceof Error) throw reason
+        return JSON.stringify({ error: "Brain agent request aborted" })
+      }
+      throw err
+    }
+    readCount++
+    const { done, value } = read
     if (done) break
 
     buffer += decoder.decode(value, { stream: true })
@@ -106,6 +143,7 @@ export async function askBrain(
   }
 
   clearTimeout(timeout)
+  externalSignal?.removeEventListener("abort", onExternalAbort)
   log(`[brain] Response: ${fullResponse.substring(0, 100)}...`)
   return fullResponse || JSON.stringify({ error: "Empty response from brain agent" })
 }

--- a/relay-server/src/tools/brain.ts
+++ b/relay-server/src/tools/brain.ts
@@ -41,6 +41,11 @@ export async function askBrain(
     logError(`[brain] signal aborted after ${Date.now() - requestStart}ms — reason: ${reasonMsg}`)
   })
 
+  const cleanup = () => {
+    clearTimeout(timeout)
+    externalSignal?.removeEventListener("abort", onExternalAbort)
+  }
+
   let response: Response
   try {
     response = await fetch(url, {
@@ -60,8 +65,7 @@ export async function askBrain(
       signal: controller.signal,
     })
   } catch (err) {
-    clearTimeout(timeout)
-    externalSignal?.removeEventListener("abort", onExternalAbort)
+    cleanup()
     if (err instanceof DOMException && err.name === "AbortError") {
       const reason = controller.signal.reason
       if (reason instanceof Error) throw reason
@@ -87,65 +91,62 @@ export async function askBrain(
   let buffer = ""
 
   let readCount = 0
-  try {
-    while (true) {
-      let read: ReadableStreamReadResult<Uint8Array>
-      try {
-        read = await reader.read()
-      } catch (err) {
-        const elapsed = Date.now() - requestStart
-        logError(`[brain] reader.read() threw after ${elapsed}ms readCount=${readCount} aborted=${controller.signal.aborted}:`, err)
-        if (controller.signal.aborted) {
-          const reason = controller.signal.reason
-          if (reason instanceof Error) throw reason
-          return JSON.stringify({ error: "Brain agent request aborted" })
-        }
-        throw err
+  while (true) {
+    let read: ReadableStreamReadResult<Uint8Array>
+    try {
+      read = await reader.read()
+    } catch (err) {
+      reader.cancel().catch(() => {})
+      cleanup()
+      const elapsed = Date.now() - requestStart
+      logError(`[brain] reader.read() threw after ${elapsed}ms readCount=${readCount} aborted=${controller.signal.aborted}:`, err)
+      if (controller.signal.aborted) {
+        const reason = controller.signal.reason
+        if (reason instanceof Error) throw reason
+        return JSON.stringify({ error: "Brain agent request aborted" })
       }
-      readCount++
-      const { done, value } = read
-      if (done) break
+      throw err
+    }
+    readCount++
+    const { done, value } = read
+    if (done) break
 
-      buffer += decoder.decode(value, { stream: true })
-      const lines = buffer.split("\n")
-      buffer = lines.pop() ?? ""
+    buffer += decoder.decode(value, { stream: true })
+    const lines = buffer.split("\n")
+    buffer = lines.pop() ?? ""
 
-      for (const line of lines) {
-        if (!line.startsWith("data: ")) continue
-        const data = line.slice(6).trim()
+    for (const line of lines) {
+      if (!line.startsWith("data: ")) continue
+      const data = line.slice(6).trim()
 
-        if (data === "[DONE]") continue
+      if (data === "[DONE]") continue
 
-        try {
-          const parsed = JSON.parse(data)
+      try {
+        const parsed = JSON.parse(data)
 
-          // Check for step completion signals (live progress injection)
-          if (parsed.type === "step_complete" && parsed.summary) {
-            log(`[brain] Step complete: ${parsed.summary}`)
-            sendToClient({
-              type: "tool.progress",
-              callId,
-              summary: parsed.summary,
-            })
-            continue
-          }
-
-          // Standard OpenAI-compatible SSE chunk
-          const delta = parsed.choices?.[0]?.delta?.content
-          if (delta) {
-            fullResponse += delta
-          }
-        } catch {
-          // Skip unparseable chunks
+        // Check for step completion signals (live progress injection)
+        if (parsed.type === "step_complete" && parsed.summary) {
+          log(`[brain] Step complete: ${parsed.summary}`)
+          sendToClient({
+            type: "tool.progress",
+            callId,
+            summary: parsed.summary,
+          })
+          continue
         }
+
+        // Standard OpenAI-compatible SSE chunk
+        const delta = parsed.choices?.[0]?.delta?.content
+        if (delta) {
+          fullResponse += delta
+        }
+      } catch {
+        // Skip unparseable chunks
       }
     }
-  } finally {
-    reader.cancel().catch(() => {})
-    clearTimeout(timeout)
-    externalSignal?.removeEventListener("abort", onExternalAbort)
   }
 
+  cleanup()
   log(`[brain] Response: ${fullResponse.substring(0, 100)}...`)
   return fullResponse || JSON.stringify({ error: "Empty response from brain agent" })
 }

--- a/relay-server/src/types.ts
+++ b/relay-server/src/types.ts
@@ -79,6 +79,7 @@ export type RelayEvent =
   | SessionRotatingEvent
   | SessionRotatedEvent
   | UsageMetricsEvent
+  | ToolCancelledEvent
   | ErrorEvent
 
 export interface SessionReadyEvent {
@@ -151,6 +152,16 @@ export interface UsageMetricsEvent {
   totalTokens?: number
   inputAudioTokens?: number
   outputAudioTokens?: number
+}
+
+// Adapter signals that the upstream model gave up on a tool call
+// (e.g., Gemini toolCallCancellation). Session uses this to abort the matching
+// in-flight server-side fetch so the gateway slot is released, then forwards
+// the event to the client so it can update UI (drop speculative prefixes,
+// clear spinners, etc.).
+export interface ToolCancelledEvent {
+  type: "tool.cancelled"
+  callIds: string[]
 }
 
 export interface ErrorEvent {


### PR DESCRIPTION
## Summary
- Fixes the relay losing its voice after a few barge-ins on Gemini. Each `toolCallCancellation` was leaking the in-flight gateway fetch — zombies queued behind each other and timed out at 120s, blocking every subsequent `ask_brain` call.
- Relay now tracks in-flight server-side tool calls by `callId` and aborts the matching fetch when the upstream cancels (or session is replaced / cleaned up). Cancelled callIds are also forwarded to the client so the mobile UI can drop the speculative "Let me check on that…" prefix.
- Transcript-sync (`syncTranscriptToBrain`) now retries with bounded backoff (5s / 30s / 120s) — same gateway congestion was wiping post-session memory writes.

## Repro that triggered this
From `logs/relay.log`: 4 `ask_brain` calls fired during one Gemini turn, each cancelled by barge-in. Only the first received any response bytes; the other three got `readCount=0` and aborted at the local 120s timer because the gateway serializes per session key.

## Notes
- OpenAI Realtime adapter doesn't get a parallel "cancel this tool" event from upstream, so nothing changes there. If we want barge-in to abort in-flight tools on OpenAI too, we can hook it from `response.cancel` separately.
- Adds `logs/` (gitignored) + `dev:server` / `dev:mobile` tee scripts — Rails-style log dir that made this diagnosis possible.

## Test plan
- [ ] On Gemini: ask a long brain query, barge in mid-tool-call multiple times. Verify relay logs show `Aborting in-flight tool <callId>` and the next `ask_brain` is not blocked.
- [ ] Verify mobile receives `tool.cancelled` events (no client handler yet — just confirm wire format).
- [ ] End a session while `ask_brain` is in-flight; confirm `Aborting N in-flight tool(s): session ended` and transcript sync still attempts (with retries on failure).
- [ ] On OpenAI: smoke test that nothing regressed (no `tool.cancelled` path exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)