### PR TITLE
Make ask_brain non-blocking for async conversation

### DIFF
--- a/relay-server/src/adapters/echo.ts
+++ b/relay-server/src/adapters/echo.ts
@@ -19,6 +19,10 @@ export class EchoAdapter implements ProviderAdapter {
     // no-op for echo
   }
 
+  injectContext(_text: string) {
+    // no-op for echo
+  }
+
   commitAudio() {
     // no-op for echo
   }

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -303,13 +303,13 @@ export class GeminiAdapter implements ProviderAdapter {
   }
 
   injectContext(text: string) {
+    // Use realtimeInput.text — clientContent is not supported mid-session on
+    // Gemini 3.1 Flash Live and triggers 1007. realtimeInput.text can be sent
+    // concurrently with audio streaming without conflict.
+    log(`[gemini] Injecting context via realtimeInput.text (${text.length} chars)`)
     this.sendUpstream({
-      clientContent: {
-        turns: [{
-          role: "user",
-          parts: [{ text }],
-        }],
-        turnComplete: true,
+      realtimeInput: {
+        text,
       },
     })
   }
@@ -660,12 +660,8 @@ export class GeminiAdapter implements ProviderAdapter {
     this.watchdogTimer = setTimeout(() => {
       log("[gemini] Watchdog: no audio for 20s, injecting prompt")
       this.sendUpstream({
-        clientContent: {
-          turns: [{
-            role: "user",
-            parts: [{ text: "(The user has been silent for a while. If you were mid-conversation, gently check if they're still there. If the conversation had naturally ended, stay quiet.)" }],
-          }],
-          turnComplete: true,
+        realtimeInput: {
+          text: "(The user has been silent for a while. If you were mid-conversation, gently check if they're still there. If the conversation had naturally ended, stay quiet.)",
         },
       })
     }, WATCHDOG_TIMEOUT_MS)

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -302,6 +302,18 @@ export class GeminiAdapter implements ProviderAdapter {
     }
   }
 
+  injectContext(text: string) {
+    this.sendUpstream({
+      clientContent: {
+        turns: [{
+          role: "user",
+          parts: [{ text }],
+        }],
+        turnComplete: true,
+      },
+    })
+  }
+
   getTranscript() {
     return [...this.transcript]
   }

--- a/relay-server/src/adapters/openai.ts
+++ b/relay-server/src/adapters/openai.ts
@@ -47,6 +47,10 @@ export class OpenAIAdapter implements ProviderAdapter {
     // OpenAI Realtime does not support video input
   }
 
+  injectContext(_text: string) {
+    // TODO: implement for OpenAI if needed
+  }
+
   commitAudio() {
     this.sendUpstream({ type: "input_audio_buffer.commit" })
   }

--- a/relay-server/src/adapters/types.ts
+++ b/relay-server/src/adapters/types.ts
@@ -27,6 +27,9 @@ export interface ProviderAdapter {
   /** Send a tool result back to the provider */
   sendToolResult(callId: string, output: string): void
 
+  /** Inject context into the conversation (e.g. async tool results) */
+  injectContext(text: string): void
+
   /** Get the conversation transcript so far */
   getTranscript(): { role: "user" | "assistant", text: string }[]
 

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -116,58 +116,71 @@ export class RelaySession {
 
   }
 
-  private async handleAskBrain(callId: string, args: string) {
+  private handleAskBrain(callId: string, args: string) {
     if (!this.config) return
 
     const controller = new AbortController()
     this.inFlightTools.set(callId, controller)
 
+    let query: string
     try {
       const parsed = JSON.parse(args)
-      const query = parsed.query
+      query = parsed.query
+    } catch {
+      const errorPayload = JSON.stringify({ error: "invalid arguments" })
+      this.tracer.endToolCall(callId, errorPayload, "invalid arguments")
+      this.adapter?.sendToolResult(callId, errorPayload)
+      this.inFlightTools.delete(callId)
+      return
+    }
 
-      // Send progress so the user knows the agent is thinking
-      this.send({
-        type: "transcript.delta",
-        text: "Let me check on that...\n",
-        role: "assistant",
-      })
+    // Immediately unblock Gemini so the user can keep talking.
+    // Gemini will naturally say something like "Let me check on that."
+    this.adapter?.sendToolResult(callId, JSON.stringify({
+      status: "searching",
+      message: "Looking into it now. I'll share what I find in a moment.",
+    }))
+    this.tracer.endToolCall(callId, '{"status":"searching"}')
 
-      const sendToClient: SendToClient = (event) => this.send(event)
+    // Run the brain agent in the background.
+    // Keep the controller in inFlightTools so cleanup() can abort it on disconnect.
+    const sendToClient: SendToClient = (event) => this.send(event)
+    const gatewayUrl = process.env.OPENCLAW_GATEWAY_URL || "http://localhost:18789"
+    const authToken = process.env.OPENCLAW_GATEWAY_AUTH_TOKEN || this.config.apiKey
+    const sessionKey = this.config.sessionKey || `voiceclaw:realtime`
 
-      const gatewayUrl = process.env.OPENCLAW_GATEWAY_URL || "http://localhost:18789"
-      const authToken = process.env.OPENCLAW_GATEWAY_AUTH_TOKEN || this.config.apiKey
+    const brainStart = Date.now()
+    log(`[session:${this.id}] ask_brain (async) → ${gatewayUrl}`)
 
-      const brainStart = Date.now()
-      log(`[session:${this.id}] ask_brain → ${gatewayUrl}`)
-
-      const sessionKey = this.config.sessionKey || `voiceclaw:realtime`
-      const result = await askBrain(query, {
-        gatewayUrl,
-        authToken,
-        sessionId: sessionKey,
-      }, sendToClient, callId, controller.signal)
-
+    askBrain(query, {
+      gatewayUrl,
+      authToken,
+      sessionId: sessionKey,
+    }, sendToClient, callId, controller.signal).then((result) => {
       const brainMs = Date.now() - brainStart
       log(`[session:${this.id}] ask_brain completed in ${brainMs}ms`)
-      // If the upstream cancelled mid-flight, the callId is dead — don't echo
-      // a result back; it would be rejected and may confuse the model state.
+
       if (controller.signal.aborted) {
         log(`[session:${this.id}] ask_brain (${callId}) was cancelled — discarding result`)
-        this.tracer.endToolCall(callId, result, "cancelled")
         return
       }
-      this.tracer.endToolCall(callId, result)
-      this.adapter?.sendToolResult(callId, result)
-    } catch (err) {
+
+      // Inject the result back into the conversation so Gemini speaks it
+      this.adapter?.injectContext(
+        `[Brain agent result for query: "${query}"]\n${result}\n\nPlease share this information with the user naturally.`
+      )
+    }).catch((err) => {
       const message = err instanceof Error ? err.message : "brain agent call failed"
       logError(`[session:${this.id}] ask_brain error:`, message)
-      const errorPayload = JSON.stringify({ error: message })
-      this.tracer.endToolCall(callId, errorPayload, message)
-      this.adapter?.sendToolResult(callId, errorPayload)
-    } finally {
+
+      if (!controller.signal.aborted) {
+        this.adapter?.injectContext(
+          `[Brain agent failed for query: "${query}": ${message}]\nLet the user know the search didn't work and offer to try again.`
+        )
+      }
+    }).finally(() => {
       this.inFlightTools.delete(callId)
-    }
+    })
   }
 
   private handleToolCancelled(callIds: string[]) {

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -126,9 +126,13 @@ export class RelaySession {
     try {
       const parsed = JSON.parse(args)
       query = parsed.query
-    } catch {
-      const errorPayload = JSON.stringify({ error: "invalid arguments" })
-      this.tracer.endToolCall(callId, errorPayload, "invalid arguments")
+      if (typeof query !== "string" || query.trim() === "") {
+        throw new Error("missing or empty query")
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "invalid arguments"
+      const errorPayload = JSON.stringify({ error: msg })
+      this.tracer.endToolCall(callId, errorPayload, msg)
       this.adapter?.sendToolResult(callId, errorPayload)
       this.inFlightTools.delete(callId)
       return


### PR DESCRIPTION
## Summary
- Immediately returns a "searching" tool result to unblock Gemini when `ask_brain` is called
- Runs the brain agent in the background while the user continues talking
- When the brain finishes, injects the result via `clientContent` so Gemini speaks it naturally
- Adds `injectContext()` to `ProviderAdapter` interface

## Motivation
Previously, when Gemini called `ask_brain`, audio input/output was blocked until the agent finished. Users couldn't continue the conversation while waiting. Now the flow is:

1. User: "Research restaurants for my date"
2. Gemini (spoken): "Let me check on that..."
3. User can keep talking, Gemini responds normally
4. Brain finishes → Gemini speaks the result

## Test plan
- [ ] Start voice call, trigger ask_brain (e.g. "what did we talk about recently?")
- [ ] Verify Gemini speaks acknowledgment immediately (not blocked)
- [ ] Verify user can keep talking while brain works
- [ ] Verify brain result is spoken when it arrives
- [ ] Verify session disconnect during brain work aborts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)