### PR TITLE
Add echo gate debug controls and RMS overlay

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -10,7 +10,7 @@ import { useConversationContext } from '@/lib/conversation-context'
 import { maybeGenerateTitle } from '@/lib/title'
 import { useCallSounds } from '@/lib/sounds'
 import { usePipeline } from '@/lib/use-pipeline'
-import { useRealtime } from '@/lib/use-realtime'
+import { useRealtime, type RmsMetrics } from '@/lib/use-realtime'
 import { useTranscriptBuffer } from '@/lib/use-transcript-buffer'
 import { useAutoReconnect } from '@/lib/use-auto-reconnect'
 import ExpoCustomPipelineModule from '@/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule'
@@ -126,6 +126,7 @@ export default function ChatScreen() {
   const cancelReconnectRef = useRef<(() => void) | null>(null)
   const triggerReconnectRef = useRef<(() => void) | null>(null)
   const [pipelineDebugState, setPipelineDebugState] = useState(INITIAL_PIPELINE_DEBUG_STATE)
+  const [rmsMetrics, setRmsMetrics] = useState<RmsMetrics | null>(null)
   const conversationIdRef = useRef<number | null>(null)
   conversationIdRef.current = conversationId
 
@@ -320,6 +321,9 @@ export default function ChatScreen() {
           addMessage(convId, 'assistant', 'Authentication failed. Check your OpenClaw gateway URL and auth token in Settings.').then(() => loadMessagesRef.current())
         }
       }
+    },
+    onRmsMetrics: (metrics) => {
+      setRmsMetrics(metrics)
     },
   })
 
