### PR TITLE
Reduce HistoryPage DB polling

### DIFF
--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -49,7 +49,7 @@ export function App() {
             <ChatPage />
           </div>
           <div className={`flex-1 flex flex-col overflow-hidden ${activeTab !== 'history' ? 'hidden' : ''}`}>
-            <HistoryPage />
+            <HistoryPage isVisible={activeTab === 'history'} />
           </div>
           <div className={`flex-1 flex flex-col overflow-hidden ${activeTab !== 'settings' ? 'hidden' : ''}`}>
             <SettingsPage />

--- a/desktop/src/renderer/src/pages/HistoryPage.tsx
+++ b/desktop/src/renderer/src/pages/HistoryPage.tsx
@@ -15,7 +15,11 @@ type ConversationSection = {
   data: ConversationWithPreview[]
 }
 
-export function HistoryPage() {
+type HistoryPageProps = {
+  isVisible: boolean
+}
+
+export function HistoryPage({ isVisible }: HistoryPageProps) {
   const [conversations, setConversations] = useState<ConversationWithPreview[]>([])
   const { selectConversation } = useConversationContext()
 
@@ -26,19 +30,24 @@ export function HistoryPage() {
     setConversations(result)
   }, [])
 
+  // Initial load
   useEffect(() => {
     loadConversations()
   }, [loadConversations])
 
-  // Reload periodically, but skip when the window is hidden to avoid wasted DB calls
+  // Refresh immediately when the tab becomes visible so the list is never stale
   useEffect(() => {
-    const interval = setInterval(() => {
-      if (!document.hidden) {
-        loadConversations()
-      }
-    }, 10_000)
+    if (isVisible) {
+      loadConversations()
+    }
+  }, [isVisible, loadConversations])
+
+  // Poll every 10s while the tab is visible to stay fresh during active use
+  useEffect(() => {
+    if (!isVisible) return
+    const interval = setInterval(loadConversations, 10_000)
     return () => clearInterval(interval)
-  }, [loadConversations])
+  }, [isVisible, loadConversations])
 
   const handleTap = useCallback(
     (id: number) => {

--- a/desktop/src/renderer/src/pages/HistoryPage.tsx
+++ b/desktop/src/renderer/src/pages/HistoryPage.tsx
@@ -30,9 +30,13 @@ export function HistoryPage() {
     loadConversations()
   }, [loadConversations])
 
-  // Reload periodically to stay fresh
+  // Reload periodically, but skip when the window is hidden to avoid wasted DB calls
   useEffect(() => {
-    const interval = setInterval(loadConversations, 2000)
+    const interval = setInterval(() => {
+      if (!document.hidden) {
+        loadConversations()
+      }
+    }, 10_000)
     return () => clearInterval(interval)
   }, [loadConversations])
 


### PR DESCRIPTION
## Summary
- Skip DB fetch when document/tab is hidden
- Increase polling interval from 2s to 10s

## Test plan
- [ ] Switch to History tab — conversations load
- [ ] Start a call, send messages, switch to History — new conversation appears within 10s
- [ ] Switch to Chat tab — History stops polling (check via console/network)

🤖 Generated with [Claude Code](https://claude.com/claude-code)