### PR TITLE
Rename OPENCLAW_GATEWAY_* to BRAIN_GATEWAY_* (agent-agnostic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ The relay server reads these environment variables from `relay-server/.env`:
 | `GEMINI_API_KEY` | Yes (for Gemini provider) | Google Gemini API key for Live API |
 | `OPENAI_API_KEY` | Yes (for OpenAI provider) | OpenAI API key for Realtime API |
 | `RELAY_API_KEY` | Recommended | API key clients must send to connect. Generate with `openssl rand -hex 24` |
-| `OPENCLAW_GATEWAY_AUTH_TOKEN` | Optional | Auth token for your brain agent endpoint |
-| `OPENCLAW_GATEWAY_URL` | Optional | Brain agent URL -- any OpenAI-compatible endpoint (default: `http://localhost:18789`) |
+| `BRAIN_GATEWAY_AUTH_TOKEN` | Optional | Auth token for your brain agent endpoint |
+| `BRAIN_GATEWAY_URL` | Optional | Brain agent URL -- any OpenAI-compatible endpoint (default: `http://localhost:18789`) |
 | `PORT` | Optional | Server port (default: `8080`) |
 | `LANGFUSE_PUBLIC_KEY` | Optional | Langfuse tracing public key |
 | `LANGFUSE_SECRET_KEY` | Optional | Langfuse tracing secret key |

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -23,7 +23,7 @@ VoiceClaw is a three-tier system: clients (mobile/desktop) talk to a relay serve
 |                  |
 |   - Session mgmt |   One RelaySession per WebSocket connection
 |   - Adapter      |   Provider-specific protocol translation
-|   - Brain agent  |   Async tool calls via OpenClaw gateway
+|   - Brain agent  |   Async tool calls via brain agent gateway
 |   - Tracing      |   Langfuse OTEL integration
 +--------+---------+
          |
@@ -131,10 +131,10 @@ The brain agent gives the voice AI capabilities beyond conversation -- web searc
 [AI Model] -- tool call: ask_brain --> [Relay Session]
                                            |
                                            | 1. Immediately return "searching" to unblock AI
-                                           | 2. POST /v1/chat/completions to OpenClaw gateway
+                                           | 2. POST /v1/chat/completions to brain agent gateway
                                            |
                                            v
-                                    [OpenClaw Gateway]
+                                    [Brain Agent Gateway]
                                            |
                                            | SSE streaming response
                                            | (step_complete events for progress)

--- a/docs/src/content/docs/contributing.mdx
+++ b/docs/src/content/docs/contributing.mdx
@@ -78,7 +78,7 @@ voiceclaw/
   desktop/            # Electron macOS app
   relay-server/       # TypeScript relay server
   website/            # Next.js marketing site
-  agent/              # OpenClaw agent plugins/config
+  agent/              # Agent plugins/config (OpenClaw, Hermes, etc.)
   docs/               # This documentation (GitHub Pages)
   package.json        # Root workspace config
 ```

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -28,7 +28,7 @@ import { Card, CardGrid, Steps, Tabs, TabItem } from '@astrojs/starlight/compone
     The relay server handles protocol translation transparently.
   </Card>
   <Card title="Brain agent" icon="magnifier">
-    An async tool-calling agent that gives the voice AI access to web search, calendars, tasks, memory, and more -- powered by OpenClaw.
+    An async tool-calling agent that gives the voice AI access to web search, calendars, tasks, memory, and more -- powered by any OpenAI-compatible agent.
   </Card>
   <Card title="Screen sharing" icon="laptop">
     Share your screen on desktop so the AI can see what you see.

--- a/docs/src/content/docs/relay-server.mdx
+++ b/docs/src/content/docs/relay-server.mdx
@@ -42,8 +42,8 @@ Environment variables (see `.env.example`):
 | `OPENAI_API_KEY` | Yes (for OpenAI) | OpenAI API key |
 | `RELAY_API_KEY` | Recommended | Shared secret clients must send in `session.config.apiKey` |
 | `PORT` | No | Server port (default: `8080`) |
-| `OPENCLAW_GATEWAY_URL` | No | Brain agent gateway URL (default: `http://localhost:18789`) |
-| `OPENCLAW_GATEWAY_AUTH_TOKEN` | No | Auth token for the brain agent gateway |
+| `BRAIN_GATEWAY_URL` | No | Brain agent gateway URL (default: `http://localhost:18789`) |
+| `BRAIN_GATEWAY_AUTH_TOKEN` | No | Auth token for the brain agent gateway |
 | `ROTATION_INTERVAL_MS` | No | OpenAI session rotation interval (default: `3000000` / 50 min) |
 | `LANGFUSE_BASE_URL` | No | Langfuse endpoint for tracing |
 | `LANGFUSE_PUBLIC_KEY` | No | Langfuse public key |
@@ -352,7 +352,7 @@ Common error codes:
 
 ## Brain Agent
 
-The brain agent (`ask_brain` tool) connects to an [OpenClaw](https://github.com/yagudaev/openclaw) gateway to give the voice AI extended capabilities:
+The brain agent (`ask_brain` tool) connects to any OpenAI-compatible chat completions endpoint (e.g. [OpenClaw](https://github.com/yagudaev/openclaw)) to give the voice AI extended capabilities:
 
 - Web search and browsing
 - Calendar management

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -323,7 +323,7 @@ export default function ChatScreen() {
       if (code === 401) {
         const convId = conversationIdRef.current
         if (convId) {
-          addMessage(convId, 'assistant', 'Authentication failed. Check your OpenClaw gateway URL and auth token in Settings.').then(() => loadMessagesRef.current())
+          addMessage(convId, 'assistant', 'Authentication failed. Check your brain agent gateway URL and auth token in Settings.').then(() => loadMessagesRef.current())
         }
       }
     },
@@ -648,7 +648,7 @@ export default function ChatScreen() {
 
     const { apiKey, model, apiUrl } = await getApiConfig()
     if (!apiKey || !apiUrl) {
-      await addMessage(conversationId, 'assistant', 'Please configure your OpenClaw API URL and key in Settings first.')
+      await addMessage(conversationId, 'assistant', 'Please configure your brain agent API URL and key in Settings first.')
       await loadMessages()
       return
     }
@@ -846,7 +846,7 @@ export default function ChatScreen() {
 
     const { apiKey, apiUrl, model } = await getApiConfig()
     if (!apiKey || !apiUrl) {
-      await addMessage(conversationId, 'assistant', 'Please configure your OpenClaw API URL and key in Settings first.')
+      await addMessage(conversationId, 'assistant', 'Please configure your brain agent API URL and key in Settings first.')
       await loadMessages()
       return false
     }

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -4,7 +4,7 @@ import { Icon } from '@/components/ui/icon'
 import { Input } from '@/components/ui/input'
 import { Text } from '@/components/ui/text'
 import { getSetting, setSetting, getLatencyAverages, type LatencyAverages } from '@/db'
-import type { OpenClawConnectionMode } from '@/lib/chat'
+import type { BrainConnectionMode } from '@/lib/chat'
 import { connectPlugin, disconnectPlugin, getPluginStatus, addPluginStatusListener, type PluginConnectionStatus } from '@/lib/plugin-completion'
 import { runPipelineTests, type TestResult } from '@/lib/pipeline-test-runner'
 import { useAutoSave, type SaveStatus } from '@/lib/use-auto-save'
@@ -58,12 +58,12 @@ export default function SettingsScreen() {
   const [vapiPublicKey, setVapiPublicKey] = useState('')
   const [assistantId, setAssistantId] = useState('')
   const [defaultModel, setDefaultModel] = useState('openclaw:voice')
-  const [openclawApiKey, setOpenclawApiKey] = useState('')
-  const [openclawApiUrl, setOpenclawApiUrl] = useState('')
+  const [brainApiKey, setBrainApiKey] = useState('')
+  const [brainApiUrl, setBrainApiUrl] = useState('')
   const [systemPrompt, setSystemPrompt] = useState('You are a helpful assistant. Keep responses concise. Use markdown for formatting and images when appropriate. Your identity, personality, and capabilities are defined in your system files.')
 
-  // OpenClaw connection mode
-  const [connectionMode, setConnectionMode] = useState<OpenClawConnectionMode>('http')
+  // Brain agent connection mode
+  const [connectionMode, setConnectionMode] = useState<BrainConnectionMode>('http')
   const [gatewayUrl, setGatewayUrl] = useState('')
   const [authToken, setAuthToken] = useState('')
   const [pluginStatus, setPluginStatus] = useState<PluginConnectionStatus>('disconnected')
@@ -110,14 +110,14 @@ export default function SettingsScreen() {
 
   // API key validation state
   const [validationStatus, setValidationStatus] = useState<Record<Provider, ValidationStatus>>({
-    openclaw: 'idle',
+    brain: 'idle',
     elevenlabs: 'idle',
     deepgram: 'idle',
     openai_tts: 'idle',
     vapi: 'idle',
   })
   const [validationErrors, setValidationErrors] = useState<Record<Provider, string | undefined>>({
-    openclaw: undefined,
+    brain: undefined,
     elevenlabs: undefined,
     deepgram: undefined,
     openai_tts: undefined,
@@ -184,18 +184,18 @@ export default function SettingsScreen() {
       const key = (await getSetting('vapi_public_key')) || (await getSetting('vapi_api_key'))
       const assistant = await getSetting('assistant_id')
       const model = await getSetting('default_model')
-      const ocKey = await getSetting('openclaw_api_key')
-      const ocUrl = await getSetting('openclaw_api_url')
+      const ocKey = (await getSetting('brain_api_key')) || (await getSetting('openclaw_api_key'))
+      const ocUrl = (await getSetting('brain_api_url')) || (await getSetting('openclaw_api_url'))
       if (key) setVapiPublicKey(key)
       if (assistant) setAssistantId(assistant)
       if (model) setDefaultModel(model)
-      if (ocKey) setOpenclawApiKey(ocKey)
-      if (ocUrl) setOpenclawApiUrl(ocUrl)
-      const cm = await getSetting('openclaw_connection_mode')
+      if (ocKey) setBrainApiKey(ocKey)
+      if (ocUrl) setBrainApiUrl(ocUrl)
+      const cm = (await getSetting('brain_connection_mode')) || (await getSetting('openclaw_connection_mode'))
       if (cm === 'http' || cm === 'plugin') setConnectionMode(cm)
-      const gw = await getSetting('openclaw_gateway_url')
+      const gw = (await getSetting('brain_gateway_url')) || (await getSetting('openclaw_gateway_url'))
       if (gw) setGatewayUrl(gw)
-      const at = await getSetting('openclaw_auth_token')
+      const at = (await getSetting('brain_auth_token')) || (await getSetting('openclaw_auth_token'))
       if (at) setAuthToken(at)
       const sp = await getSetting('system_prompt')
       if (sp) setSystemPrompt(sp)
@@ -356,31 +356,31 @@ export default function SettingsScreen() {
     if (loadedRef.current) saveDebounced('default_model', v)
   }, [saveDebounced])
 
-  const updateOpenclawApiKey = useCallback((v: string) => {
-    setOpenclawApiKey(v)
-    resetValidation('openclaw')
-    if (loadedRef.current) saveDebounced('openclaw_api_key', v)
+  const updateBrainApiKey = useCallback((v: string) => {
+    setBrainApiKey(v)
+    resetValidation('brain')
+    if (loadedRef.current) saveDebounced('brain_api_key', v)
   }, [saveDebounced, resetValidation])
 
-  const updateOpenclawApiUrl = useCallback((v: string) => {
-    setOpenclawApiUrl(v)
-    resetValidation('openclaw')
-    if (loadedRef.current) saveDebounced('openclaw_api_url', v)
+  const updateBrainApiUrl = useCallback((v: string) => {
+    setBrainApiUrl(v)
+    resetValidation('brain')
+    if (loadedRef.current) saveDebounced('brain_api_url', v)
   }, [saveDebounced, resetValidation])
 
-  const updateConnectionMode = useCallback((v: OpenClawConnectionMode) => {
+  const updateConnectionMode = useCallback((v: BrainConnectionMode) => {
     setConnectionMode(v)
-    if (loadedRef.current) saveImmediate('openclaw_connection_mode', v)
+    if (loadedRef.current) saveImmediate('brain_connection_mode', v)
   }, [saveImmediate])
 
   const updateGatewayUrl = useCallback((v: string) => {
     setGatewayUrl(v)
-    if (loadedRef.current) saveDebounced('openclaw_gateway_url', v)
+    if (loadedRef.current) saveDebounced('brain_gateway_url', v)
   }, [saveDebounced])
 
   const updateAuthToken = useCallback((v: string) => {
     setAuthToken(v)
-    if (loadedRef.current) saveDebounced('openclaw_auth_token', v)
+    if (loadedRef.current) saveDebounced('brain_auth_token', v)
   }, [saveDebounced])
 
   const updateSystemPrompt = useCallback((v: string) => {
@@ -718,8 +718,8 @@ export default function SettingsScreen() {
           </Card>
         )}
 
-        {voiceMode !== 'realtime' && <Card testID="openclaw-config-card" className="gap-4 p-4">
-          <Text className="text-lg font-semibold text-foreground">OpenClaw Configuration</Text>
+        {voiceMode !== 'realtime' && <Card testID="brain-config-card" className="gap-4 p-4">
+          <Text className="text-lg font-semibold text-foreground">Brain Agent Configuration</Text>
 
           <View className="gap-2">
             <Text className="text-sm text-muted-foreground">Connection Mode</Text>
@@ -739,8 +739,8 @@ export default function SettingsScreen() {
                 <Text className="text-sm text-muted-foreground">API URL</Text>
                 <Input
                   placeholder="https://your-server.com/v1/chat/completions"
-                  value={openclawApiUrl}
-                  onChangeText={updateOpenclawApiUrl}
+                  value={brainApiUrl}
+                  onChangeText={updateBrainApiUrl}
                   autoCapitalize="none"
                   autoCorrect={false}
                   keyboardType="url"
@@ -750,12 +750,12 @@ export default function SettingsScreen() {
               <View className="gap-2">
                 <Text className="text-sm text-muted-foreground">API Key</Text>
                 <SecretInput
-                  value={openclawApiKey}
-                  onChangeText={updateOpenclawApiKey}
-                  placeholder="Enter your OpenClaw API key"
-                  validationStatus={validationStatus.openclaw}
-                  validationError={validationErrors.openclaw}
-                  onTest={() => testApiKey('openclaw', openclawApiKey, openclawApiUrl)}
+                  value={brainApiKey}
+                  onChangeText={updateBrainApiKey}
+                  placeholder="Enter your brain agent API key"
+                  validationStatus={validationStatus.brain}
+                  validationError={validationErrors.brain}
+                  onTest={() => testApiKey('brain', brainApiKey, brainApiUrl)}
                 />
               </View>
             </>
@@ -806,8 +806,8 @@ export default function SettingsScreen() {
               <View className="rounded-lg border border-input bg-background/50 p-3 dark:bg-input/20">
                 <Text className="mb-1 text-xs font-medium text-muted-foreground">Setup Instructions</Text>
                 <Text className="text-xs leading-5 text-muted-foreground">
-                  1. Install the OpenClaw plugin: see openclaw-plugin/ in the repo{'\n'}
-                  2. Start the OpenClaw gateway on your machine with the plugin enabled{'\n'}
+                  1. Install the brain agent plugin: see openclaw-plugin/ in the repo{'\n'}
+                  2. Start the brain agent gateway on your machine with the plugin enabled{'\n'}
                   3. Enter the gateway base URL above (e.g. http://your-ip:8080){'\n'}
                   4. Tap Connect to verify the plugin health endpoint
                 </Text>

--- a/mobile/lib/chat.ts
+++ b/mobile/lib/chat.ts
@@ -2,7 +2,7 @@ import { getSetting } from '@/db'
 import { pluginStreamCompletion } from '@/lib/plugin-completion'
 import EventSource from 'react-native-sse'
 
-export type OpenClawConnectionMode = 'http' | 'plugin'
+export type BrainConnectionMode = 'http' | 'plugin'
 
 const DEFAULT_SYSTEM_PROMPT = `\
 You are a helpful assistant. Keep responses concise. Use markdown for formatting \
@@ -149,10 +149,10 @@ export function streamCompletion(
 }
 
 export async function getApiConfig() {
-  const connectionMode = ((await getSetting('openclaw_connection_mode')) || 'http') as OpenClawConnectionMode
-  const apiKey = await getSetting('openclaw_api_key')
+  const connectionMode = ((await getSetting('brain_connection_mode')) || (await getSetting('openclaw_connection_mode')) || 'http') as BrainConnectionMode
+  const apiKey = (await getSetting('brain_api_key')) || (await getSetting('openclaw_api_key'))
   const model = (await getSetting('default_model')) || 'openclaw:voice'
-  const apiUrl = await getSetting('openclaw_api_url')
+  const apiUrl = (await getSetting('brain_api_url')) || (await getSetting('openclaw_api_url'))
   return { apiKey, model, apiUrl, connectionMode }
 }
 
@@ -171,7 +171,7 @@ export function unifiedStreamCompletion(
   apiUrl: string,
   systemPrompt: string,
   conversationId: number,
-  connectionMode: OpenClawConnectionMode,
+  connectionMode: BrainConnectionMode,
   callbacks: {
     onToken: (fullText: string) => void
     onDone: (fullText: string) => void

--- a/mobile/lib/plugin-completion.ts
+++ b/mobile/lib/plugin-completion.ts
@@ -26,8 +26,8 @@ export function addPluginStatusListener(listener: PluginStatusListener): () => v
 }
 
 export async function connectPlugin(baseUrl?: string, token?: string): Promise<void> {
-  const gatewayBaseUrl = normalizeBaseUrl(baseUrl ?? await getSetting('openclaw_gateway_url'))
-  const authToken = token ?? await getSetting('openclaw_auth_token')
+  const gatewayBaseUrl = normalizeBaseUrl(baseUrl ?? (await getSetting('brain_gateway_url')) ?? (await getSetting('openclaw_gateway_url')))
+  const authToken = token ?? (await getSetting('brain_auth_token')) ?? (await getSetting('openclaw_auth_token'))
 
   if (!gatewayBaseUrl) {
     setStatus('error')
@@ -133,8 +133,8 @@ export function pluginStreamCompletion(
 }
 
 export async function getPluginConfig() {
-  const gatewayBaseUrl = normalizeBaseUrl(await getSetting('openclaw_gateway_url'))
-  const authToken = await getSetting('openclaw_auth_token')
+  const gatewayBaseUrl = normalizeBaseUrl((await getSetting('brain_gateway_url')) || (await getSetting('openclaw_gateway_url')))
+  const authToken = (await getSetting('brain_auth_token')) || (await getSetting('openclaw_auth_token'))
   const model = (await getSetting('default_model')) || 'openclaw:voice'
   return { gatewayBaseUrl, authToken, model }
 }

--- a/mobile/lib/validate-api-key.ts
+++ b/mobile/lib/validate-api-key.ts
@@ -5,7 +5,7 @@ export type ValidationResult = {
   error?: string
 }
 
-export type Provider = 'openclaw' | 'elevenlabs' | 'deepgram' | 'openai_tts' | 'vapi'
+export type Provider = 'brain' | 'elevenlabs' | 'deepgram' | 'openai_tts' | 'vapi'
 
 export async function validateApiKey(
   provider: Provider,
@@ -17,8 +17,8 @@ export async function validateApiKey(
   }
 
   switch (provider) {
-    case 'openclaw':
-      return validateOpenClaw(apiKey, apiUrl)
+    case 'brain':
+      return validateBrainAgent(apiKey, apiUrl)
     case 'elevenlabs':
       return validateElevenLabs(apiKey)
     case 'deepgram':
@@ -34,7 +34,7 @@ export async function validateApiKey(
 
 // --- Validation functions ---
 
-async function validateOpenClaw(
+async function validateBrainAgent(
   apiKey: string,
   apiUrl?: string,
 ): Promise<ValidationResult> {

--- a/mobile/uitests/SmokeTests.swift
+++ b/mobile/uitests/SmokeTests.swift
@@ -56,7 +56,7 @@ final class SmokeTests: VoiceClawUITests {
   func testSettingsScreenHasCards() throws {
     navigateToTab("Settings")
     assertExists(testID: "voice-pipeline-card")
-    assertExists(testID: "openclaw-config-card")
+    assertExists(testID: "brain-config-card")
     assertExists(testID: "latency-stats-card")
     takeScreenshot(name: "settings-cards")
   }

--- a/relay-server/.env.example
+++ b/relay-server/.env.example
@@ -12,20 +12,20 @@ GEMINI_API_KEY=
 # Generate one: openssl rand -hex 24
 RELAY_API_KEY=
 
-# OpenClaw gateway auth token (for brain agent)
-# Found in ~/.openclaw/openclaw.json under gateway.auth.token
-OPENCLAW_GATEWAY_AUTH_TOKEN=
+# Brain agent gateway auth token (formerly OPENCLAW_GATEWAY_AUTH_TOKEN)
+# If using OpenClaw, found in ~/.openclaw/openclaw.json under gateway.auth.token
+BRAIN_GATEWAY_AUTH_TOKEN=
 
 # ── Optional ─────────────────────────────────────────────────────────────────
 
 # Server port (default: 8080)
 # PORT=8080
 
-# OpenClaw gateway URL (default: http://localhost:18789)
-# OPENCLAW_GATEWAY_URL=http://localhost:18789
+# Brain agent gateway URL -- any OpenAI-compatible endpoint (formerly OPENCLAW_GATEWAY_URL)
+# BRAIN_GATEWAY_URL=http://localhost:18789
 
-# OpenClaw workspace name (used in system instructions)
-# OPENCLAW_WORKSPACE=
+# Brain agent workspace path (used in system instructions; formerly OPENCLAW_WORKSPACE)
+# BRAIN_WORKSPACE=
 
 # OpenAI session rotation interval in ms (default: 50 minutes)
 # ROTATION_INTERVAL_MS=3000000

--- a/relay-server/README.md
+++ b/relay-server/README.md
@@ -1,11 +1,12 @@
 # VoiceClaw Relay Server
 
-WebSocket relay that bridges mobile clients to the OpenAI Realtime API and OpenClaw brain agent.
+WebSocket relay that bridges mobile clients to the OpenAI Realtime API and the brain agent gateway.
 
 ## Setup
 
 1. Copy `.env.example` to `.env` and fill in your keys
-2. Enable the OpenClaw gateway completions endpoint (required for brain agent):
+2. Point `BRAIN_GATEWAY_URL` at any OpenAI-compatible chat completions endpoint (required for brain agent).
+   If you use [OpenClaw](https://github.com/yagudaev/openclaw), enable the gateway completions endpoint:
    - In `~/.openclaw/openclaw.json`, add under the `gateway` key:
      ```json
      "http": {
@@ -22,8 +23,8 @@ WebSocket relay that bridges mobile clients to the OpenAI Realtime API and OpenC
 ```
 Mobile App ──WebSocket──▶ Relay Server ──WebSocket──▶ OpenAI Realtime API
                               │
-                              └──HTTP──▶ OpenClaw Gateway (/v1/chat/completions)
-                                         (brain agent queries)
+                              └──HTTP──▶ Brain Agent Gateway (/v1/chat/completions)
+                                         (any OpenAI-compatible endpoint)
 ```
 
 The relay handles:

--- a/relay-server/src/auth.ts
+++ b/relay-server/src/auth.ts
@@ -1,6 +1,6 @@
-// Validate OpenClaw auth token by hitting the gateway's /v1/models endpoint
+// Validate brain agent auth token by hitting the gateway's /v1/models endpoint
 
-export async function validateOpenClawToken(
+export async function validateBrainGatewayToken(
   gatewayUrl: string,
   authToken: string,
 ): Promise<boolean> {

--- a/relay-server/src/instructions.ts
+++ b/relay-server/src/instructions.ts
@@ -1,5 +1,5 @@
 // Build the system instructions for the STS session
-// Loads agent identity from OpenClaw workspace, adds conversation rules and context
+// Loads agent identity from brain agent workspace, adds conversation rules and context
 
 import { readFileSync, existsSync } from "node:fs"
 import { join } from "node:path"
@@ -7,7 +7,8 @@ import { homedir } from "node:os"
 import type { SessionConfigEvent } from "./types.js"
 import { log, warn } from "./log.js"
 
-const OPENCLAW_WORKSPACE = process.env.OPENCLAW_WORKSPACE
+const BRAIN_WORKSPACE = process.env.BRAIN_WORKSPACE
+  || process.env.OPENCLAW_WORKSPACE  // backward compat
   || join(homedir(), ".openclaw", "workspace")
 
 const CONVERSATION_RULES = `
@@ -127,7 +128,7 @@ function loadAgentProfile() {
 }
 
 function loadFile(filename: string): string | null {
-  const path = join(OPENCLAW_WORKSPACE, filename)
+  const path = join(BRAIN_WORKSPACE, filename)
   if (!existsSync(path)) return null
   try {
     return readFileSync(path, "utf-8")

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -149,8 +149,8 @@ export class RelaySession {
     // Run the brain agent in the background.
     // Keep the controller in inFlightTools so cleanup() can abort it on disconnect.
     const sendToClient: SendToClient = (event) => this.send(event)
-    const gatewayUrl = process.env.OPENCLAW_GATEWAY_URL || "http://localhost:18789"
-    const authToken = process.env.OPENCLAW_GATEWAY_AUTH_TOKEN || this.config.apiKey
+    const gatewayUrl = process.env.BRAIN_GATEWAY_URL || process.env.OPENCLAW_GATEWAY_URL || "http://localhost:18789"
+    const authToken = process.env.BRAIN_GATEWAY_AUTH_TOKEN || process.env.OPENCLAW_GATEWAY_AUTH_TOKEN || this.config.apiKey
     const sessionKey = this.config.sessionKey || `voiceclaw:realtime`
 
     const brainStart = Date.now()
@@ -314,8 +314,8 @@ export class RelaySession {
       lines,
     ].join("\n")
 
-    const gatewayUrl = process.env.OPENCLAW_GATEWAY_URL || "http://localhost:18789"
-    const authToken = process.env.OPENCLAW_GATEWAY_AUTH_TOKEN || this.config.apiKey
+    const gatewayUrl = process.env.BRAIN_GATEWAY_URL || process.env.OPENCLAW_GATEWAY_URL || "http://localhost:18789"
+    const authToken = process.env.BRAIN_GATEWAY_AUTH_TOKEN || process.env.OPENCLAW_GATEWAY_AUTH_TOKEN || this.config.apiKey
     const sessionKey = this.config.sessionKey || `voiceclaw:realtime`
     const sessionId = this.id
 

--- a/relay-server/src/tools/brain.ts
+++ b/relay-server/src/tools/brain.ts
@@ -1,4 +1,4 @@
-// Brain agent tool — sends queries to OpenClaw via /v1/chat/completions
+// Brain agent tool — sends queries to the brain gateway via /v1/chat/completions
 // Uses SSE streaming to get responses, signals step completions for live progress injection
 
 import type { SendToClient } from "../adapters/types.js"

--- a/relay-server/test/test-openai-instructions-transform.ts
+++ b/relay-server/test/test-openai-instructions-transform.ts
@@ -3,8 +3,8 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 
-const fixtureDir = mkdtempSync(join(tmpdir(), "voiceclaw-openclaw-"))
-process.env.OPENCLAW_WORKSPACE = fixtureDir
+const fixtureDir = mkdtempSync(join(tmpdir(), "voiceclaw-brain-"))
+process.env.BRAIN_WORKSPACE = fixtureDir
 
 writeFileSync(join(fixtureDir, "IDENTITY.md"), `# IDENTITY.md - Who Am I?
 

--- a/relay-server/test/test-phase1a.ts
+++ b/relay-server/test/test-phase1a.ts
@@ -1,7 +1,7 @@
 // Phase 1a test script — verifies auth + echo loopback
 // Run: npx tsx test/test-phase1a.ts
 // Requires: relay server running on ws://localhost:8080/ws
-// Spins up a mock OpenClaw gateway for auth testing
+// Spins up a mock brain agent gateway for auth testing
 
 import { createServer, type Server } from "node:http"
 import WebSocket from "ws"
@@ -53,7 +53,7 @@ function waitForClose(ws: WebSocket, timeoutMs = 5000): Promise<void> {
   })
 }
 
-// Mock OpenClaw gateway — returns JSON for valid token, 401 for invalid
+// Mock brain agent gateway — returns JSON for valid token, 401 for invalid
 function startMockGateway(): Promise<Server> {
   return new Promise((resolve) => {
     const server = createServer((req, res) => {
@@ -182,7 +182,7 @@ async function main() {
   console.log(`Mock Gateway: ${MOCK_GATEWAY_URL}`)
 
   const gateway = await startMockGateway()
-  console.log("Mock OpenClaw gateway started")
+  console.log("Mock brain agent gateway started")
 
   try {
     await testValidAuth()

--- a/relay-server/test/test-phase1bc.ts
+++ b/relay-server/test/test-phase1bc.ts
@@ -188,7 +188,7 @@ async function main() {
   console.log(`Relay: ${RELAY_URL}`)
 
   const gateway = await startMockGateway()
-  console.log("Mock OpenClaw gateway started")
+  console.log("Mock brain agent gateway started")
 
   try {
     await testOpenAIConnection()


### PR DESCRIPTION
## Summary
Renames all OpenClaw-specific gateway env vars and code to be agent-agnostic, since the brain agent can be any OpenAI-compatible endpoint (OpenClaw, Hermes, custom agent, etc.).

### Renames (with backward-compat fallbacks)
- `OPENCLAW_GATEWAY_URL` → `BRAIN_GATEWAY_URL`
- `OPENCLAW_GATEWAY_AUTH_TOKEN` → `BRAIN_GATEWAY_AUTH_TOKEN`
- `OPENCLAW_WORKSPACE` → `BRAIN_WORKSPACE`

### Files changed (20)
- **relay-server**: session.ts, auth.ts, instructions.ts, .env.example, tools/brain.ts, tests
- **mobile**: settings.tsx, chat.ts, validate-api-key.ts, plugin-completion.ts, SmokeTests.swift
- **docs**: architecture, relay-server, index, contributing
- **README.md**: config table

### Intentionally left alone
- `x-openclaw-session-key` / `x-openclaw-scopes` headers (OpenClaw API protocol)
- `model: "openclaw"` (product-specific model name)
- `mobile/openclaw-plugin/` package (separate OpenClaw SDK)
- `~/.openclaw/workspace` default path (filesystem convention)

## Test plan
- [x] relay-server typecheck passes
- [ ] Existing `OPENCLAW_GATEWAY_*` env vars still work (fallback)
- [ ] Setting `BRAIN_GATEWAY_*` env vars connects to brain agent
- [ ] Mobile settings UI shows "Brain Agent Configuration"

🤖 Generated with [Claude Code](https://claude.com/claude-code)