### PR TITLE
Add README and MIT license for open-source release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 VoiceClaw Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,28 +1,118 @@
 # VoiceClaw
 
-Voice interface for any AI. Monorepo containing the mobile app, marketing website, relay server, agent configs, and desktop app.
+Open-source voice AI assistant. Talk to any AI model in real time from your phone or desktop.
 
-## Structure
+VoiceClaw connects mobile and desktop clients to AI providers (Gemini Live, OpenAI Realtime) through a WebSocket relay server. The relay handles authentication, provider switching, tool execution, and session tracing -- so clients stay thin and provider-agnostic.
+
+## Architecture
 
 ```
-mobile/           - React Native (Expo) iOS/Android app
-website/          - Next.js marketing site
-relay-server/     - TypeScript relay server for STS providers
-agent/            - Hermes & OpenClaw agent plugins/config
-desktop/          - macOS Electron app
++------------------+        WebSocket         +----------------+        Streaming API       +------------------+
+|                  | -----------------------> |                | -----------------------> |                  |
+|   Mobile App     |    audio + events        |  Relay Server  |    audio + events        |   AI Provider    |
+|   (Expo / iOS)   | <----------------------- |  (Node.js)     | <----------------------- |   (Gemini Live   |
+|                  |                          |                |                          |    or OpenAI     |
++------------------+                          |   +----------+ |                          |    Realtime)     |
+                                              |   |  Brain   | |                          +------------------+
++------------------+                          |   |  Agent   | |
+|                  | -----------------------> |   +----------+ |
+|   Desktop App    |    audio + events        |                |
+|   (Electron)     | <----------------------- +----------------+
+|                  |
++------------------+
 ```
 
-## Getting Started
+**Mobile app** -- React Native / Expo iOS app with voice capture and playback.
+**Desktop app** -- Electron + React + Tailwind macOS app with screen sharing support.
+**Relay server** -- TypeScript / Node.js WebSocket server that brokers sessions between clients and AI providers. Includes a "brain agent" for async tool calls (web search, calculations, etc.).
+
+## Quick Start
+
+### Prerequisites
+
+- Node.js 20+
+- yarn
+
+### 1. Clone the repo
 
 ```bash
-yarn install          # install all workspace dependencies
-
-yarn dev              # start mobile + web dev servers
-yarn dev:mobile       # start Expo dev server
-yarn dev:web          # start Next.js dev server
-
-yarn ios              # run iOS simulator
-yarn ios:device       # run on connected device
-
-yarn build:web        # production build
+git clone https://github.com/nichochar/voiceclaw.git
+cd voiceclaw
+yarn install
 ```
+
+### 2. Start the relay server
+
+```bash
+cd relay-server
+cp .env.example .env
+# Edit .env and add your API keys (see Configuration below)
+yarn dev
+```
+
+The server starts on `http://localhost:8080` with a test page at `/test`.
+
+### 3. Start the desktop app
+
+```bash
+cd desktop
+yarn dev
+```
+
+### 4. Start the mobile app
+
+```bash
+cd mobile
+yarn dev
+```
+
+Or use the root workspace scripts:
+
+```bash
+yarn dev:server     # relay server only
+yarn dev:desktop    # desktop app only
+yarn dev:mobile     # mobile app only
+yarn dev            # mobile + web + server together
+```
+
+## Configuration
+
+The relay server reads these environment variables from `relay-server/.env`:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `OPENAI_API_KEY` | Yes (for OpenAI provider) | OpenAI API key for Realtime API |
+| `GEMINI_API_KEY` | Yes (for Gemini provider) | Google Gemini API key for Live API |
+| `RELAY_API_KEY` | Recommended | API key clients must send to connect. Generate with `openssl rand -hex 24` |
+| `OPENCLAW_GATEWAY_AUTH_TOKEN` | Optional | Auth token for the brain agent (OpenClaw gateway) |
+| `OPENCLAW_GATEWAY_URL` | Optional | Brain agent gateway URL (default: `http://localhost:18789`) |
+| `PORT` | Optional | Server port (default: `8080`) |
+| `LANGFUSE_PUBLIC_KEY` | Optional | Langfuse tracing public key |
+| `LANGFUSE_SECRET_KEY` | Optional | Langfuse tracing secret key |
+| `LANGFUSE_BASE_URL` | Optional | Langfuse endpoint (default: `https://cloud.langfuse.com`) |
+
+You need at least one provider key (`OPENAI_API_KEY` or `GEMINI_API_KEY`) for the relay to be useful.
+
+## Project Structure
+
+```
+voiceclaw/
+  mobile/           React Native (Expo) iOS app
+  desktop/          Electron + React + Tailwind macOS app
+  relay-server/     TypeScript WebSocket relay server
+  website/          Next.js marketing site
+  agent/            Agent plugins and configuration
+  package.json      Yarn workspaces root
+```
+
+## Contributing
+
+1. Fork the repo and create a feature branch
+2. Make your changes
+3. Open a pull request against `main`
+
+Please keep PRs focused -- one feature or fix per PR.
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ VoiceClaw connects mobile and desktop clients to AI providers (Gemini Live, Open
 ### 1. Clone the repo
 
 ```bash
-git clone https://github.com/nichochar/voiceclaw.git
+git clone https://github.com/yagudaev/voiceclaw.git
 cd voiceclaw
 yarn install
 ```


### PR DESCRIPTION
## Summary
- Adds comprehensive README.md with architecture diagram, quick start guide, configuration table, and project structure
- Adds MIT LICENSE (2026, VoiceClaw Contributors)

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Clone/setup instructions are accurate
- [ ] All env vars in configuration table match actual relay server usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)