### PR TITLE
Add documentation website for GitHub Pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,11 +2,11 @@ title: VoiceClaw Documentation
 description: Voice interface for any AI — open-source mobile, desktop, and relay server
 remote_theme: just-the-docs/just-the-docs
 
-url: https://nano3labs.github.io/voiceclaw
+url: https://yagudaev.github.io/voiceclaw
 
 aux_links:
   "GitHub":
-    - "https://github.com/nano3labs/voiceclaw"
+    - "https://github.com/yagudaev/voiceclaw"
 
 nav_order:
   - index

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,21 @@
+title: VoiceClaw Documentation
+description: Voice interface for any AI — open-source mobile, desktop, and relay server
+remote_theme: just-the-docs/just-the-docs
+
+url: https://nano3labs.github.io/voiceclaw
+
+aux_links:
+  "GitHub":
+    - "https://github.com/nano3labs/voiceclaw"
+
+nav_order:
+  - index
+  - architecture
+  - relay-server
+  - desktop-app
+  - mobile-app
+  - contributing
+
+color_scheme: dark
+
+search_enabled: true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,164 @@
+---
+layout: default
+title: Architecture
+nav_order: 2
+---
+
+# Architecture
+
+VoiceClaw is a three-tier system: clients (mobile/desktop) talk to a relay server over WebSocket, and the relay server talks to AI providers (Gemini Live, OpenAI Realtime) over their native WebSocket APIs.
+
+## System Overview
+
+```
++------------------+
+|   Mobile App     |   React Native / Expo
+|   (iOS)          |   Native audio I/O via system audio route
++--------+---------+
+         |
+         | WebSocket (relay protocol)
+         | ws://<relay>:8080/ws
+         |
++--------+---------+
+|   Relay Server   |   TypeScript / Node.js
+|                  |
+|   - Session mgmt |   One RelaySession per WebSocket connection
+|   - Adapter      |   Provider-specific protocol translation
+|   - Brain agent  |   Async tool calls via OpenClaw gateway
+|   - Tracing      |   Langfuse OTEL integration
++--------+---------+
+         |
+         | Provider WebSocket
+         | (Gemini BidiGenerateContent / OpenAI Realtime)
+         |
++--------+---------+
+|   AI Provider    |   Gemini Live or OpenAI Realtime API
+|                  |   Voice activity detection (VAD)
+|                  |   Speech-to-text + text-to-speech
++------------------+
+
++------------------+
+|   Desktop App    |   Electron + React + Tailwind
+|   (macOS)        |   Web Audio API for capture/playback
+|   + screen share |   desktopCapturer for screen frames
++--------+---------+
+         |
+         | WebSocket (same relay protocol)
+         |
+         +-------> Relay Server (same as above)
+```
+
+## Audio Flow
+
+All audio travels as **PCM16 at 24kHz**, base64-encoded over WebSocket JSON messages.
+
+### Client to Provider
+
+1. Client captures microphone audio (24kHz PCM16, mono)
+2. Client sends `audio.append` messages with base64 data
+3. Relay forwards to provider:
+   - **Gemini**: downsampled to 16kHz (Gemini requires 16kHz), sent as `realtimeInput.audio`
+   - **OpenAI**: forwarded at 24kHz as `input_audio_buffer.append`
+4. Provider runs voice activity detection (VAD) to determine speech boundaries
+
+### Provider to Client
+
+1. Provider generates speech audio
+2. Relay receives audio and sends `audio.delta` messages to client
+3. Client decodes base64 PCM16 and plays through speakers
+4. On barge-in (user starts talking), client receives `turn.started` and stops playback
+
+```
+Mic -> PCM16 24kHz -> base64 -> audio.append -> [Relay] -> provider format -> [AI]
+                                                                                |
+[Speakers] <- PCM16 decode <- base64 <- audio.delta <- [Relay] <- model audio <-+
+```
+
+## Video / Screen Sharing Flow
+
+The desktop app can share screen content with the AI (Gemini only -- OpenAI Realtime does not support video input).
+
+1. User picks a screen source via Electron's `desktopCapturer`
+2. `ScreenCapture` grabs frames at **1 FPS**
+3. Frames are resized to fit within 768px (preserving aspect ratio)
+4. Exported as JPEG at 70% quality, base64 encoded
+5. Sent as `frame.append` messages over the relay protocol
+6. Relay forwards to Gemini as `realtimeInput.video`
+
+Screen frames do not reset the watchdog timer -- only audio activity counts as user presence.
+
+## Session Lifecycle
+
+### Connection
+
+1. Client opens WebSocket to `ws://<relay>:8080/ws`
+2. Client sends `session.config` with provider, model, voice, API key, and options
+3. Relay validates the API key against `RELAY_API_KEY`
+4. Relay creates a provider adapter (Gemini or OpenAI) and connects upstream
+5. Relay sends `session.ready` back to client
+
+### Conversation
+
+1. Client streams audio via `audio.append`
+2. Provider detects speech and generates responses
+3. Relay forwards audio (`audio.delta`), transcripts (`transcript.delta`/`transcript.done`), and turn signals (`turn.started`/`turn.ended`)
+4. If the AI calls a tool, relay sends `tool.call` to client (or handles it server-side for `echo_tool` and `ask_brain`)
+
+### Session Rotation
+
+Long-running sessions need periodic rotation to avoid provider timeouts:
+
+- **Gemini**: uses session resumption handles. On `goAway`, the relay reconnects with the stored handle. The conversation continues transparently. Audio and control messages are queued during reconnect.
+- **OpenAI**: uses timer-based rotation (default 50 minutes). The relay summarizes the transcript, closes the old connection, opens a new one with the summary injected into instructions.
+
+Both emit `session.rotating` / `session.rotated` so clients can handle the transition (clear audio buffers, show status).
+
+### Disconnection
+
+1. Client closes WebSocket (or connection drops)
+2. Relay session cleanup runs:
+   - Aborts all in-flight tool calls
+   - Ends the Langfuse tracing session
+   - Syncs conversation transcript to the brain agent for long-term memory
+   - Disconnects the provider adapter
+
+## Brain Agent
+
+The brain agent gives the voice AI capabilities beyond conversation -- web search, calendar, tasks, memory, and more. It runs as an async background process.
+
+```
+[AI Model] -- tool call: ask_brain --> [Relay Session]
+                                           |
+                                           | 1. Immediately return "searching" to unblock AI
+                                           | 2. POST /v1/chat/completions to OpenClaw gateway
+                                           |
+                                           v
+                                    [OpenClaw Gateway]
+                                           |
+                                           | SSE streaming response
+                                           | (step_complete events for progress)
+                                           |
+                                           v
+                                    [Relay Session]
+                                           |
+                                           | injectContext() -- feeds result back to AI
+                                           v
+                                    [AI speaks the answer]
+```
+
+Key design decisions:
+- The initial `ask_brain` tool result is returned immediately with `{"status": "searching"}` so the AI can say something like "Let me check on that..." while the brain works
+- Progress events (`tool.progress`) stream to the client for live UI updates
+- The final result is injected back via `injectContext()` rather than as a tool result, because the AI has already moved past the tool call
+- Brain calls are cancellable -- if the AI model cancels the tool call (e.g., user changed topic), the in-flight HTTP request is aborted
+- On session disconnect, the full transcript is synced to the brain with retry logic so the agent remembers the conversation
+
+## Tracing
+
+The relay server integrates with [Langfuse](https://langfuse.com) via OpenTelemetry for observability:
+
+- Each session is a Langfuse trace
+- Each conversation turn is a generation span with token/audio usage
+- Tool calls are nested spans within turns
+- Client timing events (`client.timing`) attach latency metrics (e.g., time to first audio)
+- Usage metrics from providers are forwarded to Langfuse for cost tracking

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -20,7 +20,7 @@ VoiceClaw is an open-source project and contributions are welcome. This page cov
 ### Install
 
 ```bash
-git clone https://github.com/nano3labs/voiceclaw.git
+git clone https://github.com/yagudaev/voiceclaw.git
 cd voiceclaw
 yarn install
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,172 @@
+---
+layout: default
+title: Contributing
+nav_order: 6
+---
+
+# Contributing
+
+VoiceClaw is an open-source project and contributions are welcome. This page covers the development setup, conventions, and workflow.
+
+## Development Setup
+
+### Prerequisites
+
+- **Node.js** 20+
+- **Yarn** (package manager -- always use yarn, not npm)
+- **Xcode** (for iOS builds)
+- macOS (required for the desktop Electron app and iOS development)
+
+### Install
+
+```bash
+git clone https://github.com/nano3labs/voiceclaw.git
+cd voiceclaw
+yarn install
+```
+
+This installs dependencies for all workspaces (mobile, desktop, relay-server, website).
+
+### Running Everything
+
+```bash
+# Start relay server + mobile dev server together
+yarn dev
+
+# Or run components individually
+yarn dev:server     # relay server with auto-reload
+yarn dev:mobile     # Expo dev server
+yarn dev:desktop    # Electron app in dev mode
+```
+
+### Relay Server
+
+```bash
+cd relay-server
+cp .env.example .env   # add your GEMINI_API_KEY, OPENAI_API_KEY, RELAY_API_KEY
+yarn dev
+```
+
+The relay server runs on `http://localhost:8080`. The test page at `/test` lets you verify WebSocket connectivity from a browser.
+
+### Desktop App
+
+```bash
+cd desktop
+yarn dev
+```
+
+### Mobile App
+
+```bash
+cd mobile
+yarn dev              # start Expo dev server
+yarn ios              # run on iOS simulator
+yarn ios:device       # run on connected device
+```
+
+## Monorepo Structure
+
+```
+voiceclaw/
+  mobile/             # React Native / Expo iOS app
+  desktop/            # Electron macOS app
+  relay-server/       # TypeScript relay server
+  website/            # Next.js marketing site
+  agent/              # OpenClaw agent plugins/config
+  docs/               # This documentation (GitHub Pages)
+  package.json        # Root workspace config
+```
+
+The root `package.json` defines yarn workspaces. Each sub-package has its own `package.json` with its own scripts and dependencies.
+
+## Branch Strategy
+
+- **Never push directly to `main`**. Always use feature branches and pull requests.
+- Branch naming: `feature/<description>`, `fix/<description>`, etc.
+- PRs should be reviewed before merging.
+
+## Code Style
+
+### No Semicolons
+
+All TypeScript and JavaScript code must omit semicolons:
+
+```typescript
+// Good
+const value = compute()
+log(`Result: ${value}`)
+
+// Bad
+const value = compute();
+log(`Result: ${value}`);
+```
+
+### File Organization
+
+Public interface and exports go at the **top** of each file. Helper functions go at the **bottom**:
+
+```typescript
+// -- Public interface at the top --
+
+export function buildInstructions(config: SessionConfigEvent): string {
+  const parts: string[] = []
+  // ...
+  return parts.join("\n\n")
+}
+
+// -- Helpers at the bottom --
+
+function loadAgentIdentity(provider: string): string {
+  // ...
+}
+
+function stripMarkdown(text: string): string {
+  // ...
+}
+```
+
+### Script Naming
+
+Use `verb:app` naming for scripts (not `app:verb`):
+
+```json
+{
+  "dev:server": "...",
+  "dev:mobile": "...",
+  "build:web": "..."
+}
+```
+
+### General Guidelines
+
+- Use TypeScript for all new code
+- Keep functions small and focused
+- Use descriptive variable and function names
+- Add comments for non-obvious logic, especially protocol translation
+- No emoji in code or log messages
+
+## Testing
+
+- **Relay server**: use the test page at `http://localhost:8080/test` for quick WebSocket testing
+- **Mobile**: test on a real iOS device or simulator with Expo Go -- do not test on web
+- **Desktop**: run `yarn dev` and verify audio capture, playback, and screen sharing
+- Always build, deploy, and test on a device before committing
+
+## Making Changes
+
+1. Create a feature branch from `main`:
+   ```bash
+   git checkout -b feature/your-feature main
+   ```
+
+2. Make your changes, following the code style guidelines above.
+
+3. Test your changes:
+   - Run the relay server and verify the protocol works
+   - Test on the relevant client (mobile device, desktop app)
+   - Check that existing functionality still works
+
+4. Commit with a clear message describing the change.
+
+5. Push and open a pull request against `main`.

--- a/docs/desktop-app.md
+++ b/docs/desktop-app.md
@@ -1,0 +1,87 @@
+---
+layout: default
+title: Desktop App
+nav_order: 4
+---
+
+# Desktop App
+
+The desktop app is a macOS Electron application that provides a voice assistant interface with screen sharing capabilities. It connects to the relay server using the same WebSocket protocol as the mobile app.
+
+## Features
+
+- **Voice conversations** -- full-duplex audio with barge-in support via Web Audio API
+- **Screen sharing** -- share any window or your entire screen with the AI (Gemini only)
+- **Conversation history** -- local SQLite database stores all conversations with searchable transcripts
+- **Audio device selection** -- choose input and output devices
+- **Volume control** -- adjustable playback volume
+- **Dark/light theme** -- follows system preference or manual toggle
+- **Tab navigation** -- Chat, History, and Settings pages
+- **Auto-reconnect** -- reconnects up to 3 times on unexpected disconnects
+
+## Tech Stack
+
+- **Electron** 35 -- desktop runtime
+- **React** 19 -- UI framework
+- **Tailwind CSS** 3 -- styling
+- **electron-vite** -- build tooling (Vite for renderer, esbuild for main)
+- **better-sqlite3** -- local conversation storage
+- **lucide-react** -- icons
+- **Web Audio API** -- microphone capture and audio playback
+
+## Building from Source
+
+```bash
+cd desktop
+yarn install
+yarn dev          # start in development mode (hot reload)
+```
+
+For production builds:
+
+```bash
+yarn build        # compile renderer + main process
+yarn typecheck    # run TypeScript type checking
+```
+
+## Screen Sharing
+
+Screen sharing lets the AI see your screen content in real time. This uses Electron's `desktopCapturer` API.
+
+How it works:
+
+1. Click the screen share button in the chat interface
+2. Pick a screen source from the available windows/displays
+3. The `ScreenCapture` class captures frames at **1 FPS**
+4. Frames are resized to max 768px and exported as JPEG (70% quality)
+5. Sent to the relay server as `frame.append` messages
+6. The relay forwards frames to the AI provider
+
+Notes:
+- Screen sharing is only supported with the **Gemini** provider (OpenAI Realtime does not accept video input)
+- Context window compression is enabled on the Gemini side to handle the steady stream of image tokens
+- Screen frames do not count as user activity for the watchdog timer
+
+## Audio Engine
+
+The desktop app uses the Web Audio API for audio:
+
+- **Capture**: `getUserMedia` at 24kHz mono with echo cancellation and noise suppression
+- **Playback**: `AudioBufferSourceNode` chain with a `GainNode` for volume control
+- **Format**: PCM16 at 24kHz, base64 encoded (matching the relay protocol)
+- **Frame size**: 2400 samples (100ms chunks)
+- **Input level**: RMS computed per capture frame for the level meter UI
+
+## Settings
+
+Configurable via the Settings page:
+
+- **Server URL** -- relay server WebSocket address
+- **API Key** -- relay server authentication key
+- **Provider** -- Gemini or OpenAI
+- **Model** -- provider-specific model identifier
+- **Voice** -- voice selection
+- **Brain Agent** -- enable/disable the brain agent
+- **Audio devices** -- input and output device selection
+- **Volume** -- playback volume slider
+- **Theme** -- dark, light, or system

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,77 @@
+---
+layout: default
+title: Home
+nav_order: 1
+---
+
+# VoiceClaw
+
+**Voice interface for any AI.** An open-source system that lets you talk to AI models using natural speech -- on your phone, on your Mac, or from any WebSocket client.
+
+VoiceClaw connects to multiple AI providers (Gemini Live, OpenAI Realtime) through a unified relay server, giving you a consistent voice experience regardless of which model is on the other end.
+
+## Key Features
+
+- **Real-time voice conversations** -- speak naturally and hear AI responses with low latency
+- **Multi-provider support** -- switch between Gemini and OpenAI models without changing client code
+- **Brain agent** -- an async tool-calling agent that gives the voice AI access to web search, calendars, tasks, memory, and more
+- **Screen sharing** -- share your screen on desktop so the AI can see what you see (JPEG frames at 1 FPS)
+- **Session resumption** -- Gemini sessions survive network drops and transparently reconnect
+- **Conversation history** -- local SQLite storage on both mobile and desktop with full transcript search
+- **Observability** -- optional Langfuse tracing for latency and token usage tracking
+
+## Components
+
+| Component | Tech | Description |
+|-----------|------|-------------|
+| [Relay Server](relay-server) | TypeScript / Node.js | WebSocket relay that translates between clients and AI providers |
+| [Desktop App](desktop-app) | Electron + React + Tailwind | macOS voice assistant with screen sharing |
+| [Mobile App](mobile-app) | React Native / Expo | iOS voice assistant |
+
+## Quick Start
+
+```bash
+# Clone and install
+git clone https://github.com/nano3labs/voiceclaw.git
+cd voiceclaw
+yarn install
+
+# Start the relay server
+cd relay-server
+cp .env.example .env    # add your API keys
+yarn dev
+
+# In another terminal, start the desktop app
+cd desktop
+yarn dev
+
+# Or start the mobile app
+cd mobile
+yarn dev
+```
+
+## How It Works
+
+At a high level:
+
+```
++-----------+        WebSocket        +---------------+        WebSocket        +----------------+
+|           |  ---session.config--->  |               |  ---provider setup--->  |                |
+|  Client   |  ---audio.append----->  | Relay Server  |  ---audio stream----->  |  AI Provider   |
+|  (mobile  |  <---audio.delta------  |               |  <---model audio------  |  (Gemini /     |
+|   or      |  <---transcript.delta-  |  - protocol   |  <---transcription----  |   OpenAI)      |
+|  desktop) |  ---frame.append----->  |    translate   |  ---video frames----->  |                |
+|           |  <---tool.call--------  |  - brain agent |                        +----------------+
+|           |  <---tool.progress----  |  - tracing     |
++-----------+                         +---------------+
+```
+
+The relay server sits between clients and AI providers. It normalizes the different provider protocols into a single, clean WebSocket API. Clients never talk directly to Gemini or OpenAI -- they speak the relay protocol, and the relay handles the translation.
+
+## Learn More
+
+- [Architecture](architecture) -- detailed system design, audio flow, and session lifecycle
+- [Relay Server](relay-server) -- WebSocket protocol reference, configuration, and brain agent
+- [Desktop App](desktop-app) -- building from source, screen sharing, and settings
+- [Mobile App](mobile-app) -- Expo build setup and iOS-specific notes
+- [Contributing](contributing) -- development setup, code style, and branch strategy

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ VoiceClaw connects to multiple AI providers (Gemini Live, OpenAI Realtime) throu
 
 ```bash
 # Clone and install
-git clone https://github.com/nano3labs/voiceclaw.git
+git clone https://github.com/yagudaev/voiceclaw.git
 cd voiceclaw
 yarn install
 

--- a/docs/mobile-app.md
+++ b/docs/mobile-app.md
@@ -1,0 +1,101 @@
+---
+layout: default
+title: Mobile App
+nav_order: 5
+---
+
+# Mobile App
+
+The mobile app is a React Native application built with Expo, designed as an iOS voice assistant. It connects to the relay server over WebSocket and provides a native voice conversation experience.
+
+## Features
+
+- **Voice conversations** -- real-time voice I/O using the system audio route
+- **Conversation history** -- local SQLite storage with searchable transcripts
+- **Conversation continuity** -- prior messages injected as context when resuming
+- **Tab navigation** -- Chat, History, and Settings
+- **Brain agent integration** -- tool progress displayed in the UI
+- **Barge-in support** -- interrupt the AI mid-response by speaking
+
+## Tech Stack
+
+- **Expo** 55 -- build and development framework
+- **React Native** 0.83 -- cross-platform UI
+- **Expo Router** -- file-based routing
+- **NativeWind** 4 (Tailwind CSS) -- styling
+- **expo-sqlite** -- local conversation storage
+- **React Native Reanimated** 4 -- animations
+- **lucide-react-native** -- icons
+- **react-native-sse** -- server-sent events support
+
+## Getting Started
+
+```bash
+cd mobile
+yarn install
+yarn dev          # start Expo dev server (clears cache)
+```
+
+### Running on Simulator
+
+```bash
+yarn ios          # launch in iOS simulator (development variant)
+```
+
+### Running on Device
+
+```bash
+yarn ios:device   # build and run on connected iOS device (development variant)
+```
+
+### Release Build
+
+```bash
+yarn ios:release  # build release configuration on device
+```
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `yarn dev` | Start Expo dev server with cache clear |
+| `yarn ios` | Run on iOS simulator (development build) |
+| `yarn ios:device` | Run on connected iOS device |
+| `yarn ios:release` | Release build on device |
+| `yarn android` | Start for Android |
+| `yarn web` | Start for web |
+| `yarn clean` | Remove `.expo`, `node_modules`, `ios`, `android` |
+
+## iOS-Specific Notes
+
+- The app uses the **system audio route** for voice I/O, which means it works correctly with Bluetooth headphones, speaker, and other audio peripherals
+- **Echo cancellation** is handled at the native level
+- A development build (`APP_VARIANT=development`) is used during development for faster iteration
+- The app requires microphone permission on first launch
+- EAS Build can be used for CI/CD (see `eas.json` for build profiles)
+
+## App Variants
+
+The project supports multiple build variants:
+
+- **development** -- used during local development (`APP_VARIANT=development`)
+- **staging** -- for internal testing
+- **production** -- for App Store release
+
+Each variant can have its own app icon, bundle identifier, and configuration (see `app.config.ts`).
+
+## Project Structure
+
+```
+mobile/
+  app/
+    (tabs)/
+      _layout.tsx       # Tab navigator layout
+      index.tsx         # Chat page (main voice interface)
+      history.tsx       # Conversation history
+      settings.tsx      # Settings page
+    _layout.tsx         # Root layout
+  assets/               # Images, fonts, icons
+  lib/                  # Shared utilities
+  plugins/              # Expo config plugins
+```

--- a/docs/relay-server.md
+++ b/docs/relay-server.md
@@ -346,7 +346,7 @@ Common error codes:
 
 ## Brain Agent
 
-The brain agent (`ask_brain` tool) connects to an [OpenClaw](https://github.com/nano3labs/openclaw) gateway to give the voice AI extended capabilities:
+The brain agent (`ask_brain` tool) connects to an [OpenClaw](https://github.com/yagudaev/openclaw) gateway to give the voice AI extended capabilities:
 
 - Web search and browsing
 - Calendar management

--- a/docs/relay-server.md
+++ b/docs/relay-server.md
@@ -1,0 +1,370 @@
+---
+layout: default
+title: Relay Server
+nav_order: 3
+---
+
+# Relay Server
+
+The relay server is a TypeScript / Node.js WebSocket server that sits between clients and AI providers. It translates the relay protocol into provider-specific formats (Gemini Live, OpenAI Realtime), handles server-side tool calls, manages session lifecycle, and provides observability via Langfuse.
+
+## Running
+
+```bash
+cd relay-server
+cp .env.example .env    # add your API keys
+yarn install
+yarn dev                # starts with tsx watch (auto-reload)
+```
+
+Production:
+
+```bash
+yarn build
+yarn start              # runs dist/index.js
+```
+
+The server starts on port 8080 by default. It exposes:
+
+- `GET /health` -- health check endpoint (returns `{"status": "ok"}`)
+- `GET /test` -- browser-based test page for quick WebSocket testing
+- `ws://localhost:8080/ws` -- WebSocket endpoint for clients
+
+## Configuration
+
+Environment variables (see `.env.example`):
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GEMINI_API_KEY` | Yes (for Gemini) | Google AI API key |
+| `OPENAI_API_KEY` | Yes (for OpenAI) | OpenAI API key |
+| `RELAY_API_KEY` | Recommended | Shared secret clients must send in `session.config.apiKey` |
+| `PORT` | No | Server port (default: `8080`) |
+| `OPENCLAW_GATEWAY_URL` | No | Brain agent gateway URL (default: `http://localhost:18789`) |
+| `OPENCLAW_GATEWAY_AUTH_TOKEN` | No | Auth token for the brain agent gateway |
+| `ROTATION_INTERVAL_MS` | No | OpenAI session rotation interval (default: `3000000` / 50 min) |
+| `LANGFUSE_BASE_URL` | No | Langfuse endpoint for tracing |
+| `LANGFUSE_PUBLIC_KEY` | No | Langfuse public key |
+| `LANGFUSE_SECRET_KEY` | No | Langfuse secret key |
+
+## WebSocket Protocol
+
+All messages are JSON objects with a `type` field. The protocol is symmetric -- clients send `ClientEvent` types, the server sends `RelayEvent` types.
+
+### Client to Relay
+
+#### `session.config`
+
+Must be the first message after connecting. Configures the session.
+
+```json
+{
+  "type": "session.config",
+  "provider": "gemini",
+  "voice": "Zephyr",
+  "model": "gemini-3.1-flash-live-preview",
+  "brainAgent": "enabled",
+  "apiKey": "your-relay-api-key",
+  "sessionKey": "optional-session-identifier",
+  "deviceContext": {
+    "timezone": "America/Los_Angeles",
+    "locale": "en-US",
+    "deviceModel": "iPhone 15 Pro",
+    "location": "San Francisco, CA"
+  },
+  "instructionsOverride": "Optional user-specific context",
+  "conversationHistory": [
+    { "role": "user", "text": "Previous message" },
+    { "role": "assistant", "text": "Previous response" }
+  ]
+}
+```
+
+Fields:
+- `provider` -- `"gemini"` or `"openai"`
+- `voice` -- voice name (Gemini: Puck, Charon, Kore, Fenrir, Aoede, Leda, Orus, Zephyr; OpenAI: any supported voice, default "marin")
+- `model` -- model identifier (default: `gemini-3.1-flash-live-preview` for Gemini, `gpt-realtime-mini` for OpenAI)
+- `brainAgent` -- `"enabled"` or `"none"`
+- `apiKey` -- must match `RELAY_API_KEY` if set on the server
+- `conversationHistory` -- prior messages to inject as context (for continuing conversations)
+
+#### `audio.append`
+
+Stream microphone audio to the provider.
+
+```json
+{
+  "type": "audio.append",
+  "data": "<base64-encoded PCM16 audio>"
+}
+```
+
+Audio format: PCM16, 24kHz, mono. The relay handles downsampling for providers that need it (Gemini requires 16kHz).
+
+#### `audio.commit`
+
+Signal that the current audio buffer is complete (used by OpenAI's manual VAD mode). Gemini uses automatic VAD and ignores this.
+
+```json
+{
+  "type": "audio.commit"
+}
+```
+
+#### `frame.append`
+
+Send a screen capture frame (desktop screen sharing).
+
+```json
+{
+  "type": "frame.append",
+  "data": "<base64-encoded JPEG>",
+  "mimeType": "image/jpeg"
+}
+```
+
+Only supported by Gemini. OpenAI Realtime does not accept video input.
+
+#### `response.create`
+
+Manually trigger a response from the provider. Gemini auto-responds based on VAD, so this is mainly for OpenAI.
+
+```json
+{
+  "type": "response.create"
+}
+```
+
+#### `response.cancel`
+
+Cancel an in-progress response.
+
+```json
+{
+  "type": "response.cancel"
+}
+```
+
+#### `tool.result`
+
+Send the result of a client-side tool call back to the relay.
+
+```json
+{
+  "type": "tool.result",
+  "callId": "call_abc123",
+  "output": "{\"result\": \"some data\"}"
+}
+```
+
+#### `client.timing`
+
+Report client-side latency measurements for tracing.
+
+```json
+{
+  "type": "client.timing",
+  "phase": "ttft_audio",
+  "ms": 342,
+  "turnId": "turn-uuid"
+}
+```
+
+### Relay to Client
+
+#### `session.ready`
+
+Sent after successful connection to the AI provider.
+
+```json
+{
+  "type": "session.ready",
+  "sessionId": "uuid"
+}
+```
+
+#### `audio.delta`
+
+Streaming audio from the AI model.
+
+```json
+{
+  "type": "audio.delta",
+  "data": "<base64-encoded PCM16 audio>"
+}
+```
+
+#### `transcript.delta`
+
+Streaming transcript text (partial, for live display).
+
+```json
+{
+  "type": "transcript.delta",
+  "text": "partial text",
+  "role": "assistant"
+}
+```
+
+#### `transcript.done`
+
+Final transcript for a complete utterance.
+
+```json
+{
+  "type": "transcript.done",
+  "text": "complete utterance text",
+  "role": "user"
+}
+```
+
+#### `tool.call`
+
+The AI model wants to call a tool. Server-side tools (`echo_tool`, `ask_brain`) are handled by the relay automatically and not forwarded to the client.
+
+```json
+{
+  "type": "tool.call",
+  "callId": "call_abc123",
+  "name": "some_tool",
+  "arguments": "{\"param\": \"value\"}"
+}
+```
+
+#### `tool.progress`
+
+Progress update from an async tool (e.g., brain agent search steps).
+
+```json
+{
+  "type": "tool.progress",
+  "callId": "call_abc123",
+  "summary": "Searching the web for..."
+}
+```
+
+#### `tool.cancelled`
+
+The AI model cancelled a tool call (e.g., user changed topic mid-search).
+
+```json
+{
+  "type": "tool.cancelled",
+  "callIds": ["call_abc123"]
+}
+```
+
+#### `turn.started`
+
+The user started speaking (detected by VAD). Clients should stop audio playback for barge-in.
+
+```json
+{
+  "type": "turn.started",
+  "turnId": "optional-trace-id"
+}
+```
+
+#### `turn.ended`
+
+The AI finished its response.
+
+```json
+{
+  "type": "turn.ended"
+}
+```
+
+#### `session.rotating` / `session.rotated`
+
+Emitted during session rotation (long-running session refresh). Clients should clear audio playback buffers.
+
+```json
+{ "type": "session.rotating" }
+```
+
+```json
+{
+  "type": "session.rotated",
+  "sessionId": "new-session-id"
+}
+```
+
+#### `session.ended`
+
+Session summary on clean shutdown.
+
+```json
+{
+  "type": "session.ended",
+  "summary": "Conversation summary",
+  "durationSec": 300,
+  "turnCount": 12
+}
+```
+
+#### `error`
+
+Error from the relay or upstream provider.
+
+```json
+{
+  "type": "error",
+  "message": "description of the error",
+  "code": 502
+}
+```
+
+Common error codes:
+- `400` -- invalid message format
+- `401` -- unauthorized (bad API key)
+- `500` -- adapter connection failed
+- `502` -- upstream provider error
+
+## Supported Providers
+
+### Gemini Live
+
+- Model: `gemini-3.1-flash-live-preview` (default)
+- Audio: 16kHz PCM16 (relay downsamples from 24kHz)
+- VAD: automatic activity detection (server-side)
+- Video: supported (JPEG frames via `realtimeInput.video`)
+- Session resumption: transparent reconnection using resumption handles
+- Rotation: proactive on `goAway`, deferred if tool calls are in flight
+- Context window compression: enabled with sliding window (10k token trigger)
+- Voices: Puck, Charon, Kore, Fenrir, Aoede, Leda, Orus, Zephyr
+
+### OpenAI Realtime
+
+- Model: `gpt-realtime-mini` (default)
+- Audio: 24kHz PCM16 (native)
+- VAD: server-side with configurable threshold
+- Video: not supported
+- Rotation: timer-based (default 50 minutes), transcript summary injected into new session
+- Transcription: `gpt-4o-mini-transcribe` for input audio
+- Voices: any OpenAI-supported voice (default: "marin")
+
+## Brain Agent
+
+The brain agent (`ask_brain` tool) connects to an [OpenClaw](https://github.com/nano3labs/openclaw) gateway to give the voice AI extended capabilities:
+
+- Web search and browsing
+- Calendar management
+- Task tracking
+- Long-term memory across sessions
+- File operations
+
+The brain runs asynchronously -- the relay returns `{"status": "searching"}` immediately so the AI can give a verbal bridge ("Let me check..."), then injects the result into the conversation when it arrives.
+
+On disconnect, the relay syncs the full conversation transcript to the brain for long-term memory, with retry logic (backoff at 5s, 30s, 2min).
+
+## Server-Side Tools
+
+Two tools are handled server-side (never forwarded to the client):
+
+- `echo_tool` -- test tool that echoes back input (useful for verifying the tool pipeline)
+- `ask_brain` -- async brain agent call (described above)
+
+## Watchdog
+
+If no audio is received for 20 seconds, the relay injects a gentle prompt asking the AI to check if the user is still there. The watchdog pauses during tool calls to avoid interrupting work in progress.


### PR DESCRIPTION
## Summary
- Adds `docs/` folder with 7 files for GitHub Pages using just-the-docs theme
- **index.md**: Landing page with features, quick start, architecture diagram
- **architecture.md**: System design, audio/video flow, session lifecycle, brain agent flow
- **relay-server.md**: Complete WebSocket protocol reference (8 client + 13 server message types), env vars, provider comparison
- **desktop-app.md**: Build instructions, screen sharing, settings
- **mobile-app.md**: Expo setup, iOS notes, app variants
- **contributing.md**: Dev setup, code style, branch strategy

## Test plan
- [ ] Enable GitHub Pages on the repo (Settings → Pages → Source: Deploy from branch, Branch: main, Folder: /docs)
- [ ] Docs render correctly at https://yagudaev.github.io/voiceclaw/
- [ ] All internal links work
- [ ] Protocol message examples match actual types.ts definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)