### PR TITLE
Security fixes: .gitignore, redact UDID, remove SSRF-prone fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ out/
 .env.local
 .mcp.json
 
+# mobile sensitive / build artifacts
+mobile/eas.json
+mobile/build/
+mobile/scripts/ExportOptions.plist
+
 # IDE
 .idea/
 .vscode/

--- a/mobile/docs/device-testing-plan.md
+++ b/mobile/docs/device-testing-plan.md
@@ -2,7 +2,9 @@
 
 ## Goal
 
-Enable Claude Code to autonomously build, deploy, interact with, and verify the VoiceClaw app on a physical iPhone 12 Pro (UDID: `00008101-000D69900150001E`) without requiring manual user intervention.
+Enable Claude Code to autonomously build, deploy, interact with, and verify the VoiceClaw app on a physical iPhone (UDID: `<YOUR_DEVICE_UDID>`) without requiring manual user intervention.
+
+> **Note:** Replace `<YOUR_DEVICE_UDID>` with your own device UDID. Find it with `xcrun xctrace list devices` or `idevice_id -l`.
 
 ## Current Environment
 
@@ -45,7 +47,7 @@ Enable Claude Code to autonomously build, deploy, interact with, and verify the 
 xcodebuild test \
   -workspace ios/voiceclaw.xcworkspace \
   -scheme VoiceClaw \
