### PR TITLE
Add WebSocket auto-reconnect to desktop app

### DIFF
--- a/desktop/src/renderer/src/lib/use-realtime.ts
+++ b/desktop/src/renderer/src/lib/use-realtime.ts
@@ -222,7 +222,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
       ws.onmessage = handleMessage
 
       ws.onerror = () => {
-        callbacksRef.current.onError?.('WebSocket connection error', 0)
+        callbacksRef.current.onError?.('Could not connect to relay server. Is it running?', 0)
       }
 
       ws.onclose = () => {

--- a/desktop/src/renderer/src/lib/use-realtime.ts
+++ b/desktop/src/renderer/src/lib/use-realtime.ts
@@ -47,6 +47,9 @@ export interface RealtimeControls {
   sessionId: string | null
 }
 
+const MAX_RECONNECT_ATTEMPTS = 3
+const RECONNECT_DELAYS = [1000, 3000, 5000]
+
 export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
   const wsRef = useRef<WebSocket | null>(null)
   const configRef = useRef<RealtimeConfig | null>(null)
@@ -54,6 +57,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
   const userStoppedRef = useRef(false)
   const turnStartedAtRef = useRef<number | null>(null)
   const turnIdRef = useRef<string | null>(null)
+  const reconnectAttemptsRef = useRef(0)
   const [isConnected, setIsConnected] = useState(false)
   const [sessionId, setSessionId] = useState<string | null>(null)
   const callbacksRef = useRef(callbacks)
@@ -83,6 +87,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
 
       switch (data.type) {
         case 'session.ready':
+          reconnectAttemptsRef.current = 0
           setSessionId(data.sessionId)
           setIsConnected(true)
           cb.onSessionReady?.(data.sessionId)
@@ -206,7 +211,22 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
         engine.stopCapture()
         engine.stopPlayback()
         if (!userStoppedRef.current) {
-          callbacksRef.current.onDisconnect?.()
+          if (reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS) {
+            const attempt = reconnectAttemptsRef.current
+            const delay = RECONNECT_DELAYS[attempt]
+            reconnectAttemptsRef.current += 1
+            console.log(
+              `[useRealtime] Unexpected disconnect — reconnect attempt ${reconnectAttemptsRef.current}/${MAX_RECONNECT_ATTEMPTS} in ${delay}ms`,
+            )
+            setTimeout(() => {
+              if (!userStoppedRef.current && configRef.current) {
+                start(configRef.current)
+              }
+            }, delay)
+          } else {
+            console.log('[useRealtime] Max reconnect attempts reached, giving up')
+            callbacksRef.current.onDisconnect?.()
+          }
         }
       }
     },

--- a/desktop/src/renderer/src/lib/use-realtime.ts
+++ b/desktop/src/renderer/src/lib/use-realtime.ts
@@ -58,6 +58,8 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
   const turnStartedAtRef = useRef<number | null>(null)
   const turnIdRef = useRef<string | null>(null)
   const reconnectAttemptsRef = useRef(0)
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const connectionIdRef = useRef(0)
   const [isConnected, setIsConnected] = useState(false)
   const [sessionId, setSessionId] = useState<string | null>(null)
   const callbacksRef = useRef(callbacks)
@@ -74,6 +76,11 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
   // Clean up on unmount
   useEffect(() => {
     return () => {
+      userStoppedRef.current = true
+      if (reconnectTimerRef.current !== null) {
+        clearTimeout(reconnectTimerRef.current)
+        reconnectTimerRef.current = null
+      }
       engineRef.current?.destroy()
       wsRef.current?.close()
       wsRef.current = null
@@ -144,8 +151,22 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
 
   const start = useCallback(
     (config: RealtimeConfig) => {
+      // Cancel any pending reconnect timer so a stale timeout can't race with this call
+      if (reconnectTimerRef.current !== null) {
+        clearTimeout(reconnectTimerRef.current)
+        reconnectTimerRef.current = null
+      }
+
+      // Bump connection ID so any in-flight onclose from the previous ws is ignored
+      const myConnectionId = connectionIdRef.current + 1
+      connectionIdRef.current = myConnectionId
+
+      // Tear down previous connection
       if (wsRef.current) {
         wsRef.current.close()
+      }
+      if (engineRef.current) {
+        engineRef.current.destroy()
       }
 
       configRef.current = config
@@ -205,6 +226,9 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
       }
 
       ws.onclose = () => {
+        // Ignore close events from superseded connections (e.g. old ws closed by a new start() call)
+        if (connectionIdRef.current !== myConnectionId) return
+
         console.log('[useRealtime] WebSocket closed, userStopped:', userStoppedRef.current)
         setIsConnected(false)
         setSessionId(null)
@@ -218,7 +242,8 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
             console.log(
               `[useRealtime] Unexpected disconnect — reconnect attempt ${reconnectAttemptsRef.current}/${MAX_RECONNECT_ATTEMPTS} in ${delay}ms`,
             )
-            setTimeout(() => {
+            reconnectTimerRef.current = setTimeout(() => {
+              reconnectTimerRef.current = null
               if (!userStoppedRef.current && configRef.current) {
                 start(configRef.current)
               }
@@ -235,6 +260,10 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
 
   const stop = useCallback(() => {
     userStoppedRef.current = true
+    if (reconnectTimerRef.current !== null) {
+      clearTimeout(reconnectTimerRef.current)
+      reconnectTimerRef.current = null
+    }
     engineRef.current?.destroy()
     engineRef.current = null
     wsRef.current?.close()

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -28,6 +28,7 @@ export function ChatPage() {
   const [streamingText, setStreamingText] = useState('')
   const [streamingRole, setStreamingRole] = useState<'user' | 'assistant'>('assistant')
   const [showLatency, setShowLatency] = useState(false)
+  const [connectionError, setConnectionError] = useState('')
   const [showScreenPicker, setShowScreenPicker] = useState(false)
   const [isScreenSharing, setIsScreenSharing] = useState(false)
   const [screenSourceName, setScreenSourceName] = useState('')
@@ -141,13 +142,16 @@ export function ChatPage() {
     },
     onError: (message) => {
       console.error('[ChatPage] Relay error:', message)
+      setConnectionError(message)
       setIsConnecting(false)
+      setIsCallActive(false)
     },
   }
 
   const realtime = useRealtime(realtimeCallbacks)
 
   const startCall = useCallback(async () => {
+    setConnectionError('')
     setIsConnecting(true)
     const serverUrl = (await getSetting('realtime_server_url')) || 'ws://localhost:8080/ws'
     const voice = (await getSetting('realtime_voice')) || 'Zephyr'
@@ -331,6 +335,13 @@ export function ChatPage() {
       {isCallActive && (
         <div className="px-4">
           <AudioLevelMeter getLevel={realtime.getInputLevel} active={isCallActive && !isMuted} />
+        </div>
+      )}
+
+      {/* Connection error */}
+      {connectionError && (
+        <div className="mx-4 mt-2 px-3 py-2 rounded-md bg-destructive/10 text-destructive text-sm text-center">
+          {connectionError}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Auto-reconnect on unexpected WebSocket close (up to 3 attempts with 1s/3s/5s backoff)
- Reset attempt counter on successful session.ready
- Only reconnects if user didn't manually end the call

## Test plan
- [ ] Start call, kill relay server, restart it — app should reconnect
- [ ] Start call, kill relay 4 times rapidly — should give up after 3 attempts
- [ ] End call manually — should NOT attempt reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)