### PR TITLE
Fix Gemini hallucinations on memory recap queries (NAN-632)

### DIFF
--- a/relay-server/src/instructions.ts
+++ b/relay-server/src/instructions.ts
@@ -55,6 +55,22 @@ You have an ask_brain tool that connects to your brain agent. Your brain is wher
 When in doubt, ask your brain. You are a voice interface to a powerful agent — don't try to answer from your own limited context when your brain has the full picture.
 
 **NEVER say "I can't do that" or "I don't have access to that" before checking with your brain.** You don't know your own capabilities — your brain does. Always try first. Say "Let me see what I can do..." and ask your brain. Only after the brain confirms something is impossible should you tell the user.
+
+## MANDATORY: Memory and History Queries
+
+**This is a hard rule with zero exceptions.** You do NOT have memory of past conversations. You do NOT know what happened earlier, yesterday, last week, or in any prior session. Your conversation context only contains the current session.
+
+When the user asks ANYTHING about:
+- What you worked on, discussed, or talked about (today, earlier, recently, last time, etc.)
+- Recaps, summaries, or reviews of past work or conversations
+- What happened, what was decided, what was agreed on
+- Prior tasks, action items, or things to remember
+- Previous conversations or sessions
+- Anything the user told you before or that you should remember
+
+You MUST call ask_brain FIRST. Say "Let me check on that..." and call the tool. Do NOT answer from your own knowledge or make anything up. Do NOT synthesize a plausible answer. Do NOT guess. If you answer a memory question without calling ask_brain, you WILL fabricate false information and destroy the user's trust.
+
+This applies even if you think you know the answer from the current conversation. Your brain has the complete history — you do not.
 `.trim()
 
 export function buildInstructions(config: SessionConfigEvent): string {


### PR DESCRIPTION
## Summary
- Adds a mandatory system prompt section that explicitly forbids the Gemini voice model from answering memory/history/recap questions from its own (empty) context
- Instructs the model to ALWAYS call `ask_brain` first for any question about past conversations, prior work, recaps, tasks done, things to remember, etc.
- Tells the model to say "Let me check on that..." as a verbal bridge while awaiting the tool result

## Problem
When users ask "what did we work on today?" or "remind me what happened earlier," Gemini immediately fabricates a plausible answer instead of calling `ask_brain` to look up actual memory/history. This is a trust-destroying failure.

## Root Cause
The existing system prompt said "when in doubt, ask your brain" but did not have a hard rule specifically targeting memory/history queries. Gemini was confident enough in its (empty) context to skip the tool call entirely.

## Test plan
- [ ] Start a voice session with brain agent enabled
- [ ] Ask "what did we work on today?" -- model should call `ask_brain`, not answer directly
- [ ] Ask "remind me what happened earlier" -- same behavior
- [ ] Ask "what did we discuss last time?" -- same behavior
- [ ] Verify normal conversation (non-memory questions) still works without unnecessary tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)