-  -destination 'platform=iOS,id=00008101-000D69900150001E' \
+  -destination 'platform=iOS,id=<YOUR_DEVICE_UDID>' \
   -only-testing:VoiceClawUITests/TestClassName/testMethodName
 ```
 

--- a/relay-server/src/test-page.ts
+++ b/relay-server/src/test-page.ts
@@ -47,17 +47,6 @@ export function getTestPageHTML(host: string): string {
     </select>
   </div>
 
-  <div class="section row">
-    <div>
-      <label>OpenClaw Gateway URL</label>
-      <input id="gateway-url" type="text" placeholder="http://localhost:18789" value="">
-    </div>
-    <div>
-      <label>Auth Token</label>
-      <input id="auth-token" type="password" placeholder="Bearer token">
-    </div>
-  </div>
-
   <div class="section">
     <label>Provider</label>
     <select id="provider">
@@ -212,8 +201,6 @@ export function getTestPageHTML(host: string): string {
             model: selectedModel,
             voice: document.getElementById("voice").value,
             brainAgent: document.getElementById("brain-agent").value,
-            openclawGatewayUrl: document.getElementById("gateway-url").value || "http://localhost:18789",
-            openclawAuthToken: document.getElementById("auth-token").value || "test-token",
             deviceContext: {
               timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
               locale: navigator.language,

--- a/relay-server/src/types.ts
+++ b/relay-server/src/types.ts
@@ -19,8 +19,6 @@ export interface SessionConfigEvent {
   brainAgent: "enabled" | "none"
   apiKey: string
   sessionKey?: string
-  openclawGatewayUrl?: string
-  openclawAuthToken?: string
   deviceContext?: {
     timezone?: string
     locale?: string

--- a/relay-server/test/test-gemini-e2e.ts
+++ b/relay-server/test/test-gemini-e2e.ts
@@ -106,8 +106,6 @@ async function runTest() {
     voice: "Zephyr",
     apiKey: "test-e2e-key",
     brainAgent: "none",
-    openclawGatewayUrl: "http://localhost:18789",
-    openclawAuthToken: "test-token",
     deviceContext: {
       timezone: "America/Los_Angeles",
       locale: "en-US",

--- a/relay-server/test/test-gemini-reconnect.ts
+++ b/relay-server/test/test-gemini-reconnect.ts
@@ -102,8 +102,6 @@ async function runReconnectTest() {
     voice: "Zephyr",
     apiKey: "test",
     brainAgent: "none",
-    openclawGatewayUrl: "http://localhost:18789",
-    openclawAuthToken: "test-token",
     deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
   }
 
@@ -174,8 +172,6 @@ async function runUnrecoverableCloseTest() {
     voice: "Zephyr",
     apiKey: "test",
     brainAgent: "none",
-    openclawGatewayUrl: "http://localhost:18789",
-    openclawAuthToken: "test-token",
     deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
   }
 
@@ -250,8 +246,6 @@ async function runReconnectRetryTest() {
     voice: "Zephyr",
     apiKey: "test",
     brainAgent: "none",
-    openclawGatewayUrl: "http://localhost:18789",
-    openclawAuthToken: "test-token",
     deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
   }
 
@@ -374,8 +368,6 @@ async function runDeferredRotationMidToolCallTest() {
     voice: "Zephyr",
     apiKey: "test",
     brainAgent: "none",
-    openclawGatewayUrl: "http://localhost:18789",
-    openclawAuthToken: "test-token",
     deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
   }
 
@@ -471,8 +463,6 @@ async function runHardCloseMidToolCallTest() {
     voice: "Zephyr",
     apiKey: "test",
     brainAgent: "none",
-    openclawGatewayUrl: "http://localhost:18789",
-    openclawAuthToken: "test-token",
     deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
   }
 
@@ -549,8 +539,6 @@ async function runSendQueueDrainTest() {
     voice: "Zephyr",
     apiKey: "test",
     brainAgent: "none",
-    openclawGatewayUrl: "http://localhost:18789",
-    openclawAuthToken: "test-token",
     deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
   }
 
@@ -629,8 +617,6 @@ async function runClose1011WithHandleTest() {
     voice: "Zephyr",
     apiKey: "test",
     brainAgent: "none",
-    openclawGatewayUrl: "http://localhost:18789",
-    openclawAuthToken: "test-token",
     deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
   }
 
@@ -692,8 +678,6 @@ async function runReconnectExhaustedTest() {
     voice: "Zephyr",
     apiKey: "test",
     brainAgent: "none",
-    openclawGatewayUrl: "http://localhost:18789",
-    openclawAuthToken: "test-token",
     deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
   }
 
@@ -766,8 +750,6 @@ async function runChainedGoAwayTest() {
     voice: "Zephyr",
     apiKey: "test",
     brainAgent: "none",
-    openclawGatewayUrl: "http://localhost:18789",
-    openclawAuthToken: "test-token",
     deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
   }
 
@@ -842,8 +824,6 @@ async function runResumedGoAwayBeforeFreshHandleTest() {
     voice: "Zephyr",
     apiKey: "test",
     brainAgent: "none",
-    openclawGatewayUrl: "http://localhost:18789",
-    openclawAuthToken: "test-token",
     deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
   }
 
@@ -915,8 +895,6 @@ async function runQueueAcrossRetryTest() {
     voice: "Zephyr",
     apiKey: "test",
     brainAgent: "none",
-    openclawGatewayUrl: "http://localhost:18789",
-    openclawAuthToken: "test-token",
     deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
   }
 
@@ -994,8 +972,6 @@ async function runControlOverflowTest() {
     voice: "Zephyr",
     apiKey: "test",
     brainAgent: "none",
-    openclawGatewayUrl: "http://localhost:18789",
-    openclawAuthToken: "test-token",
     deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
   }
 

--- a/relay-server/test/test-phase1a.ts
+++ b/relay-server/test/test-phase1a.ts
@@ -84,8 +84,6 @@ async function testValidAuth() {
     provider: "echo",
     voice: "alloy",
     brainAgent: "none",
-    openclawGatewayUrl: MOCK_GATEWAY_URL,
-    openclawAuthToken: VALID_TOKEN,
   }))
 
   const ready = await waitForMessage(ws)
@@ -113,8 +111,6 @@ async function testInvalidToken() {
     provider: "echo",
     voice: "alloy",
     brainAgent: "none",
-    openclawGatewayUrl: MOCK_GATEWAY_URL,
-    openclawAuthToken: "invalid-token-12345",
   }))
 
   const error = await waitForMessage(ws)
@@ -134,8 +130,6 @@ async function testNoToken() {
     provider: "echo",
     voice: "alloy",
     brainAgent: "none",
-    openclawGatewayUrl: MOCK_GATEWAY_URL,
-    openclawAuthToken: "",
   }))
 
   const error = await waitForMessage(ws)
@@ -154,8 +148,6 @@ async function testNoGateway() {
     provider: "echo",
     voice: "alloy",
     brainAgent: "none",
-    openclawGatewayUrl: "",
-    openclawAuthToken: VALID_TOKEN,
   }))
 
   const error = await waitForMessage(ws)
@@ -174,8 +166,6 @@ async function testUnreachableGateway() {
     provider: "echo",
     voice: "alloy",
     brainAgent: "none",
-    openclawGatewayUrl: "http://127.0.0.1:59999",
-    openclawAuthToken: VALID_TOKEN,
   }))
 
   const error = await waitForMessage(ws, 10000)

--- a/relay-server/test/test-phase1bc.ts
+++ b/relay-server/test/test-phase1bc.ts
@@ -85,8 +85,6 @@ async function testOpenAIConnection() {
     provider: "openai",
     voice: "alloy",
     brainAgent: "none",
-    openclawGatewayUrl: MOCK_GATEWAY_URL,
-    openclawAuthToken: VALID_TOKEN,
   }))
 
   const ready = await waitForMessage(ws)
@@ -110,8 +108,6 @@ async function testAudioFlow() {
     provider: "openai",
     voice: "alloy",
     brainAgent: "none",
-    openclawGatewayUrl: MOCK_GATEWAY_URL,
-    openclawAuthToken: VALID_TOKEN,
   }))
 
   const ready = await waitForMessage(ws)
@@ -150,8 +146,6 @@ async function testToolCall() {
     provider: "openai",
     voice: "alloy",
     brainAgent: "none",
-    openclawGatewayUrl: MOCK_GATEWAY_URL,
-    openclawAuthToken: VALID_TOKEN,
   }))
 
   const ready = await waitForMessage(ws)


### PR DESCRIPTION
## Summary
- Add `mobile/eas.json`, `mobile/build/`, `mobile/scripts/ExportOptions.plist` to .gitignore
- Redact hardcoded device UDID from `mobile/docs/device-testing-plan.md`
- Remove `openclawGatewayUrl` and `openclawAuthToken` from `SessionConfigEvent` type (latent SSRF vector — server reads these from env vars only)
- Clean up test page and test files that sent the removed fields

## Test plan
- [ ] `npx tsc --noEmit` passes in relay-server
- [ ] Relay server starts and accepts connections without the removed fields
- [ ] `mobile/eas.json` is properly ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)