### PR TITLE
Fix duplicate message entries in desktop chat (NAN-633)

### DIFF
--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -38,6 +38,15 @@ export function ChatPage() {
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const { selectedConversationId, selectConversation } = useConversationContext()
 
+  // Reload messages from DB — single source of truth, prevents duplicates.
+  // Uses conversationIdRef so callbacks always see the latest ID.
+  const loadMessages = useCallback(async () => {
+    const convId = conversationIdRef.current
+    if (!convId) return
+    const msgs = await getMessages(convId)
+    setMessages(msgs)
+  }, [])
+
   // Auto-scroll to bottom on new messages
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
@@ -105,8 +114,8 @@ export function ChatPage() {
       setStreamingText('')
       if (!text.trim()) return
       const convId = await ensureConversation()
-      const msg = await addMessage(convId, role, text)
-      setMessages((prev) => [...prev, msg])
+      await addMessage(convId, role, text)
+      await loadMessages()
 
       if (role === 'user' && !titleGeneratedRef.current) {
         titleGeneratedRef.current = true
@@ -124,14 +133,14 @@ export function ChatPage() {
     onTurnEnded: () => {
       setIsThinking(true)
     },
-    onToolCall: async (callId, name, args) => {
+    onToolCall: async (_callId, name, args) => {
       // Handle displayText tool call locally
       if (name === 'displayText') {
         try {
           const parsed = JSON.parse(args)
           const convId = await ensureConversation()
-          const msg = await addMessage(convId, 'assistant', parsed.text)
-          setMessages((prev) => [...prev, msg])
+          await addMessage(convId, 'assistant', parsed.text)
+          await loadMessages()
         } catch {
           // ignore parse errors
         }


### PR DESCRIPTION
## Summary

- **Root cause**: `onTranscriptDone` and `onToolCall` handlers in the desktop `ChatPage` appended new messages to React state optimistically after DB insert (`setMessages((prev) => [...prev, msg])`). This could produce duplicates when events arrived rapidly or when the conversation was reloaded from DB.
- **Fix**: Replace the optimistic append with a `loadMessages()` call that reloads the full message list from the database after each insert. The database is now the single source of truth, matching the mobile app's existing pattern.
- Both `onTranscriptDone` (user and assistant turns) and `onToolCall` (`displayText`) paths are fixed.

## Test plan

- [ ] Start a desktop voice call with the relay server and verify messages appear once in the chat UI
- [ ] Test a multi-turn conversation (user speaks, assistant responds, user speaks again) and confirm no duplicates
- [ ] Trigger a `displayText` tool call and verify it shows once
- [ ] Switch between conversations via History tab and return -- messages should not be duplicated
- [ ] Compare with mobile app behavior to confirm parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)