### PR TITLE
Make watchdog/check-in optional and off by default (NAN-634)

### DIFF
--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -43,6 +43,7 @@ export class GeminiAdapter implements ProviderAdapter {
   private currentUserText = ""
   private userSpeaking = false
   private hasVideoInput = false
+  private watchdogEnabled = false
 
   // Session resumption state
   private resumptionHandle: string | null = null
@@ -61,6 +62,7 @@ export class GeminiAdapter implements ProviderAdapter {
     this.sendToClient = sendToClient
     this.config = config
     this.disconnected = false
+    this.watchdogEnabled = config.watchdog === "enabled"
 
     await this.openUpstream()
   }
@@ -662,6 +664,7 @@ export class GeminiAdapter implements ProviderAdapter {
 
   private resetWatchdog() {
     this.clearWatchdog()
+    if (!this.watchdogEnabled) return
     // While a tool call is in flight, leave the watchdog paused — firing the
     // "user silent" prompt mid-tool would inject a fake user turn into a
     // session that's already waiting on us, corrupting the conversation.

--- a/relay-server/src/adapters/openai.ts
+++ b/relay-server/src/adapters/openai.ts
@@ -25,10 +25,12 @@ export class OpenAIAdapter implements ProviderAdapter {
   private pendingResponseCancel = false
   private pendingResponseCreate = false
   private pendingToolCalls = 0
+  private watchdogEnabled = false
 
   async connect(config: SessionConfigEvent, sendToClient: SendToClient): Promise<void> {
     this.sendToClient = sendToClient
     this.config = config
+    this.watchdogEnabled = config.watchdog === "enabled"
 
     await this.openUpstream(config)
     this.startRotationTimer()
@@ -323,7 +325,9 @@ export class OpenAIAdapter implements ProviderAdapter {
   private resetWatchdog() {
     if (this.watchdogTimer) {
       clearTimeout(this.watchdogTimer)
+      this.watchdogTimer = null
     }
+    if (!this.watchdogEnabled) return
     this.watchdogTimer = setTimeout(() => this.handleWatchdogTimeout(), WATCHDOG_TIMEOUT_MS)
   }
 

--- a/relay-server/src/types.ts
+++ b/relay-server/src/types.ts
@@ -25,6 +25,7 @@ export interface SessionConfigEvent {
     deviceModel?: string
     location?: string
   }
+  watchdog?: "enabled" | "disabled"
   instructionsOverride?: string
   conversationHistory?: { role: "user" | "assistant", text: string }[]
 }

--- a/relay-server/test/test-gemini-reconnect.ts
+++ b/relay-server/test/test-gemini-reconnect.ts
@@ -282,10 +282,13 @@ async function runWatchdogGatedTest() {
   type AdapterInternals = {
     pendingToolCalls: number
     watchdogTimer: ReturnType<typeof setTimeout> | null
+    watchdogEnabled: boolean
     resetWatchdog: () => void
   }
   const internals = adapter as unknown as AdapterInternals
 
+  // Enable watchdog so the gating logic is testable
+  internals.watchdogEnabled = true
   internals.pendingToolCalls = 0
   internals.resetWatchdog()
   assert(internals.watchdogTimer !== null, "watchdog armed when no pending tool calls")


### PR DESCRIPTION
## Summary
- Adds a `watchdog` field to `SessionConfigEvent` (`"enabled" | "disabled"`, defaults to `"disabled"`)
- Both Gemini and OpenAI adapters now skip the 20-second silence watchdog timer unless explicitly enabled via session config
- Existing clients get the improved behavior (no "are you still there?" prompts) without any changes
- Updated existing Gemini reconnect tests to explicitly enable the watchdog when testing gating logic

## Changes
- `relay-server/src/types.ts` — added `watchdog?: "enabled" | "disabled"` to `SessionConfigEvent`
- `relay-server/src/adapters/gemini.ts` — reads `config.watchdog`, gates `resetWatchdog()` on the flag
- `relay-server/src/adapters/openai.ts` — same pattern as Gemini adapter
- `relay-server/test/test-gemini-reconnect.ts` — updated watchdog gating test to set `watchdogEnabled = true`

## Test plan
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] OpenAI response guard tests pass (including watchdog tests)
- [x] Gemini unit tests pass
- [x] Gemini reconnect tests pass (47/47)
- [ ] Verify on device that sessions no longer get "are you still there?" prompts by default
- [ ] Verify that passing `watchdog: "enabled"` in session config restores the old behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)