### PR TITLE
Add brain agent setup guides (OpenClaw, Hermes, Custom)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -35,6 +35,14 @@ export default defineConfig({
             { slug: 'mobile-app' },
           ],
         },
+        {
+          label: 'Brain Agent Guides',
+          items: [
+            { slug: 'guides/openclaw' },
+            { slug: 'guides/hermes' },
+            { slug: 'guides/custom-agent' },
+          ],
+        },
       ],
       customCss: ['./src/styles/custom.css'],
       lastUpdated: true,

--- a/docs/src/content/docs/guides/custom-agent.mdx
+++ b/docs/src/content/docs/guides/custom-agent.mdx
@@ -1,0 +1,232 @@
+---
+title: Custom Brain Agent
+description: Connect any OpenAI-compatible agent as your VoiceClaw brain
+---
+
+import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components'
+
+VoiceClaw's brain agent integration works with any server that implements the OpenAI chat completions API with SSE streaming. This means you can plug in your own agent built with LangChain, CrewAI, a raw Flask/Express server, or anything else that speaks the right protocol.
+
+The key idea: VoiceClaw is a thin voice layer. You bring the agent, VoiceClaw gives it a voice.
+
+## What the relay expects
+
+The relay sends a `POST` request to your agent's `/v1/chat/completions` endpoint with streaming enabled. Your server needs to handle this and return an SSE stream in the OpenAI format.
+
+### Request format
+
+```http
+POST /v1/chat/completions HTTP/1.1
+Content-Type: application/json
+Authorization: Bearer <BRAIN_GATEWAY_AUTH_TOKEN>
+
+{
+  "model": "openclaw",
+  "messages": [
+    { "role": "user", "content": "What's on my calendar today?" }
+  ],
+  "stream": true
+}
+```
+
+Headers sent by the relay:
+
+| Header | Value |
+|--------|-------|
+| `Content-Type` | `application/json` |
+| `Authorization` | `Bearer <BRAIN_GATEWAY_AUTH_TOKEN>` |
+| `x-openclaw-session-key` | Session identifier for multi-turn context |
+
+<Aside type="note">
+The `model` field is always `"openclaw"` -- your server can ignore it or use it to route to different backends.
+</Aside>
+
+### Response format
+
+Your server must return an SSE stream. Each chunk follows the OpenAI format:
+
+```
+data: {"choices":[{"delta":{"content":"The capital"},"index":0}]}
+
+data: {"choices":[{"delta":{"content":" of France"},"index":0}]}
+
+data: {"choices":[{"delta":{"content":" is Paris."},"index":0}]}
+
+data: [DONE]
+```
+
+The relay reads `choices[0].delta.content` from each chunk and concatenates it into the final response.
+
+### Optional: progress events
+
+If your agent performs multi-step work (web search, tool calls), you can emit progress events so VoiceClaw clients show live status updates:
+
+```
+data: {"type":"step_complete","summary":"Searching the web for calendar events..."}
+```
+
+These are forwarded to the client as `tool.progress` messages.
+
+## Configuration
+
+In your relay server `.env` file:
+
+```bash
+BRAIN_GATEWAY_URL=http://localhost:YOUR_PORT/v1
+BRAIN_GATEWAY_AUTH_TOKEN=your-secret-token
+```
+
+Replace `YOUR_PORT` with whatever port your agent server runs on. The relay appends `/chat/completions` to the URL automatically, so if your full endpoint is `http://localhost:3000/v1/chat/completions`, set `BRAIN_GATEWAY_URL=http://localhost:3000/v1`.
+
+<Aside type="caution">
+The relay has a 2-minute timeout on brain agent requests. If your agent takes longer, the request will be aborted.
+</Aside>
+
+## System prompt template
+
+Give your agent this system prompt so it knows how to respond appropriately for voice:
+
+```text
+You are the brain behind a voice assistant called VoiceClaw.
+
+You receive questions via the ask_brain tool when the realtime voice model
+needs help with tasks beyond basic conversation.
+
+Guidelines:
+- Respond concisely. Your answers will be spoken aloud, not read on a screen.
+- Keep responses to 2-3 sentences when possible. The user is listening.
+- Skip formatting (no markdown, no bullet lists, no headers). Plain text only.
+- Lead with the answer, then add context if needed.
+- If you performed an action, confirm it in one sentence.
+- If you do not know something, say so briefly rather than guessing.
+```
+
+Adapt this to mention your agent's specific capabilities (web search, database access, API integrations, etc.).
+
+## Examples with popular frameworks
+
+### LangChain (Python)
+
+```python
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+from langchain_openai import ChatOpenAI
+import json
+
+app = FastAPI()
+llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
+
+@app.post("/v1/chat/completions")
+async def chat(request: Request):
+    body = await request.json()
+    messages = body["messages"]
+
+    async def generate():
+        async for chunk in llm.astream(messages):
+            data = {
+                "choices": [{
+                    "delta": {"content": chunk.content},
+                    "index": 0
+                }]
+            }
+            yield f"data: {json.dumps(data)}\n\n"
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
+```
+
+### Express (Node.js)
+
+```javascript
+const express = require("express")
+const OpenAI = require("openai")
+
+const app = express()
+app.use(express.json())
+
+const openai = new OpenAI()
+
+app.post("/v1/chat/completions", async (req, res) => {
+  const { messages } = req.body
+
+  res.setHeader("Content-Type", "text/event-stream")
+  res.setHeader("Cache-Control", "no-cache")
+
+  const stream = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    messages,
+    stream: true,
+  })
+
+  for await (const chunk of stream) {
+    const data = JSON.stringify(chunk)
+    res.write(`data: ${data}\n\n`)
+  }
+
+  res.write("data: [DONE]\n\n")
+  res.end()
+})
+
+app.listen(3000)
+```
+
+### CrewAI (Python)
+
+```python
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+from crewai import Agent, Task, Crew
+import json
+
+app = FastAPI()
+
+researcher = Agent(
+    role="Research Assistant",
+    goal="Answer questions accurately and concisely for voice output",
+    backstory="You are the brain behind a voice assistant. Keep answers brief.",
+)
+
+@app.post("/v1/chat/completions")
+async def chat(request: Request):
+    body = await request.json()
+    query = body["messages"][-1]["content"]
+
+    task = Task(
+        description=query,
+        agent=researcher,
+        expected_output="A concise 1-3 sentence answer suitable for voice",
+    )
+
+    crew = Crew(agents=[researcher], tasks=[task])
+    result = crew.kickoff()
+
+    # CrewAI doesn't stream natively, so wrap the result
+    def generate():
+        data = {
+            "choices": [{
+                "delta": {"content": str(result)},
+                "index": 0
+            }]
+        }
+        yield f"data: {json.dumps(data)}\n\n"
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
+```
+
+## Testing your endpoint
+
+You can test your brain agent endpoint directly with curl:
+
+```bash
+curl -N http://localhost:YOUR_PORT/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer your-token" \
+  -d '{
+    "model": "openclaw",
+    "messages": [{"role": "user", "content": "What is 2 + 2?"}],
+    "stream": true
+  }'
+```
+
+You should see SSE chunks streaming back. Once that works, configure the relay and test end-to-end with a VoiceClaw client.

