### PR TITLE
Fix History tab: clicking conversation now loads in Chat

### DIFF
--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { TabBar, type TabId } from './components/TabBar'
 import { ChatPage } from './pages/ChatPage'
 import { HistoryPage } from './pages/HistoryPage'
@@ -10,6 +10,8 @@ export function App() {
   const [activeTab, setActiveTab] = useState<TabId>('chat')
   // Initialize theme system (applies dark/light class to html)
   useTheme()
+
+  const navigateToChat = useCallback(() => setActiveTab('chat'), [])
 
   // Global keyboard shortcuts
   useEffect(() => {
@@ -49,7 +51,7 @@ export function App() {
             <ChatPage />
           </div>
           <div className={`flex-1 flex flex-col overflow-hidden ${activeTab !== 'history' ? 'hidden' : ''}`}>
-            <HistoryPage isVisible={activeTab === 'history'} />
+            <HistoryPage isVisible={activeTab === 'history'} onNavigateToChat={navigateToChat} />
           </div>
           <div className={`flex-1 flex flex-col overflow-hidden ${activeTab !== 'settings' ? 'hidden' : ''}`}>
             <SettingsPage />

--- a/desktop/src/renderer/src/pages/HistoryPage.tsx
+++ b/desktop/src/renderer/src/pages/HistoryPage.tsx
@@ -17,9 +17,10 @@ type ConversationSection = {
 
 type HistoryPageProps = {
   isVisible: boolean
+  onNavigateToChat: () => void
 }
 
-export function HistoryPage({ isVisible }: HistoryPageProps) {
+export function HistoryPage({ isVisible, onNavigateToChat }: HistoryPageProps) {
   const [conversations, setConversations] = useState<ConversationWithPreview[]>([])
   const { selectConversation } = useConversationContext()
 
@@ -52,8 +53,9 @@ export function HistoryPage({ isVisible }: HistoryPageProps) {
   const handleTap = useCallback(
     (id: number) => {
       selectConversation(id)
+      onNavigateToChat()
     },
-    [selectConversation]
+    [selectConversation, onNavigateToChat]
   )
 
   const handleDelete = useCallback(


### PR DESCRIPTION
## Summary
- Clicking a conversation in History tab now switches to Chat tab and loads the conversation
- Root cause: `selectConversation()` updated context but never triggered a tab switch
- Fix: Added `onNavigateToChat` callback prop from App.tsx to HistoryPage

## Test plan
- [ ] Click a conversation in History — should switch to Chat tab and show messages
- [ ] New conversation button still works
- [ ] Tab switching between Chat/History/Settings still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)