@@ -917,6 +921,12 @@ export default function ChatScreen() {
     const tracingEnabled = tracingPref === null || tracingPref === undefined
       ? __DEV__
       : tracingPref === 'true'
+    const echoGatePref = await getSetting('echo_gate_enabled')
+    const echoGateEnabled = echoGatePref === null ? true : echoGatePref === 'true'
+    const echoGateThresholdPref = await getSetting('echo_gate_threshold')
+    const echoGateThreshold = echoGateThresholdPref ? parseFloat(echoGateThresholdPref) : 0.06
+    const debugPref = await getSetting('debug_mode')
+    const isDebug = debugPref === 'true'
 
     if (!apiKey) {
       await addMessage(conversationId, 'assistant', 'Please configure your API key in the Realtime settings first.')
@@ -941,7 +951,7 @@ export default function ChatScreen() {
       .slice(-20)
       .map((m) => ({ role: m.role as 'user' | 'assistant', text: m.content }))
 
-    console.log('[Realtime] Starting session with', { serverUrl, voice, model, historyMessages: recentMessages.length })
+    console.log('[Realtime] Starting session with', { serverUrl, voice, model, historyMessages: recentMessages.length, echoGateEnabled, echoGateThreshold })
     realtime.start({
       serverUrl,
       voice,
@@ -950,6 +960,9 @@ export default function ChatScreen() {
       apiKey,
       sessionKey: `voiceclaw:${conversationId}`,
       volume,
+      echoGateEnabled,
+      echoGateThreshold,
+      debugMode: isDebug,
       deviceContext: {
         timezone,
         locale,
@@ -1164,6 +1177,51 @@ export default function ChatScreen() {
             <Button testID="simulate-interrupt-transcript-button" variant="secondary" size="sm" onPress={() => simulatePipelineTranscript('Actually stop the dragon story and reply with exactly: redirect successful.')}>
               <Text className="text-xs text-foreground">Redirect Turn</Text>
             </Button>
+          </View>
+        </View>
+      )}
+
+      {debugMode && isCallActive && activeVoiceModeRef.current === 'realtime' && rmsMetrics && (
+        <View testID="rms-debug-panel" className="gap-2 border-t border-dashed border-border bg-background px-4 py-3">
+          <Text className="text-xs font-semibold text-muted-foreground">Audio Debug</Text>
+          <View className="flex-row items-center gap-2">
+            <Text className="w-12 text-xs text-muted-foreground">RMS</Text>
+            <View className="h-4 flex-1 overflow-hidden rounded bg-muted">
+              <View
+                style={{
+                  width: `${Math.min(rmsMetrics.rms * 500, 100)}%`,
+                  backgroundColor: rmsMetrics.gated ? '#ef4444' : rmsMetrics.playbackActive ? '#f59e0b' : '#22c55e',
+                }}
+                className="h-full rounded"
+              />
+              <View
+                style={{
+                  position: 'absolute',
+                  left: `${Math.min(rmsMetrics.threshold * 500, 100)}%`,
+                  top: 0,
+                  bottom: 0,
+                  width: 2,
+                  backgroundColor: '#ffffff',
+                }}
+              />
+            </View>
+            <Text className="w-16 text-right text-xs tabular-nums text-muted-foreground">
+              {rmsMetrics.rms.toFixed(4)}
+            </Text>
+          </View>
+          <View className="flex-row flex-wrap gap-3">
+            <Text className="text-xs text-muted-foreground">
+              gate:{rmsMetrics.gated ? 'GATED' : 'open'}
+            </Text>
+            <Text className="text-xs text-muted-foreground">
+              playback:{rmsMetrics.playbackActive ? 'on' : 'off'}
+            </Text>
+            <Text className="text-xs text-muted-foreground">
+              threshold:{rmsMetrics.threshold.toFixed(3)}
+            </Text>
+            <Text className="text-xs text-muted-foreground">
+              route:{rmsMetrics.route}
+            </Text>
           </View>
         </View>
       )}

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -90,6 +90,10 @@ export default function SettingsScreen() {
   // Debug mode
   const [debugMode, setDebugMode] = useState(false)
 
+  // Echo gate settings
+  const [echoGateEnabled, setEchoGateEnabled] = useState(true)
+  const [echoGateThreshold, setEchoGateThreshold] = useState(0.06)
+
   // Show latency
   const [showLatency, setShowLatencyState] = useState(false)
 
@@ -233,6 +237,10 @@ export default function SettingsScreen() {
       }
       const dm = await getSetting('debug_mode')
       if (dm === 'true') setDebugMode(true)
+      const ege = await getSetting('echo_gate_enabled')
+      if (ege === 'false') setEchoGateEnabled(false)
+      const egt = await getSetting('echo_gate_threshold')
+      if (egt) setEchoGateThreshold(parseFloat(egt))
       const sl = await getSetting('show_latency')
       if (sl === 'true') setShowLatencyState(true)
       const tr = await getSetting('tracing_enabled')
@@ -414,6 +422,16 @@ export default function SettingsScreen() {
   const toggleDebugMode = useCallback((v: boolean) => {
     setDebugMode(v)
     setSetting('debug_mode', v ? 'true' : 'false')
+  }, [])
+
+  const toggleEchoGate = useCallback((v: boolean) => {
+    setEchoGateEnabled(v)
+    setSetting('echo_gate_enabled', v ? 'true' : 'false')
+  }, [])
+
+  const updateEchoGateThreshold = useCallback((v: number) => {
+    setEchoGateThreshold(v)
+    setSetting('echo_gate_threshold', v.toFixed(4))
   }, [])
 
   const toggleShowLatency = useCallback((v: boolean) => {
@@ -830,6 +848,46 @@ export default function SettingsScreen() {
               onValueChange={toggleDebugMode}
             />
           </View>
+
+          {debugMode && (
+            <View className="mt-2 gap-3 border-t border-border pt-3">
+              <View className="flex-row items-center justify-between">
+                <View className="flex-1">
+                  <Text className="text-sm font-medium text-foreground">Echo Gate</Text>
+                  <Text className="text-xs text-muted-foreground">
+                    Client-side RMS gate during playback — disable to let Gemini&apos;s server VAD handle interruption
+                  </Text>
+                </View>
+                <Switch
+                  testID="echo-gate-toggle"
+                  value={echoGateEnabled}
+                  onValueChange={toggleEchoGate}
+                />
+              </View>
+
+              {echoGateEnabled && (
+                <View className="gap-1">
+                  <View className="flex-row items-center justify-between">
+                    <Text className="text-sm font-medium text-foreground">Gate Threshold</Text>
+                    <Text className="text-xs tabular-nums text-muted-foreground">{echoGateThreshold.toFixed(3)}</Text>
+                  </View>
+                  <Slider
+                    testID="echo-gate-threshold-slider"
+                    minimumValue={0.01}
+                    maximumValue={0.2}
+                    step={0.005}
+                    value={echoGateThreshold}
+                    onSlidingComplete={updateEchoGateThreshold}
+                    minimumTrackTintColor="#3b82f6"
+                    maximumTrackTintColor="#6b7280"
+                  />
+                  <Text className="text-xs text-muted-foreground">
+                    Lower = more sensitive to voice during playback. Default: 0.060
+                  </Text>
+                </View>
+              )}
+            </View>
+          )}
         </Card>
 
         <Card testID="show-latency-card" className="gap-2 p-4">

--- a/mobile/lib/use-realtime.ts
+++ b/mobile/lib/use-realtime.ts
@@ -12,6 +12,9 @@ export interface RealtimeConfig {
   apiKey: string
   sessionKey?: string
   volume?: number
+  echoGateEnabled?: boolean
+  echoGateThreshold?: number
+  debugMode?: boolean
   deviceContext?: {
     timezone?: string
     locale?: string
@@ -20,6 +23,14 @@ export interface RealtimeConfig {
   instructionsOverride?: string
   conversationHistory?: { role: 'user' | 'assistant', text: string }[]
   tracingEnabled?: boolean
+}
+
+export interface RmsMetrics {
+  rms: number
+  playbackActive: boolean
+  gated: boolean
+  threshold: number
+  route: string
 }
 
 export interface RealtimeCallbacks {
@@ -33,6 +44,7 @@ export interface RealtimeCallbacks {
   onSessionEnded?: (summary: string) => void
   onDisconnect?: () => void
   onError?: (message: string, code: number) => void
+  onRmsMetrics?: (metrics: RmsMetrics) => void
 }
 
 export interface RealtimeControls {
@@ -80,6 +92,17 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
     return () => sub.remove()
   }, [])
 
+  // Forward RMS metrics to callback
+  useEffect(() => {
+    const sub = ExpoRealtimeAudioModule.addListener(
+      'onRmsMetrics',
+      (event: RmsMetrics) => {
+        callbacksRef.current.onRmsMetrics?.(event)
+      },
+    )
+    return () => sub.remove()
+  }, [])
+
   // Listen for audio from native module and forward to WebSocket
   useEffect(() => {
     const subscription = ExpoRealtimeAudioModule.addListener(
@@ -105,9 +128,16 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
       case 'session.ready':
         setSessionId(data.sessionId)
         setIsConnected(true)
-        if (configRef.current?.volume && typeof ExpoRealtimeAudioModule.setVolume === 'function') {
+        if (configRef.current?.volume != null) {
           ExpoRealtimeAudioModule.setVolume(configRef.current.volume)
         }
+        if (configRef.current?.echoGateEnabled != null) {
+          ExpoRealtimeAudioModule.setEchoGateEnabled(configRef.current.echoGateEnabled)
+        }
+        if (configRef.current?.echoGateThreshold != null) {
+          ExpoRealtimeAudioModule.setEchoGateThreshold(configRef.current.echoGateThreshold)
+        }
+        ExpoRealtimeAudioModule.setDebugMetricsEnabled(configRef.current?.debugMode ?? false)
         cb.onSessionReady?.(data.sessionId)
         break
 

--- a/mobile/modules/expo-realtime-audio/ios/ExpoRealtimeAudioModule.swift
+++ b/mobile/modules/expo-realtime-audio/ios/ExpoRealtimeAudioModule.swift
@@ -7,16 +7,29 @@ public class ExpoRealtimeAudioModule: Module {
     public func definition() -> ModuleDefinition {
         Name("ExpoRealtimeAudio")
 
-        Events("onAudioCaptured", "onError", "onLog")
+        Events("onAudioCaptured", "onError", "onLog", "onRmsMetrics")
 
         OnCreate {
-            self.audioManager = RealtimeAudioManager { [weak self] base64Audio in
-                self?.sendEvent("onAudioCaptured", ["data": base64Audio])
-            } onError: { [weak self] message in
-                self?.sendEvent("onError", ["message": message])
-            } onLog: { [weak self] message in
-                self?.sendEvent("onLog", ["message": message])
-            }
+            self.audioManager = RealtimeAudioManager(
+                onAudioCaptured: { [weak self] base64Audio in
+                    self?.sendEvent("onAudioCaptured", ["data": base64Audio])
+                },
+                onError: { [weak self] message in
+                    self?.sendEvent("onError", ["message": message])
+                },
+                onLog: { [weak self] message in
+                    self?.sendEvent("onLog", ["message": message])
+                },
+                onRmsMetrics: { [weak self] rms, playbackActive, gated, threshold, route in
+                    self?.sendEvent("onRmsMetrics", [
+                        "rms": rms,
+                        "playbackActive": playbackActive,
+                        "gated": gated,
+                        "threshold": threshold,
+                        "route": route,
+                    ])
+                }
+            )
         }
 
         Function("startCapture") { () in
@@ -41,6 +54,18 @@ public class ExpoRealtimeAudioModule: Module {
 
         Function("setVolume") { (volume: Float) in
             self.audioManager?.setVolume(volume)
+        }
+
+        Function("setEchoGateEnabled") { (enabled: Bool) in
+            self.audioManager?.setEchoGateEnabled(enabled)
+        }
+
+        Function("setEchoGateThreshold") { (threshold: Float) in
+            self.audioManager?.setEchoGateThreshold(threshold)
+        }
+
+        Function("setDebugMetricsEnabled") { (enabled: Bool) in
+            self.audioManager?.setDebugMetricsEnabled(enabled)
         }
     }
 }

--- a/mobile/modules/expo-realtime-audio/ios/RealtimeAudioManager.swift
+++ b/mobile/modules/expo-realtime-audio/ios/RealtimeAudioManager.swift
@@ -16,7 +16,11 @@ class RealtimeAudioManager {
 
     // Echo gate: RMS threshold during playback. Speech is typically 0.05-0.3,
     // speaker echo with .default mode is typically 0.01-0.05. Tune as needed.
-    private let echoGateThreshold: Float = 0.06
+    private var echoGateEnabled: Bool = true
+    private var echoGateThreshold: Float = 0.06
+
+    // Debug: emit RMS metrics to JS when enabled
+    private var debugMetricsEnabled: Bool = false
 
     private var audioEngine: AVAudioEngine?
     private var playerNode: AVAudioPlayerNode?
@@ -29,14 +33,21 @@ class RealtimeAudioManager {
     private let onAudioCaptured: (String) -> Void
     private let onError: (String) -> Void
     private let onLog: (String) -> Void
+    private let onRmsMetrics: (Float, Bool, Bool, Float, String) -> Void
 
     // Playback format: 24kHz Float32 mono (AVAudioEngine works best with Float32)
     private let playbackFormat: AVAudioFormat
 
-    init(onAudioCaptured: @escaping (String) -> Void, onError: @escaping (String) -> Void, onLog: @escaping (String) -> Void) {
+    init(
+        onAudioCaptured: @escaping (String) -> Void,
+        onError: @escaping (String) -> Void,
+        onLog: @escaping (String) -> Void,
+        onRmsMetrics: @escaping (Float, Bool, Bool, Float, String) -> Void
+    ) {
         self.onAudioCaptured = onAudioCaptured
         self.onError = onError
         self.onLog = onLog
+        self.onRmsMetrics = onRmsMetrics
         self.playbackFormat = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
             sampleRate: 24000,
@@ -105,17 +116,27 @@ class RealtimeAudioManager {
             for j in 0..<frameCount { sumSquares += channelData[j] * channelData[j] }
             let rms = sqrt(sumSquares / Float(frameCount))
 
+            let playbackActive = self.isPlaybackActive
+            let gateEnabled = self.echoGateEnabled
+            let threshold = self.echoGateThreshold
+            let gated = gateEnabled && playbackActive && rms < threshold
+
             tapCallCount += 1
             if tapCallCount <= 5 {
-                let gated = self.isPlaybackActive
-                self.onLog("[RealtimeAudioManager] Tap #\(tapCallCount): frames=\(frameCount) rms=\(String(format: "%.4f", rms)) playback=\(gated)")
+                self.onLog("[RealtimeAudioManager] Tap #\(tapCallCount): frames=\(frameCount) rms=\(String(format: "%.4f", rms)) playback=\(playbackActive) gateEnabled=\(gateEnabled)")
+            }
+
+            // Emit RMS metrics for debug overlay
+            if self.debugMetricsEnabled {
+                let route = AVAudioSession.sharedInstance().currentRoute.outputs.first?.portName ?? "unknown"
+                self.onRmsMetrics(rms, playbackActive, gated, threshold, route)
             }
 
             // Echo gate: during active playback, only forward audio above threshold
-            if self.isPlaybackActive && rms < self.echoGateThreshold {
+            if gated {
                 gatedCount += 1
                 if gatedCount <= 3 {
-                    self.onLog("[RealtimeAudioManager] Echo gate: rms=\(String(format: "%.4f", rms)) < \(self.echoGateThreshold), sending silence")
+                    self.onLog("[RealtimeAudioManager] Echo gate: rms=\(String(format: "%.4f", rms)) < \(threshold), sending silence")
                 }
                 // Send silence to keep the audio stream alive
                 self.onAudioCaptured(silenceBase64)
@@ -240,5 +261,19 @@ class RealtimeAudioManager {
 
     func setVolume(_ volume: Float) {
         softwareGain = volume
+    }
+
+    func setEchoGateEnabled(_ enabled: Bool) {
+        echoGateEnabled = enabled
+        onLog("[RealtimeAudioManager] Echo gate \(enabled ? "enabled" : "disabled")")
+    }
+
+    func setEchoGateThreshold(_ threshold: Float) {
+        echoGateThreshold = threshold
+        onLog("[RealtimeAudioManager] Echo gate threshold set to \(String(format: "%.4f", threshold))")
+    }
+
+    func setDebugMetricsEnabled(_ enabled: Bool) {
+        debugMetricsEnabled = enabled
     }
 }

--- a/mobile/modules/expo-realtime-audio/src/ExpoRealtimeAudio.types.ts
+++ b/mobile/modules/expo-realtime-audio/src/ExpoRealtimeAudio.types.ts
@@ -6,7 +6,21 @@ export type AudioErrorEvent = {
   message: string
 }
 
+export type RmsMetricsEvent = {
+  rms: number
+  playbackActive: boolean
+  gated: boolean
+  threshold: number
+  route: string
+}
+
+export type AudioLogEvent = {
+  message: string
+}
+
 export type ExpoRealtimeAudioModuleEvents = {
   onAudioCaptured: (event: AudioCapturedEvent) => void
   onError: (event: AudioErrorEvent) => void
+  onLog: (event: AudioLogEvent) => void
+  onRmsMetrics: (event: RmsMetricsEvent) => void
 }

--- a/mobile/modules/expo-realtime-audio/src/ExpoRealtimeAudioModule.ts
+++ b/mobile/modules/expo-realtime-audio/src/ExpoRealtimeAudioModule.ts
@@ -17,6 +17,15 @@ declare class ExpoRealtimeAudioModule extends NativeModule<ExpoRealtimeAudioModu
 
   /** Set speaker output volume (0.0 = silent, 1.0 = normal, >1.0 = boosted) */
   setVolume(volume: number): void
+
+  /** Enable or disable the client-side echo gate */
+  setEchoGateEnabled(enabled: boolean): void
+
+  /** Set the RMS threshold for the echo gate (0.0–1.0) */
+  setEchoGateThreshold(threshold: number): void
+
+  /** Enable or disable RMS debug metrics emission (~10Hz onRmsMetrics events) */
+  setDebugMetricsEnabled(enabled: boolean): void
 }
 
 export default requireNativeModule<ExpoRealtimeAudioModule>('ExpoRealtimeAudio')


### PR DESCRIPTION
claude --resume f81a781d-6fdc-4527-aa82-954159d194d1

## Summary
- Exposes the client-side echo gate as a configurable setting (toggle + RMS threshold slider) under Debug Mode in Settings
- Adds a live RMS debug overlay during realtime calls showing mic level, gate status, playback state, and audio output route
- Wires new `setEchoGateEnabled`, `setEchoGateThreshold`, `setDebugMetricsEnabled` native methods on `expo-realtime-audio`

## Context
PR #58 removed `.defaultToSpeaker` and `overrideOutputAudioPort(.speaker)`, causing iOS to route playback to the earpiece receiver instead of the loudspeaker. The fixed echo gate threshold (0.06 RMS) was tuned for loudspeaker usage — with receiver routing, normal-volume speech falls below the gate and gets replaced with silence before reaching Gemini's server-side VAD. This makes barge-in require yelling.

Instead of a blind revert, this PR gives us the tools to diagnose and tune: disable the gate entirely (letting Gemini's native VAD handle interruption), adjust the threshold, and see the actual RMS values in real time.

## Test plan
- [ ] Enable Debug Mode in Settings, verify Echo Gate toggle and threshold slider appear
- [ ] Toggle echo gate off, start a Gemini realtime call — verify barge-in works at normal voice
- [ ] Toggle echo gate on, adjust threshold slider — verify threshold change takes effect mid-session
- [ ] Verify RMS debug overlay shows during realtime calls with Debug Mode on
- [ ] Verify overlay shows route name (Speaker/Receiver/Bluetooth), RMS bar, gate status
- [ ] Verify overlay does NOT appear when Debug Mode is off
- [ ] Verify settings persist across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)