### PR TITLE
Harden relay server: gate /test, warn on missing auth, limit payload

### DIFF
--- a/relay-server/src/index.ts
+++ b/relay-server/src/index.ts
@@ -10,7 +10,7 @@ import { networkInterfaces } from "node:os"
 import { WebSocketServer } from "ws"
 import { RelaySession } from "./session.js"
 import { getTestPageHTML } from "./test-page.js"
-import { log } from "./log.js"
+import { log, warn } from "./log.js"
 
 const PORT = parseInt(process.env.PORT ?? "8080", 10)
 
@@ -21,13 +21,18 @@ app.get("/health", (_req, res) => {
 })
 
 app.get("/test", (req, res) => {
+  if (!isTestPageEnabled()) {
+    res.status(404).json({ error: "Test page disabled in production" })
+    return
+  }
+
   const host = req.headers.host ?? `localhost:${PORT}`
   res.type("html").send(getTestPageHTML(host))
 })
 
 const server = createServer(app)
 
-const wss = new WebSocketServer({ server, path: "/ws" })
+const wss = new WebSocketServer({ server, path: "/ws", maxPayload: 1_048_576 })
 
 wss.on("connection", (ws) => {
   new RelaySession(ws)
@@ -54,16 +59,31 @@ async function shutdown() {
 process.on("SIGTERM", () => { void shutdown() })
 process.on("SIGINT", () => { void shutdown() })
 
+if (!process.env.RELAY_API_KEY) {
+  warn("⚠️  RELAY_API_KEY is not set — WebSocket connections will not require authentication")
+}
+
 server.listen(PORT, () => {
   const lanIP = getLanIP()
   log(`Relay server listening on http://localhost:${PORT}`)
-  log(`Test page: http://localhost:${PORT}/test`)
+  if (isTestPageEnabled()) {
+    log(`Test page: http://localhost:${PORT}/test`)
+  }
   if (lanIP) {
     log(`Connect from your phone:`)
     log(`  ws://${lanIP}:${PORT}/ws`)
-    log(`  Test page: http://${lanIP}:${PORT}/test`)
+    if (isTestPageEnabled()) {
+      log(`  Test page: http://${lanIP}:${PORT}/test`)
+    }
   }
 })
+
+function isTestPageEnabled(): boolean {
+  return (
+    process.env.NODE_ENV !== "production" ||
+    process.env.ENABLE_TEST_PAGE === "true"
+  )
+}
 
 function getLanIP(): string | null {
   const nets = networkInterfaces()


### PR DESCRIPTION
## Summary
- Gate `/test` page behind `NODE_ENV !== 'production'` (override with `ENABLE_TEST_PAGE=true`)
- Log warning at startup when `RELAY_API_KEY` is not set (no auth on WebSocket connections)
- Set `maxPayload: 1MB` on WebSocketServer to prevent memory abuse from oversized messages

## Test plan
- [ ] `yarn dev` still shows test page URL and test page works
- [ ] `NODE_ENV=production yarn start` hides test page, returns 404 JSON
- [ ] `NODE_ENV=production ENABLE_TEST_PAGE=true yarn start` re-enables test page
- [ ] Starting without RELAY_API_KEY shows warning in console
- [ ] Sending a message >1MB gets rejected by WebSocket

🤖 Generated with [Claude Code](https://claude.com/claude-code)