### PR TITLE
Fix watchdog during screen sharing and enable compression early (NAN-629)

### DIFF
--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -265,7 +265,9 @@ export class GeminiAdapter implements ProviderAdapter {
         },
       },
     }, "video")
-    this.resetWatchdog()
+    // Do NOT reset the watchdog here — video frames at 1 FPS should not
+    // count as user activity. Only audio activity pets the watchdog so the
+    // "are you still there?" prompt fires correctly during silent screen sharing.
   }
 
   commitAudio() {
@@ -379,13 +381,13 @@ export class GeminiAdapter implements ProviderAdapter {
       setup.tools = [{ functionDeclarations: tools }]
     }
 
-    // Enable context window compression when video frames are in use.
-    // Without this, audio+video sessions are limited to ~2 minutes.
-    if (this.hasVideoInput) {
-      setup.contextWindowCompression = {
-        slidingWindow: {},
-        triggerTokens: 10000,
-      }
+    // Enable context window compression unconditionally. hasVideoInput is only
+    // set when sendFrame() is called, which happens after setup, so gating on
+    // it here would miss sessions that share screen immediately after connecting.
+    // Compression is lightweight and harmless for audio-only sessions.
+    setup.contextWindowCompression = {
+      slidingWindow: {},
+      triggerTokens: 10000,
     }
 
     log(`[gemini] Setup: model=${model}, voice=${voice}, tools=${tools.length}`)


### PR DESCRIPTION
## Summary
- Stop resetting watchdog on video frames — only audio activity should pet the watchdog
- Enable contextWindowCompression unconditionally so video sessions work from the start

Ref: NAN-629

## Dependency
None — independent of PR #65

## Test plan
- [ ] Start call with screen sharing, stay silent 20s — watchdog prompt should fire
- [ ] Start call, share screen immediately — session should last >2 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)