--- a/docs/src/content/docs/guides/hermes.mdx
+++ b/docs/src/content/docs/guides/hermes.mdx
@@ -1,0 +1,126 @@
+---
+title: Connecting Hermes
+description: How to use Nous Research Hermes as your VoiceClaw brain agent
+---
+
+import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components'
+
+[Hermes](https://nousresearch.com/) by Nous Research is a family of fine-tuned open-source language models known for strong instruction following and tool use. Because Hermes can be served behind any OpenAI-compatible API, it works as a drop-in brain agent for VoiceClaw.
+
+VoiceClaw is a thin voice layer on top of your agent. You run Hermes locally, point the relay at it, and VoiceClaw gives it a voice.
+
+## Prerequisites
+
+- One of: [Ollama](https://ollama.com/), [vLLM](https://docs.vllm.ai/), or any OpenAI-compatible inference server
+- A Hermes model downloaded (e.g., `hermes3:8b` for Ollama)
+- VoiceClaw relay server cloned and ready
+
+## Setup
+
+<Steps>
+
+1. **Run Hermes via an OpenAI-compatible server**
+
+   <Tabs>
+     <TabItem label="Ollama">
+       ```bash
+       # Install Ollama if you haven't
+       brew install ollama
+
+       # Pull and run Hermes
+       ollama pull hermes3:8b
+       ollama serve
+       ```
+
+       Ollama exposes an OpenAI-compatible API at `http://localhost:11434/v1`.
+     </TabItem>
+     <TabItem label="vLLM">
+       ```bash
+       pip install vllm
+
+       vllm serve NousResearch/Hermes-3-Llama-3.1-8B \
+         --host 0.0.0.0 \
+         --port 8000 \
+         --api-key your-secret-key
+       ```
+
+       vLLM exposes an OpenAI-compatible API at `http://localhost:8000/v1`.
+     </TabItem>
+     <TabItem label="LM Studio">
+       Download Hermes from the LM Studio model browser, load it, and start the local server. It defaults to `http://localhost:1234/v1`.
+     </TabItem>
+   </Tabs>
+
+2. **Configure the VoiceClaw relay server**
+
+   In your relay server `.env` file, point at your Hermes instance:
+
+   <Tabs>
+     <TabItem label="Ollama">
+       ```bash
+       BRAIN_GATEWAY_URL=http://localhost:11434/v1
+       BRAIN_GATEWAY_AUTH_TOKEN=
+       ```
+
+       <Aside type="note">
+       Ollama does not require an auth token by default. Leave `BRAIN_GATEWAY_AUTH_TOKEN` empty.
+       </Aside>
+     </TabItem>
+     <TabItem label="vLLM">
+       ```bash
+       BRAIN_GATEWAY_URL=http://localhost:8000/v1
+       BRAIN_GATEWAY_AUTH_TOKEN=your-secret-key
+       ```
+     </TabItem>
+     <TabItem label="LM Studio">
+       ```bash
+       BRAIN_GATEWAY_URL=http://localhost:1234/v1
+       BRAIN_GATEWAY_AUTH_TOKEN=
+       ```
+     </TabItem>
+   </Tabs>
+
+3. **Start the relay server**
+
+   ```bash
+   cd relay-server
+   yarn dev
+   ```
+
+4. **Connect and test**
+
+   Open the desktop or mobile app with `brainAgent` set to `"enabled"`. Ask a question like "What is the capital of France?" -- the voice model will call `ask_brain`, the relay will query Hermes, and you will hear the answer.
+
+</Steps>
+
+## System prompt for Hermes
+
+Since Hermes runs locally without built-in tools like web search or calendar, adapt the system prompt to match what your setup can do. Paste this into the model's system instructions:
+
+```text
+You are the brain behind a voice assistant called VoiceClaw.
+
+You receive questions via the ask_brain tool when the realtime voice model
+needs help -- factual questions, analysis, reasoning, or knowledge retrieval.
+
+Guidelines:
+- Respond concisely. Your answers will be spoken aloud, not read on a screen.
+- Keep responses to 2-3 sentences when possible. The user is listening.
+- Skip formatting (no markdown, no bullet lists, no headers). Plain text only.
+- Lead with the answer, then add context if needed.
+- If you do not know something, say so briefly rather than guessing.
+- You are running locally as a Hermes model. Be direct and helpful.
+```
+
+<Aside type="tip">
+If you add tools to your Hermes setup (e.g., via function calling with a tool-use wrapper), update the system prompt to mention those capabilities so the voice model knows to use `ask_brain` for them.
+</Aside>
+
+## Choosing a model size
+
+| Model | VRAM | Best for |
+|-------|------|----------|
+| `hermes3:8b` | ~6 GB | Fast responses, lighter hardware |
+| `hermes3:70b` | ~40 GB | Deeper reasoning, better tool use |
+
+For a voice assistant where latency matters, the 8B model is a good starting point. Upgrade to 70B if you need more nuanced answers and have the hardware.

--- a/docs/src/content/docs/guides/openclaw.mdx
+++ b/docs/src/content/docs/guides/openclaw.mdx
@@ -1,0 +1,96 @@
+---
+title: Connecting OpenClaw
+description: How to use OpenClaw as your VoiceClaw brain agent
+---
+
+import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components'
+
+[OpenClaw](https://github.com/yagudaev/openclaw) is an open-source AI agent framework that gives your voice assistant superpowers -- web search, calendar management, task tracking, long-term memory, and more. VoiceClaw acts as a thin voice layer on top of OpenClaw: you bring the agent, VoiceClaw gives it a voice.
+
+When the voice model needs help (web lookups, scheduling, memory recall), it calls the `ask_brain` tool. The relay server forwards that query to your OpenClaw instance via the standard `/v1/chat/completions` endpoint with SSE streaming.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) or Node.js 20+
+- OpenClaw installed and running
+- VoiceClaw relay server cloned and ready
+
+## Setup
+
+<Steps>
+
+1. **Install and run OpenClaw**
+
+   Follow the [OpenClaw README](https://github.com/yagudaev/openclaw) to get it running locally. By default it starts a gateway on port `18789`.
+
+   ```bash
+   # Example with Docker
+   docker run -d -p 18789:18789 openclaw/openclaw
+   ```
+
+   Once running, find your auth token:
+
+   ```bash
+   cat ~/.openclaw/openclaw.json | grep token
+   ```
+
+2. **Configure the VoiceClaw relay server**
+
+   In your relay server `.env` file, point at your OpenClaw instance:
+
+   ```bash
+   BRAIN_GATEWAY_URL=http://localhost:18789
+   BRAIN_GATEWAY_AUTH_TOKEN=<your-openclaw-token>
+   ```
+
+   <Aside type="note">
+   If you are migrating from an older VoiceClaw version, note that `OPENCLAW_GATEWAY_URL` and `OPENCLAW_GATEWAY_AUTH_TOKEN` have been renamed to `BRAIN_GATEWAY_URL` and `BRAIN_GATEWAY_AUTH_TOKEN`.
+   </Aside>
+
+3. **Start the relay server**
+
+   ```bash
+   cd relay-server
+   yarn dev
+   ```
+
+   You should see a log line confirming the brain agent is reachable when you make your first voice query that triggers `ask_brain`.
+
+4. **Connect from a client**
+
+   Open the desktop or mobile app, make sure `brainAgent` is set to `"enabled"` in the session config, and start talking. Ask something like "What's on my calendar today?" -- the voice model will call `ask_brain`, the relay will hit OpenClaw, and you will hear the answer spoken back.
+
+</Steps>
+
+## System prompt for your OpenClaw agent
+
+Paste this into your OpenClaw agent's system instructions so it knows how to behave as a voice backend:
+
+```text
+You are the brain behind a voice assistant called VoiceClaw.
+
+You receive questions via the ask_brain tool when the realtime voice model
+needs help -- web search, calendar lookups, task management, memory recall,
+file operations, or any knowledge beyond basic conversation.
+
+Guidelines:
+- Respond concisely. Your answers will be spoken aloud, not read on a screen.
+- Keep responses to 2-3 sentences when possible. The user is listening.
+- Skip formatting (no markdown, no bullet lists, no headers). Plain text only.
+- Lead with the answer, then add context if needed.
+- If you performed an action (created a task, added a calendar event), confirm
+  it in one sentence.
+- If you do not know something, say so briefly rather than guessing.
+- You have access to tools like web search, calendar, memory, and file
+  operations. Use them freely -- you are the capable backend, the voice model
+  is just the interface.
+```
+
+## How it works under the hood
+
+1. The voice model (Gemini or OpenAI) decides it needs help and calls the `ask_brain` tool with a query.
+2. The relay immediately returns `{"status": "searching"}` so the voice model can say something like "Let me check on that..." while the brain works.
+3. The relay sends a `POST /v1/chat/completions` request to OpenClaw with SSE streaming enabled.
+4. As OpenClaw works, it emits `step_complete` events that the relay forwards to the client as `tool.progress` messages (useful for showing live search status in the UI).
+5. When the final answer arrives, the relay injects it back into the voice conversation via `injectContext()`, and the AI speaks the result naturally.
+6. On disconnect, the full conversation transcript is synced to OpenClaw for long-term memory.


### PR DESCRIPTION
## Summary
Adds 3 new documentation pages under docs/guides/ for connecting a brain agent to VoiceClaw:

- **OpenClaw guide**: Install, configure, system prompt, how ask_brain works under the hood
- **Hermes guide**: Connect via Ollama/vLLM/LM Studio with tabs, model size comparison table
- **Custom Agent guide**: OpenAI-compatible API spec, request/response format, code examples (LangChain, Express, CrewAI), system prompt template

Each guide includes a **copy-paste LLM system prompt** optimized for voice (concise responses, spoken-word style).

Uses new `BRAIN_GATEWAY_*` env var names (rename PR coming separately).

## Test plan
- [ ] `cd docs && npm run build` succeeds
- [ ] All 3 guide pages render correctly
- [ ] Sidebar shows "Brain Agent Guides" section
- [ ] System prompts are clear and self-contained

🤖 Generated with [Claude Code](https://claude.com/claude-code)