### PR TITLE
Implement injectContext for OpenAI Realtime adapter

### DIFF
--- a/relay-server/src/adapters/openai.ts
+++ b/relay-server/src/adapters/openai.ts
@@ -47,8 +47,17 @@ export class OpenAIAdapter implements ProviderAdapter {
     // OpenAI Realtime does not support video input
   }
 
-  injectContext(_text: string) {
-    // TODO: implement for OpenAI if needed
+  injectContext(text: string) {
+    log(`[openai] Injecting context via conversation.item.create (${text.length} chars)`)
+    this.sendUpstream({
+      type: "conversation.item.create",
+      item: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text }],
+      },
+    })
+    this.requestResponse("injectContext")
   }
 
   commitAudio() {


### PR DESCRIPTION
## Summary
Implements the `injectContext` stub in the OpenAI Realtime adapter. Sends brain agent results and transcript context into the OpenAI session via `conversation.item.create` + `response.create`, matching the existing watchdog handler pattern.

## Test plan
- [ ] OpenAI calls with brain agent enabled receive context injection
- [ ] Relay server typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)