### PR TITLE
Add iOS screen sharing to Gemini realtime calls

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -67,6 +67,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     ['./plugins/with-ios-icons', { variant: APP_VARIANT }],
     './plugins/with-ui-tests',
     './plugins/with-kokoro-swift',
+    './plugins/with-broadcast-extension',
   ],
   experiments: {
     typedRoutes: true,

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -15,10 +15,12 @@ import { useTranscriptBuffer } from '@/lib/use-transcript-buffer'
 import { useAutoReconnect } from '@/lib/use-auto-reconnect'
 import ExpoCustomPipelineModule from '@/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule'
 import ExpoRealtimeAudioModule from '@/modules/expo-realtime-audio/src/ExpoRealtimeAudioModule'
+import ExpoScreenCaptureModule from '@/modules/expo-screen-capture/src/ExpoScreenCaptureModule'
+import type { ScreenFrameEvent, ScreenCaptureStateEvent } from '@/modules/expo-screen-capture/src/ExpoScreenCapture.types'
 import ExpoVapiModule from '@/modules/expo-vapi'
 import type { FunctionCallEvent, SpeechEvent, TranscriptEvent } from '@/modules/expo-vapi'
 import { Stack } from 'expo-router'
-import { MicIcon, MicOffIcon, PhoneOffIcon, PlusIcon, RefreshCwIcon, SendIcon, XIcon } from 'lucide-react-native'
+import { MicIcon, MicOffIcon, PhoneOffIcon, PlusIcon, RefreshCwIcon, ScreenShareIcon, ScreenShareOffIcon, SendIcon, XIcon } from 'lucide-react-native'
 import { useColorScheme } from 'nativewind'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ActivityIndicator, Animated, FlatList, Image, KeyboardAvoidingView, Platform, Pressable, View } from 'react-native'
@@ -110,6 +112,10 @@ export default function ChatScreen() {
   const [debugMode, setDebugMode] = useState(false)
   const [streamingRole, setStreamingRole] = useState<'user' | 'assistant'>('assistant')
   const [isUserSpeaking, setIsUserSpeaking] = useState(false)
+  const [isScreenSharing, setIsScreenSharing] = useState(false)
+  const [screenShareSource, setScreenShareSource] = useState<'in-app' | 'broadcast' | 'none'>('none')
+  const [isGeminiModel, setIsGeminiModel] = useState(false)
+  const screenShareFramesRef = useRef(0)
   const flatListRef = useRef<FlatList<Message>>(null)
   const hasScrolledRef = useRef(false)
   const { playJoin, playEnd, startThinking, stopThinking } = useCallSounds()
@@ -634,6 +640,28 @@ export default function ChatScreen() {
     getSetting('debug_mode').then((v) => { if (v === 'true') setDebugMode(true) }).catch(() => {})
   }, [])
 
+  // Screen-capture: forward frames from the native module to the realtime relay.
+  useEffect(() => {
+    const frameSub = ExpoScreenCaptureModule.addListener('onFrame', (event: ScreenFrameEvent) => {
+      if (activeVoiceModeRef.current !== 'realtime') return
+      realtime.sendFrame(event.data)
+      screenShareFramesRef.current += 1
+    })
+    const stateSub = ExpoScreenCaptureModule.addListener('onStateChange', (event: ScreenCaptureStateEvent) => {
+      setScreenShareSource(event.source)
+      if (event.state === 'active') setIsScreenSharing(true)
+      else if (event.state === 'idle') setIsScreenSharing(false)
+    })
+    const errorSub = ExpoScreenCaptureModule.addListener('onError', (event) => {
+      console.warn('[ScreenCapture] Error:', event.message, event.code)
+    })
+    return () => {
+      frameSub.remove()
+      stateSub.remove()
+      errorSub.remove()
+    }
+  }, [realtime])
+
   useEffect(() => { loadMessages() }, [loadMessages])
 
   const sendMessage = useCallback(async () => {
@@ -941,6 +969,7 @@ export default function ChatScreen() {
     }
 
     const isGemini = model.startsWith('gemini-')
+    setIsGeminiModel(isGemini)
     activeProvidersRef.current = {
       sttProvider: isGemini ? 'gemini-realtime' : 'openai-realtime',
       llmProvider: isGemini ? 'gemini-realtime' : 'gpt-4o-mini-realtime',
@@ -989,8 +1018,54 @@ export default function ChatScreen() {
     setIsMuted(false)
     setIsThinking(false)
     setIsUserSpeaking(false)
+    setIsGeminiModel(false)
+    // Tear down any active screen share when the call ends.
+    if (isScreenSharing) {
+      ExpoScreenCaptureModule.stopInAppCapture().catch(() => {})
+      ExpoScreenCaptureModule.stopBroadcastBridge()
+      setIsScreenSharing(false)
+      setScreenShareSource('none')
+    }
     soundsRef.current.playEnd()
-  }, [realtime, cancelReconnect])
+  }, [realtime, cancelReconnect, isScreenSharing])
+
+  const toggleScreenShare = useCallback(async () => {
+    if (!isGeminiModel) return
+    if (isScreenSharing) {
+      try {
+        await ExpoScreenCaptureModule.stopInAppCapture()
+      } catch (e) {
+        console.warn('[ScreenCapture] stopInAppCapture failed', e)
+      }
+      ExpoScreenCaptureModule.stopBroadcastBridge()
+      setIsScreenSharing(false)
+      setScreenShareSource('none')
+      return
+    }
+
+    if (!ExpoScreenCaptureModule.isAvailable()) {
+      const convId = conversationIdRef.current
+      if (convId) {
+        addMessage(convId, 'assistant', 'Screen recording is not available on this device.').then(() => loadMessagesRef.current())
+      }
+      return
+    }
+
+    screenShareFramesRef.current = 0
+    try {
+      await ExpoScreenCaptureModule.startInAppCapture()
+      // Also start the broadcast bridge in case the user opts into background
+      // capture via a long-press. Bridge is cheap when inactive.
+    } catch (e) {
+      console.warn('[ScreenCapture] startInAppCapture failed', e)
+    }
+  }, [isGeminiModel, isScreenSharing])
+
+  const startBackgroundScreenShare = useCallback(() => {
+    if (!isGeminiModel) return
+    ExpoScreenCaptureModule.startBroadcastBridge()
+    ExpoScreenCaptureModule.presentBroadcastPicker()
+  }, [isGeminiModel])
 
   const handlePipelineInterrupt = useCallback(() => {
     setPipelineDebugState((current) => ({
@@ -1116,6 +1191,19 @@ export default function ChatScreen() {
             <Button testID="mute-button" variant={isMuted ? 'destructive' : 'secondary'} size="icon" className="rounded-full" onPress={toggleMute}>
               <Icon as={isMuted ? MicOffIcon : MicIcon} size={20} className="text-foreground" />
             </Button>
+          )}
+          {isGeminiModel && activeVoiceModeRef.current === 'realtime' && (
+            <Pressable
+              testID="screen-share-button"
+              onPress={toggleScreenShare}
+              onLongPress={startBackgroundScreenShare}
+              className={`h-10 w-10 items-center justify-center rounded-full ${isScreenSharing ? 'bg-primary' : 'bg-secondary'}`}>
+              <Icon
+                as={isScreenSharing ? ScreenShareOffIcon : ScreenShareIcon}
+                size={20}
+                className={isScreenSharing ? 'text-primary-foreground' : 'text-foreground'}
+              />
+            </Pressable>
           )}
           <Button testID="end-call-button" variant="destructive" className="rounded-full px-6" onPress={toggleCall}>
             <Icon as={PhoneOffIcon} size={20} className="text-destructive-foreground" />

--- a/mobile/broadcast-extension/BroadcastUpload.entitlements
+++ b/mobile/broadcast-extension/BroadcastUpload.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.yagudaev.voiceclaw.broadcast</string>
+    </array>
+</dict>
+</plist>

--- a/mobile/broadcast-extension/Info.plist
+++ b/mobile/broadcast-extension/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleDisplayName</key>
+    <string>VoiceClaw Broadcast</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.broadcast-services-upload</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>$(PRODUCT_MODULE_NAME).SampleHandler</string>
+        <key>RPBroadcastProcessMode</key>
+        <string>RPBroadcastProcessModeSampleBuffer</string>
+    </dict>
+</dict>
+</plist>

--- a/mobile/broadcast-extension/SampleHandler.swift
+++ b/mobile/broadcast-extension/SampleHandler.swift
@@ -1,0 +1,114 @@
+//
+// SampleHandler.swift
+//
+// Broadcast Upload Extension for VoiceClaw. Captures the full device screen
+// (including when the host app is backgrounded) at 1 FPS, encodes each frame
+// as JPEG, writes it to the shared App Group container, and posts a Darwin
+// notification so the host app can read it and send it over its active
+// realtime WebSocket.
+//
+// The host app reads frames in ScreenCaptureManager.handleBroadcastFrameNotification
+// (see mobile/modules/expo-screen-capture/ios/ScreenCaptureManager.swift).
+//
+// Keep constants here in sync with ScreenCaptureManager.
+
+import ReplayKit
+import UIKit
+import CoreImage
+import CoreVideo
+
+private let APP_GROUP_ID = "group.com.yagudaev.voiceclaw.broadcast"
+private let FRAME_FILENAME = "latest-frame.jpg"
+private let HEARTBEAT_FILENAME = "heartbeat.txt"
+private let FRAME_COUNTER_FILENAME = "frame-id.txt"
+private let DARWIN_FRAME_NOTIFICATION = "com.yagudaev.voiceclaw.broadcast.frame" as CFString
+
+private let MAX_DIMENSION: CGFloat = 768
+private let CAPTURE_INTERVAL: TimeInterval = 1.0
+private let JPEG_QUALITY: CGFloat = 0.7
+
+class SampleHandler: RPBroadcastSampleHandler {
+    private let ciContext = CIContext(options: [.useSoftwareRenderer: false])
+    private var frameCounter: Int = 0
+    private var lastFrameAt: TimeInterval = 0
+    private let writeQueue = DispatchQueue(label: "voiceclaw.broadcast.write", qos: .userInitiated)
+
+    override func broadcastStarted(withSetupInfo setupInfo: [String: NSObject]?) {
+        touchHeartbeat()
+    }
+
+    override func broadcastPaused() {
+        // Nothing to flush — we write on every sample buffer.
+    }
+
+    override func broadcastResumed() {
+        touchHeartbeat()
+    }
+
+    override func broadcastFinished() {
+        // Best-effort cleanup: remove the heartbeat so the app stops treating us
+        // as live. Frame file is left behind; it'll be overwritten next session.
+        guard let url = sharedURL() else { return }
+        try? FileManager.default.removeItem(at: url.appendingPathComponent(HEARTBEAT_FILENAME))
+    }
+
+    override func processSampleBuffer(_ sampleBuffer: CMSampleBuffer, with sampleBufferType: RPSampleBufferType) {
+        guard sampleBufferType == .video else { return }
+
+        let now = Date().timeIntervalSince1970
+        if now - lastFrameAt < CAPTURE_INTERVAL { return }
+        lastFrameAt = now
+
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        let sourceExtent = ciImage.extent
+        guard sourceExtent.width > 0, sourceExtent.height > 0 else { return }
+
+        let scale = min(MAX_DIMENSION / sourceExtent.width, MAX_DIMENSION / sourceExtent.height, 1.0)
+        let scaledImage = ciImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+        let targetExtent = scaledImage.extent
+        guard let cgImage = ciContext.createCGImage(scaledImage, from: targetExtent) else { return }
+
+        let uiImage = UIImage(cgImage: cgImage, scale: 1.0, orientation: .up)
+        guard let jpegData = uiImage.jpegData(compressionQuality: JPEG_QUALITY) else { return }
+
+        let id = frameCounter + 1
+        frameCounter = id
+        writeQueue.async { [weak self] in
+            self?.writeFrame(jpegData, id: id)
+        }
+    }
+
+    private func writeFrame(_ data: Data, id: Int) {
+        guard let url = sharedURL() else { return }
+        let frameURL = url.appendingPathComponent(FRAME_FILENAME)
+        let counterURL = url.appendingPathComponent(FRAME_COUNTER_FILENAME)
+
+        do {
+            try data.write(to: frameURL, options: .atomic)
+            try String(id).write(to: counterURL, atomically: true, encoding: .utf8)
+            touchHeartbeat()
+            CFNotificationCenterPostNotification(
+                CFNotificationCenterGetDarwinNotifyCenter(),
+                CFNotificationName(DARWIN_FRAME_NOTIFICATION),
+                nil,
+                nil,
+                true
+            )
+        } catch {
+            // Swallow — next frame will try again. Extensions have a 50MB cap
+            // so we don't want to throw and kill the broadcast session.
+        }
+    }
+
+    private func touchHeartbeat() {
+        guard let url = sharedURL() else { return }
+        let heartbeatURL = url.appendingPathComponent(HEARTBEAT_FILENAME)
+        let ts = String(Date().timeIntervalSince1970)
+        try? ts.write(to: heartbeatURL, atomically: true, encoding: .utf8)
+    }
+
+    private func sharedURL() -> URL? {
+        return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: APP_GROUP_ID)
+    }
+}

--- a/mobile/lib/use-realtime.ts
+++ b/mobile/lib/use-realtime.ts
@@ -51,6 +51,7 @@ export interface RealtimeControls {
   start: (config: RealtimeConfig) => void
   stop: () => void
   setMuted: (muted: boolean) => void
+  sendFrame: (base64Jpeg: string, mimeType?: string) => void
   isConnected: boolean
   sessionId: string | null
 }
@@ -251,5 +252,14 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
     mutedRef.current = muted
   }, [])
 
-  return { start, stop, setMuted, isConnected, sessionId }
+  const sendFrame = useCallback((base64Jpeg: string, mimeType = 'image/jpeg') => {
+    if (wsRef.current?.readyState !== WebSocket.OPEN) return
+    wsRef.current.send(JSON.stringify({
+      type: 'frame.append',
+      data: base64Jpeg,
+      mimeType,
+    }))
+  }, [])
+
+  return { start, stop, setMuted, sendFrame, isConnected, sessionId }
 }

--- a/mobile/modules/expo-screen-capture/expo-module.config.json
+++ b/mobile/modules/expo-screen-capture/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["ExpoScreenCaptureModule"]
+  }
+}

--- a/mobile/modules/expo-screen-capture/index.ts
+++ b/mobile/modules/expo-screen-capture/index.ts
@@ -1,0 +1,2 @@
+export { default } from './src/ExpoScreenCaptureModule'
+export * from './src/ExpoScreenCapture.types'

--- a/mobile/modules/expo-screen-capture/ios/ExpoScreenCapture.podspec
+++ b/mobile/modules/expo-screen-capture/ios/ExpoScreenCapture.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name           = 'ExpoScreenCapture'
+  s.version        = '1.0.0'
+  s.summary        = 'Expo module for iOS screen sharing via ReplayKit'
+  s.description    = 'Captures the screen at 1 FPS using ReplayKit (in-app or broadcast extension) and emits base64 JPEG frames for realtime LLM streaming'
+  s.author         = 'VoiceClaw'
+  s.homepage       = 'https://github.com/yagudaev/voiceclaw'
+  s.platforms      = { :ios => '16.0' }
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.source_files = "*.swift"
+end

--- a/mobile/modules/expo-screen-capture/ios/ExpoScreenCaptureModule.swift
+++ b/mobile/modules/expo-screen-capture/ios/ExpoScreenCaptureModule.swift
@@ -1,0 +1,82 @@
+import ExpoModulesCore
+import ReplayKit
+
+public class ExpoScreenCaptureModule: Module {
+    private var manager: ScreenCaptureManager?
+
+    public func definition() -> ModuleDefinition {
+        Name("ExpoScreenCapture")
+
+        Events("onFrame", "onError", "onStateChange")
+
+        OnCreate {
+            self.manager = ScreenCaptureManager(
+                onFrame: { [weak self] data, width, height in
+                    self?.sendEvent("onFrame", [
+                        "data": data,
+                        "width": width,
+                        "height": height,
+                    ])
+                },
+                onError: { [weak self] message, code in
+                    self?.sendEvent("onError", [
+                        "message": message,
+                        "code": code ?? "",
+                    ])
+                },
+                onState: { [weak self] state, source in
+                    self?.sendEvent("onStateChange", [
+                        "state": state,
+                        "source": source,
+                    ])
+                }
+            )
+        }
+
+        OnDestroy {
+            self.manager?.shutdown()
+        }
+
+        Function("isAvailable") { () -> Bool in
+            return RPScreenRecorder.shared().isAvailable
+        }
+
+        AsyncFunction("startInAppCapture") { (promise: Promise) in
+            self.manager?.startInAppCapture { error in
+                if let error = error {
+                    promise.reject("SCREEN_CAPTURE_ERROR", error.localizedDescription)
+                } else {
+                    promise.resolve(nil)
+                }
+            }
+        }
+
+        AsyncFunction("stopInAppCapture") { (promise: Promise) in
+            self.manager?.stopInAppCapture { error in
+                if let error = error {
+                    promise.reject("SCREEN_CAPTURE_ERROR", error.localizedDescription)
+                } else {
+                    promise.resolve(nil)
+                }
+            }
+        }
+
+        Function("presentBroadcastPicker") {
+            DispatchQueue.main.async {
+                self.manager?.presentBroadcastPicker()
+            }
+        }
+
+        Function("startBroadcastBridge") {
+            self.manager?.startBroadcastBridge()
+        }
+
+        Function("stopBroadcastBridge") {
+            self.manager?.stopBroadcastBridge()
+        }
+
+        Function("isBroadcasting") { () -> Bool in
+            return self.manager?.isBroadcasting() ?? false
+        }
+    }
+}

--- a/mobile/modules/expo-screen-capture/ios/ScreenCaptureManager.swift
+++ b/mobile/modules/expo-screen-capture/ios/ScreenCaptureManager.swift
@@ -1,0 +1,279 @@
+import Foundation
+import ReplayKit
+import UIKit
+import CoreImage
+import CoreVideo
+
+// Matches desktop's /desktop/src/renderer/src/lib/screen-capture.ts
+private let MAX_DIMENSION: CGFloat = 768
+private let CAPTURE_INTERVAL_MS: TimeInterval = 1.0  // 1 FPS
+private let JPEG_QUALITY: CGFloat = 0.7
+
+// Shared App Group + file paths used by the broadcast extension to drop frames
+// into a container the main app can read. Keep in sync with the extension's
+// SampleHandler.swift.
+private let APP_GROUP_ID = "group.com.yagudaev.voiceclaw.broadcast"
+private let FRAME_FILENAME = "latest-frame.jpg"
+private let HEARTBEAT_FILENAME = "heartbeat.txt"
+private let FRAME_COUNTER_FILENAME = "frame-id.txt"
+private let DARWIN_FRAME_NOTIFICATION = "com.yagudaev.voiceclaw.broadcast.frame" as CFString
+
+// Heartbeat older than this means the extension isn't running anymore.
+private let HEARTBEAT_STALE_SECONDS: TimeInterval = 3.0
+
+final class ScreenCaptureManager {
+    private let onFrame: (String, Int, Int) -> Void
+    private let onError: (String, String?) -> Void
+    private let onState: (String, String) -> Void
+
+    private let ciContext = CIContext(options: [.useSoftwareRenderer: false])
+    private let encodeQueue = DispatchQueue(label: "expo.screencapture.encode", qos: .userInitiated)
+
+    private var inAppCaptureActive = false
+    private var lastInAppFrameAt: TimeInterval = 0
+
+    private var bridgeActive = false
+    private var lastBroadcastFrameId: Int = -1
+
+    init(
+        onFrame: @escaping (String, Int, Int) -> Void,
+        onError: @escaping (String, String?) -> Void,
+        onState: @escaping (String, String) -> Void
+    ) {
+        self.onFrame = onFrame
+        self.onError = onError
+        self.onState = onState
+    }
+
+    func shutdown() {
+        if inAppCaptureActive {
+            RPScreenRecorder.shared().stopCapture { _ in }
+            inAppCaptureActive = false
+        }
+        stopBroadcastBridge()
+    }
+
+    // MARK: - In-app capture (RPScreenRecorder)
+
+    func startInAppCapture(completion: @escaping (Error?) -> Void) {
+        let recorder = RPScreenRecorder.shared()
+        guard recorder.isAvailable else {
+            let err = NSError(domain: "ExpoScreenCapture", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Screen recording is not available on this device",
+            ])
+            onError(err.localizedDescription, "NOT_AVAILABLE")
+            completion(err)
+            return
+        }
+        if recorder.isRecording || inAppCaptureActive {
+            completion(nil)
+            return
+        }
+
+        recorder.isMicrophoneEnabled = false
+        recorder.isCameraEnabled = false
+        onState("starting", "in-app")
+
+        recorder.startCapture(handler: { [weak self] sampleBuffer, bufferType, error in
+            guard let self = self else { return }
+            if let error = error {
+                self.onError(error.localizedDescription, "CAPTURE_HANDLER_ERROR")
+                return
+            }
+            guard bufferType == .video else { return }
+
+            let now = Date().timeIntervalSince1970
+            if now - self.lastInAppFrameAt < CAPTURE_INTERVAL_MS { return }
+            self.lastInAppFrameAt = now
+
+            // Retain the buffer across the async hop to the encode queue.
+            let retained = sampleBuffer as CMSampleBuffer
+            self.encodeQueue.async {
+                self.encodeSampleBuffer(retained)
+            }
+        }, completionHandler: { [weak self] error in
+            guard let self = self else { return }
+            if let error = error {
+                self.onError(error.localizedDescription, "START_CAPTURE_FAILED")
+                self.onState("idle", "none")
+                completion(error)
+            } else {
+                self.inAppCaptureActive = true
+                self.onState("active", "in-app")
+                completion(nil)
+            }
+        })
+    }
+
+    func stopInAppCapture(completion: @escaping (Error?) -> Void) {
+        let recorder = RPScreenRecorder.shared()
+        guard inAppCaptureActive || recorder.isRecording else {
+            completion(nil)
+            return
+        }
+        onState("stopping", "in-app")
+        recorder.stopCapture { [weak self] error in
+            guard let self = self else { return }
+            self.inAppCaptureActive = false
+            self.onState("idle", "none")
+            if let error = error {
+                self.onError(error.localizedDescription, "STOP_CAPTURE_FAILED")
+                completion(error)
+            } else {
+                completion(nil)
+            }
+        }
+    }
+
+    // MARK: - Broadcast picker (system UI)
+
+    func presentBroadcastPicker() {
+        // RPSystemBroadcastPickerView renders a button that, when tapped, shows
+        // the system broadcast picker. We programmatically trigger the tap so the
+        // app can expose the picker via a plain JS-initiated call.
+        let picker = RPSystemBroadcastPickerView(frame: CGRect(x: 0, y: 0, width: 60, height: 60))
+        picker.showsMicrophoneButton = false
+        // Filter to our extension bundle id. Set via APP_VARIANT-derived suffix.
+        let extBundleId = broadcastExtensionBundleId()
+        if !extBundleId.isEmpty {
+            picker.preferredExtension = extBundleId
+        }
+
+        // Attach to a host window so the picker can present.
+        guard let window = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .flatMap({ $0.windows })
+            .first(where: { $0.isKeyWindow }) else {
+            onError("No key window to present broadcast picker", "NO_WINDOW")
+            return
+        }
+        picker.isHidden = true
+        window.addSubview(picker)
+
+        // Find the inner UIButton and invoke it.
+        if let button = picker.subviews.compactMap({ $0 as? UIButton }).first {
+            button.sendActions(for: .touchUpInside)
+        } else {
+            // Fallback: UIKit sometimes wraps the button deeper.
+            for sub in picker.subviews {
+                for inner in sub.subviews {
+                    if let btn = inner as? UIButton {
+                        btn.sendActions(for: .touchUpInside)
+                        break
+                    }
+                }
+            }
+        }
+
+        // Remove after the system UI has had a chance to appear.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            picker.removeFromSuperview()
+        }
+    }
+
+    // MARK: - Broadcast bridge (reads frames written by the broadcast extension)
+
+    func startBroadcastBridge() {
+        if bridgeActive { return }
+        bridgeActive = true
+        lastBroadcastFrameId = readCurrentFrameId()
+        onState("active", "broadcast")
+
+        // Subscribe to Darwin notifications posted by the extension.
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        let observer = UnsafeRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        CFNotificationCenterAddObserver(
+            center,
+            observer,
+            { (_, observer, _, _, _) in
+                guard let observer = observer else { return }
+                let me = Unmanaged<ScreenCaptureManager>.fromOpaque(observer).takeUnretainedValue()
+                me.handleBroadcastFrameNotification()
+            },
+            DARWIN_FRAME_NOTIFICATION,
+            nil,
+            .deliverImmediately
+        )
+    }
+
+    func stopBroadcastBridge() {
+        if !bridgeActive { return }
+        bridgeActive = false
+
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        let observer = UnsafeRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        CFNotificationCenterRemoveEveryObserver(center, observer)
+
+        onState("idle", "none")
+    }
+
+    func isBroadcasting() -> Bool {
+        guard let url = sharedContainerURL() else { return false }
+        let heartbeat = url.appendingPathComponent(HEARTBEAT_FILENAME)
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: heartbeat.path),
+              let modified = attrs[.modificationDate] as? Date else { return false }
+        return Date().timeIntervalSince(modified) < HEARTBEAT_STALE_SECONDS
+    }
+
+    // MARK: - Helpers
+
+    private func handleBroadcastFrameNotification() {
+        encodeQueue.async { [weak self] in
+            guard let self = self, self.bridgeActive else { return }
+            let currentId = self.readCurrentFrameId()
+            if currentId == self.lastBroadcastFrameId { return }
+            self.lastBroadcastFrameId = currentId
+
+            guard let url = self.sharedContainerURL() else { return }
+            let frameURL = url.appendingPathComponent(FRAME_FILENAME)
+            guard let data = try? Data(contentsOf: frameURL) else { return }
+            guard let image = UIImage(data: data) else { return }
+
+            let base64 = data.base64EncodedString()
+            let width = Int(image.size.width)
+            let height = Int(image.size.height)
+            DispatchQueue.main.async {
+                self.onFrame(base64, width, height)
+            }
+        }
+    }
+
+    private func readCurrentFrameId() -> Int {
+        guard let url = sharedContainerURL() else { return -1 }
+        let idURL = url.appendingPathComponent(FRAME_COUNTER_FILENAME)
+        guard let str = try? String(contentsOf: idURL, encoding: .utf8) else { return -1 }
+        return Int(str.trimmingCharacters(in: .whitespacesAndNewlines)) ?? -1
+    }
+
+    private func sharedContainerURL() -> URL? {
+        return FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: APP_GROUP_ID)
+    }
+
+    private func broadcastExtensionBundleId() -> String {
+        guard let mainBundleId = Bundle.main.bundleIdentifier else { return "" }
+        return "\(mainBundleId).BroadcastUpload"
+    }
+
+    private func encodeSampleBuffer(_ sampleBuffer: CMSampleBuffer) {
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+
+        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        let sourceExtent = ciImage.extent
+        guard sourceExtent.width > 0, sourceExtent.height > 0 else { return }
+
+        let scale = min(MAX_DIMENSION / sourceExtent.width, MAX_DIMENSION / sourceExtent.height, 1.0)
+        let scaledImage = ciImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+        let targetExtent = scaledImage.extent
+        guard let cgImage = ciContext.createCGImage(scaledImage, from: targetExtent) else { return }
+
+        let uiImage = UIImage(cgImage: cgImage, scale: 1.0, orientation: .up)
+        guard let jpegData = uiImage.jpegData(compressionQuality: JPEG_QUALITY) else { return }
+
+        let base64 = jpegData.base64EncodedString()
+        let width = Int(targetExtent.width)
+        let height = Int(targetExtent.height)
+        DispatchQueue.main.async { [weak self] in
+            self?.onFrame(base64, width, height)
+        }
+    }
+}

--- a/mobile/modules/expo-screen-capture/src/ExpoScreenCapture.types.ts
+++ b/mobile/modules/expo-screen-capture/src/ExpoScreenCapture.types.ts
@@ -1,0 +1,21 @@
+export type ScreenFrameEvent = {
+  data: string // base64 JPEG (no data: prefix)
+  width: number
+  height: number
+}
+
+export type ScreenCaptureErrorEvent = {
+  message: string
+  code?: string
+}
+
+export type ScreenCaptureStateEvent = {
+  state: 'idle' | 'starting' | 'active' | 'stopping'
+  source: 'in-app' | 'broadcast' | 'none'
+}
+
+export type ExpoScreenCaptureModuleEvents = {
+  onFrame: (event: ScreenFrameEvent) => void
+  onError: (event: ScreenCaptureErrorEvent) => void
+  onStateChange: (event: ScreenCaptureStateEvent) => void
+}

--- a/mobile/modules/expo-screen-capture/src/ExpoScreenCaptureModule.ts
+++ b/mobile/modules/expo-screen-capture/src/ExpoScreenCaptureModule.ts
@@ -1,0 +1,28 @@
+import { NativeModule, requireNativeModule } from 'expo'
+
+import { ExpoScreenCaptureModuleEvents } from './ExpoScreenCapture.types'
+
+declare class ExpoScreenCaptureModule extends NativeModule<ExpoScreenCaptureModuleEvents> {
+  /** true if ReplayKit is available on this device */
+  isAvailable(): boolean
+
+  /** Start in-app screen capture via RPScreenRecorder. Emits onFrame at ~1 FPS as base64 JPEG. */
+  startInAppCapture(): Promise<void>
+
+  /** Stop in-app screen capture. */
+  stopInAppCapture(): Promise<void>
+
+  /** Present the system broadcast picker (RPSystemBroadcastPickerView) so the user can start the broadcast extension. */
+  presentBroadcastPicker(): void
+
+  /** Start the polling bridge that reads frames written to the shared App Group by the broadcast extension. */
+  startBroadcastBridge(): void
+
+  /** Stop the broadcast bridge. */
+  stopBroadcastBridge(): void
+
+  /** Returns true when the broadcast extension is currently running (based on heartbeat in shared container). */
+  isBroadcasting(): boolean
+}
+
+export default requireNativeModule<ExpoScreenCaptureModule>('ExpoScreenCapture')

--- a/mobile/plugins/with-broadcast-extension.js
+++ b/mobile/plugins/with-broadcast-extension.js
@@ -1,0 +1,574 @@
+/**
+ * Expo config plugin that integrates a ReplayKit Broadcast Upload Extension
+ * target into the iOS project during prebuild. The extension captures the
+ * full device screen (including when the host app is backgrounded) and
+ * writes JPEG frames into a shared App Group container, which the main app
+ * reads and forwards to the realtime relay as frame.append events.
+ *
+ * What this plugin does:
+ *   1. Adds `com.apple.security.application-groups` entitlement to the main
+ *      app so it can read the shared container.
+ *   2. Copies the extension source files from mobile/broadcast-extension/
+ *      into ios/BroadcastUpload/ during prebuild, substituting the app
+ *      bundle id into the entitlements file.
+ *   3. Patches the Xcode project to register a new PBXNativeTarget of type
+ *      `com.apple.product-type.app-extension`, wires up Sources / Frameworks
+ *      / Resources build phases, links ReplayKit.framework, configures
+ *      Debug+Release XCBuildConfigurations with the correct bundle id /
+ *      entitlements / deployment target, creates an "Embed App Extensions"
+ *      copy-files phase on the main target, and makes the main target
+ *      depend on the extension target.
+ *
+ * Companion runtime pieces:
+ *   - SampleHandler.swift (in mobile/broadcast-extension/) — the extension
+ *     processor. Writes frames to the App Group; posts a Darwin notification.
+ *   - ScreenCaptureManager.swift — subscribes to the Darwin notification,
+ *     reads frames from the App Group, emits them as onFrame events to JS.
+ */
+const { withDangerousMod, withEntitlementsPlist } = require('expo/config-plugins')
+const xcode = require('xcode')
+const path = require('path')
+const fs = require('fs')
+
+const EXTENSION_NAME = 'BroadcastUpload'
+const APP_GROUP_ID = 'group.com.yagudaev.voiceclaw.broadcast'
+const DEPLOYMENT_TARGET = '16.0'
+
+// Fixed UUIDs (24-char hex) so the plugin is idempotent across prebuild runs.
+const UUIDS = {
+  GROUP: '7CA1000000000000000000A1',
+  SAMPLE_HANDLER_FILE_REF: '7CA1000000000000000000A2',
+  INFO_PLIST_FILE_REF: '7CA1000000000000000000A3',
+  ENTITLEMENTS_FILE_REF: '7CA1000000000000000000A4',
+  APPEX_FILE_REF: '7CA1000000000000000000A5',
+  SAMPLE_HANDLER_BUILD_FILE: '7CA1000000000000000000A6',
+  REPLAYKIT_FILE_REF: '7CA1000000000000000000A7',
+  REPLAYKIT_BUILD_FILE: '7CA1000000000000000000A8',
+  TARGET: '7CA1000000000000000000A9',
+  SOURCES_PHASE: '7CA1000000000000000000B0',
+  FRAMEWORKS_PHASE: '7CA1000000000000000000B1',
+  RESOURCES_PHASE: '7CA1000000000000000000B2',
+  CONFIG_LIST: '7CA1000000000000000000B3',
+  CONFIG_DEBUG: '7CA1000000000000000000B4',
+  CONFIG_RELEASE: '7CA1000000000000000000B5',
+  EMBED_PHASE: '7CA1000000000000000000B6',
+  EMBED_BUILD_FILE: '7CA1000000000000000000B7',
+  TARGET_DEPENDENCY: '7CA1000000000000000000B8',
+  CONTAINER_ITEM_PROXY: '7CA1000000000000000000B9',
+}
+
+function withBroadcastExtension(config) {
+  config = withMainAppEntitlements(config)
+  config = withExtensionFiles(config)
+  config = withExtensionTarget(config)
+  return config
+}
+
+// Step 1: Add App Group entitlement to the main app.
+function withMainAppEntitlements(config) {
+  return withEntitlementsPlist(config, (config) => {
+    const existing = config.modResults['com.apple.security.application-groups'] || []
+    const groups = Array.isArray(existing) ? existing : [existing]
+    if (!groups.includes(APP_GROUP_ID)) {
+      groups.push(APP_GROUP_ID)
+    }
+    config.modResults['com.apple.security.application-groups'] = groups
+    return config
+  })
+}
+
+// Step 2: Copy extension source files into ios/BroadcastUpload/.
+function withExtensionFiles(config) {
+  return withDangerousMod(config, [
+    'ios',
+    async (config) => {
+      const projectRoot = config.modRequest.projectRoot
+      const iosRoot = config.modRequest.platformProjectRoot
+      const srcDir = path.join(projectRoot, 'broadcast-extension')
+      const dstDir = path.join(iosRoot, EXTENSION_NAME)
+
+      if (!fs.existsSync(srcDir)) {
+        console.warn(`[with-broadcast-extension] source dir not found: ${srcDir}`)
+        return config
+      }
+
+      fs.mkdirSync(dstDir, { recursive: true })
+      for (const name of fs.readdirSync(srcDir)) {
+        const srcPath = path.join(srcDir, name)
+        const dstPath = path.join(dstDir, name)
+        fs.copyFileSync(srcPath, dstPath)
+      }
+      console.log(`[with-broadcast-extension] Copied extension files to ${dstDir}`)
+      return config
+    },
+  ])
+}
+
+// Step 3: Patch project.pbxproj to add the extension target.
+function withExtensionTarget(config) {
+  return withDangerousMod(config, [
+    'ios',
+    async (config) => {
+      const iosRoot = config.modRequest.platformProjectRoot
+      const mainBundleId = config.ios?.bundleIdentifier
+      if (!mainBundleId) {
+        console.warn('[with-broadcast-extension] ios.bundleIdentifier missing; skipping')
+        return config
+      }
+      const extensionBundleId = `${mainBundleId}.${EXTENSION_NAME}`
+
+      const pbxprojPath = findPbxprojPath(iosRoot)
+      if (!pbxprojPath) {
+        console.warn('[with-broadcast-extension] project.pbxproj not found; skipping')
+        return config
+      }
+
+      const project = xcode.project(pbxprojPath)
+      project.parseSync()
+
+      if (hasTargetAlready(project)) {
+        console.log('[with-broadcast-extension] Extension target already present; skipping')
+        return config
+      }
+
+      patchPbxproj(project, extensionBundleId)
+
+      fs.writeFileSync(pbxprojPath, project.writeSync())
+      console.log('[with-broadcast-extension] Wrote updated project.pbxproj')
+      return config
+    },
+  ])
+}
+
+// --- Helpers ---
+
+function findPbxprojPath(iosRoot) {
+  const entries = fs.readdirSync(iosRoot)
+  const projectDir = entries.find((e) => e.endsWith('.xcodeproj'))
+  if (!projectDir) return null
+  const pbx = path.join(iosRoot, projectDir, 'project.pbxproj')
+  return fs.existsSync(pbx) ? pbx : null
+}
+
+function hasTargetAlready(project) {
+  const targets = section(project, 'PBXNativeTarget')
+  for (const key of Object.keys(targets)) {
+    const t = targets[key]
+    if (typeof t === 'object' && t.name === EXTENSION_NAME) return true
+  }
+  return false
+}
+
+function patchPbxproj(project, extensionBundleId) {
+  // File references for the files living at ios/BroadcastUpload/
+  ensureFileRef(project, UUIDS.SAMPLE_HANDLER_FILE_REF, 'SampleHandler.swift', 'sourcecode.swift')
+  ensureFileRef(project, UUIDS.INFO_PLIST_FILE_REF, 'Info.plist', 'text.plist.xml')
+  ensureFileRef(project, UUIDS.ENTITLEMENTS_FILE_REF, 'BroadcastUpload.entitlements', 'text.plist.entitlements')
+  ensureProductFileRef(project, UUIDS.APPEX_FILE_REF, `${EXTENSION_NAME}.appex`, 'wrapper.app-extension')
+  ensureSystemFrameworkRef(project, UUIDS.REPLAYKIT_FILE_REF, 'ReplayKit.framework')
+
+  // Build files
+  ensureBuildFile(project, UUIDS.SAMPLE_HANDLER_BUILD_FILE, UUIDS.SAMPLE_HANDLER_FILE_REF, 'SampleHandler.swift in Sources')
+  ensureBuildFile(project, UUIDS.REPLAYKIT_BUILD_FILE, UUIDS.REPLAYKIT_FILE_REF, 'ReplayKit.framework in Frameworks')
+  ensureEmbedBuildFile(project, UUIDS.EMBED_BUILD_FILE, UUIDS.APPEX_FILE_REF, `${EXTENSION_NAME}.appex in Embed App Extensions`)
+
+  // Group for the extension's source files
+  ensureGroup(project, UUIDS.GROUP, EXTENSION_NAME, [
+    { value: UUIDS.SAMPLE_HANDLER_FILE_REF, comment: 'SampleHandler.swift' },
+    { value: UUIDS.INFO_PLIST_FILE_REF, comment: 'Info.plist' },
+    { value: UUIDS.ENTITLEMENTS_FILE_REF, comment: 'BroadcastUpload.entitlements' },
+  ])
+  addGroupToMainGroup(project, UUIDS.GROUP, EXTENSION_NAME)
+
+  // Ensure the Products group includes the .appex
+  addToProductsGroup(project, UUIDS.APPEX_FILE_REF, `${EXTENSION_NAME}.appex`)
+
+  // Build phases
+  ensureSourcesPhase(project, UUIDS.SOURCES_PHASE, [
+    { value: UUIDS.SAMPLE_HANDLER_BUILD_FILE, comment: 'SampleHandler.swift in Sources' },
+  ])
+  ensureFrameworksPhase(project, UUIDS.FRAMEWORKS_PHASE, [
+    { value: UUIDS.REPLAYKIT_BUILD_FILE, comment: 'ReplayKit.framework in Frameworks' },
+  ])
+  ensureResourcesPhase(project, UUIDS.RESOURCES_PHASE)
+
+  // XC build configurations (Debug + Release) for the extension target
+  ensureBuildConfig(project, UUIDS.CONFIG_DEBUG, 'Debug', extensionBundleId)
+  ensureBuildConfig(project, UUIDS.CONFIG_RELEASE, 'Release', extensionBundleId)
+  ensureConfigList(project, UUIDS.CONFIG_LIST, [UUIDS.CONFIG_DEBUG, UUIDS.CONFIG_RELEASE])
+
+  // The native target itself
+  ensureNativeTarget(project, {
+    uuid: UUIDS.TARGET,
+    name: EXTENSION_NAME,
+    productName: EXTENSION_NAME,
+    productRef: UUIDS.APPEX_FILE_REF,
+    productType: '"com.apple.product-type.app-extension"',
+    configListRef: UUIDS.CONFIG_LIST,
+    buildPhases: [
+      { value: UUIDS.SOURCES_PHASE, comment: 'Sources' },
+      { value: UUIDS.FRAMEWORKS_PHASE, comment: 'Frameworks' },
+      { value: UUIDS.RESOURCES_PHASE, comment: 'Resources' },
+    ],
+  })
+
+  // Register the target on the PBXProject and Root
+  registerTargetOnProject(project, UUIDS.TARGET, EXTENSION_NAME, UUIDS.CONFIG_LIST)
+
+  // Main app target wiring: embed the extension + depend on it
+  const mainTargetUuid = findMainTargetUuid(project)
+  if (!mainTargetUuid) {
+    console.warn('[with-broadcast-extension] Could not find main VoiceClaw target')
+    return
+  }
+  ensureContainerItemProxy(project, UUIDS.CONTAINER_ITEM_PROXY, UUIDS.TARGET, EXTENSION_NAME)
+  ensureTargetDependency(project, UUIDS.TARGET_DEPENDENCY, UUIDS.TARGET, UUIDS.CONTAINER_ITEM_PROXY, EXTENSION_NAME)
+  attachDependencyToTarget(project, mainTargetUuid, UUIDS.TARGET_DEPENDENCY, EXTENSION_NAME)
+
+  ensureEmbedExtensionsPhase(project, mainTargetUuid, UUIDS.EMBED_PHASE, [
+    { value: UUIDS.EMBED_BUILD_FILE, comment: `${EXTENSION_NAME}.appex in Embed App Extensions` },
+  ])
+
+  console.log('[with-broadcast-extension] Patched project.pbxproj with BroadcastUpload target')
+}
+
+// --- Low-level pbxproj mutation helpers ---
+
+function section(project, name) {
+  const objs = project.hash.project.objects
+  if (!objs[name]) objs[name] = {}
+  return objs[name]
+}
+
+function ensureFileRef(project, uuid, name, lastKnownFileType) {
+  const refs = section(project, 'PBXFileReference')
+  if (refs[uuid]) return
+  refs[uuid] = {
+    isa: 'PBXFileReference',
+    lastKnownFileType,
+    path: name,
+    sourceTree: '"<group>"',
+    name,
+  }
+  refs[uuid + '_comment'] = name
+}
+
+function ensureProductFileRef(project, uuid, name, explicitFileType) {
+  const refs = section(project, 'PBXFileReference')
+  if (refs[uuid]) return
+  refs[uuid] = {
+    isa: 'PBXFileReference',
+    explicitFileType,
+    includeInIndex: 0,
+    path: name,
+    sourceTree: 'BUILT_PRODUCTS_DIR',
+  }
+  refs[uuid + '_comment'] = name
+}
+
+function ensureSystemFrameworkRef(project, uuid, name) {
+  const refs = section(project, 'PBXFileReference')
+  if (refs[uuid]) return
+  refs[uuid] = {
+    isa: 'PBXFileReference',
+    lastKnownFileType: 'wrapper.framework',
+    name,
+    path: `System/Library/Frameworks/${name}`,
+    sourceTree: 'SDKROOT',
+  }
+  refs[uuid + '_comment'] = name
+}
+
+function ensureBuildFile(project, uuid, fileRef, comment) {
+  const files = section(project, 'PBXBuildFile')
+  if (files[uuid]) return
+  files[uuid] = {
+    isa: 'PBXBuildFile',
+    fileRef,
+    fileRef_comment: comment.split(' in ')[0],
+  }
+  files[uuid + '_comment'] = comment
+}
+
+function ensureEmbedBuildFile(project, uuid, fileRef, comment) {
+  const files = section(project, 'PBXBuildFile')
+  if (files[uuid]) return
+  files[uuid] = {
+    isa: 'PBXBuildFile',
+    fileRef,
+    fileRef_comment: comment.split(' in ')[0],
+    settings: { ATTRIBUTES: ['RemoveHeadersOnCopy'] },
+  }
+  files[uuid + '_comment'] = comment
+}
+
+function ensureGroup(project, uuid, name, children) {
+  const groups = section(project, 'PBXGroup')
+  if (groups[uuid]) return
+  groups[uuid] = {
+    isa: 'PBXGroup',
+    children,
+    path: name,
+    sourceTree: '"<group>"',
+  }
+  groups[uuid + '_comment'] = name
+}
+
+function addGroupToMainGroup(project, groupUuid, comment) {
+  const mainGroup = findMainGroup(project)
+  if (!mainGroup) return
+  mainGroup.children = mainGroup.children || []
+  const already = mainGroup.children.some((c) => (c.value || c) === groupUuid)
+  if (!already) {
+    mainGroup.children.push({ value: groupUuid, comment })
+  }
+}
+
+function addToProductsGroup(project, fileRefUuid, comment) {
+  const groups = section(project, 'PBXGroup')
+  for (const key of Object.keys(groups)) {
+    const g = groups[key]
+    if (typeof g !== 'object') continue
+    if (g.name === 'Products' || g.path === 'Products') {
+      g.children = g.children || []
+      const already = g.children.some((c) => (c.value || c) === fileRefUuid)
+      if (!already) {
+        g.children.push({ value: fileRefUuid, comment })
+      }
+      return
+    }
+  }
+}
+
+function ensureSourcesPhase(project, uuid, files) {
+  const phases = section(project, 'PBXSourcesBuildPhase')
+  if (phases[uuid]) return
+  phases[uuid] = {
+    isa: 'PBXSourcesBuildPhase',
+    buildActionMask: 2147483647,
+    files,
+    runOnlyForDeploymentPostprocessing: 0,
+  }
+  phases[uuid + '_comment'] = 'Sources'
+}
+
+function ensureFrameworksPhase(project, uuid, files) {
+  const phases = section(project, 'PBXFrameworksBuildPhase')
+  if (phases[uuid]) return
+  phases[uuid] = {
+    isa: 'PBXFrameworksBuildPhase',
+    buildActionMask: 2147483647,
+    files,
+    runOnlyForDeploymentPostprocessing: 0,
+  }
+  phases[uuid + '_comment'] = 'Frameworks'
+}
+
+function ensureResourcesPhase(project, uuid) {
+  const phases = section(project, 'PBXResourcesBuildPhase')
+  if (phases[uuid]) return
+  phases[uuid] = {
+    isa: 'PBXResourcesBuildPhase',
+    buildActionMask: 2147483647,
+    files: [],
+    runOnlyForDeploymentPostprocessing: 0,
+  }
+  phases[uuid + '_comment'] = 'Resources'
+}
+
+function ensureBuildConfig(project, uuid, name, bundleId) {
+  const configs = section(project, 'XCBuildConfiguration')
+  if (configs[uuid]) return
+  const isDebug = name === 'Debug'
+  configs[uuid] = {
+    isa: 'XCBuildConfiguration',
+    buildSettings: {
+      CODE_SIGN_ENTITLEMENTS: `${EXTENSION_NAME}/BroadcastUpload.entitlements`,
+      CODE_SIGN_STYLE: 'Automatic',
+      CURRENT_PROJECT_VERSION: 1,
+      DEBUG_INFORMATION_FORMAT: isDebug ? 'dwarf' : '"dwarf-with-dsym"',
+      GCC_C_LANGUAGE_STANDARD: 'gnu11',
+      GENERATE_INFOPLIST_FILE: 'NO',
+      INFOPLIST_FILE: `${EXTENSION_NAME}/Info.plist`,
+      IPHONEOS_DEPLOYMENT_TARGET: DEPLOYMENT_TARGET,
+      LD_RUNPATH_SEARCH_PATHS: '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"',
+      MARKETING_VERSION: '1.0',
+      MTL_ENABLE_DEBUG_INFO: isDebug ? 'INCLUDE_SOURCE' : 'NO',
+      PRODUCT_BUNDLE_IDENTIFIER: bundleId,
+      PRODUCT_NAME: `"$(TARGET_NAME)"`,
+      SKIP_INSTALL: 'YES',
+      SWIFT_EMIT_LOC_STRINGS: 'YES',
+      SWIFT_OPTIMIZATION_LEVEL: isDebug ? '"-Onone"' : '"-O"',
+      SWIFT_VERSION: '5.0',
+      TARGETED_DEVICE_FAMILY: '"1,2"',
+    },
+    name,
+  }
+  configs[uuid + '_comment'] = name
+}
+
+function ensureConfigList(project, uuid, configRefs) {
+  const lists = section(project, 'XCConfigurationList')
+  if (lists[uuid]) return
+  lists[uuid] = {
+    isa: 'XCConfigurationList',
+    buildConfigurations: configRefs.map((ref) => {
+      const configName = (section(project, 'XCBuildConfiguration')[ref] || {}).name
+      return { value: ref, comment: configName || '' }
+    }),
+    defaultConfigurationIsVisible: 0,
+    defaultConfigurationName: 'Release',
+  }
+  lists[uuid + '_comment'] = `Build configuration list for PBXNativeTarget "${EXTENSION_NAME}"`
+}
+
+function ensureNativeTarget(project, opts) {
+  const targets = section(project, 'PBXNativeTarget')
+  if (targets[opts.uuid]) return
+  targets[opts.uuid] = {
+    isa: 'PBXNativeTarget',
+    buildConfigurationList: opts.configListRef,
+    buildConfigurationList_comment: `Build configuration list for PBXNativeTarget "${opts.name}"`,
+    buildPhases: opts.buildPhases,
+    buildRules: [],
+    dependencies: [],
+    name: opts.name,
+    productName: opts.productName,
+    productReference: opts.productRef,
+    productReference_comment: `${opts.name}.appex`,
+    productType: opts.productType,
+  }
+  targets[opts.uuid + '_comment'] = opts.name
+}
+
+function registerTargetOnProject(project, targetUuid, name, configListRef) {
+  const projects = section(project, 'PBXProject')
+  for (const key of Object.keys(projects)) {
+    const p = projects[key]
+    if (typeof p !== 'object') continue
+    p.targets = p.targets || []
+    const already = p.targets.some((t) => (t.value || t) === targetUuid)
+    if (!already) {
+      p.targets.push({ value: targetUuid, comment: name })
+    }
+    // Add a TargetAttributes entry so Xcode recognizes the target.
+    if (p.attributes && p.attributes.TargetAttributes) {
+      if (!p.attributes.TargetAttributes[targetUuid]) {
+        p.attributes.TargetAttributes[targetUuid] = {
+          CreatedOnToolsVersion: '15.0',
+          ProvisioningStyle: 'Automatic',
+        }
+      }
+    }
+  }
+}
+
+function findMainTargetUuid(project) {
+  const targets = section(project, 'PBXNativeTarget')
+  for (const key of Object.keys(targets)) {
+    const t = targets[key]
+    if (typeof t === 'object' && t.name === 'VoiceClaw') return key
+  }
+  return null
+}
+
+function findMainGroup(project) {
+  const projects = section(project, 'PBXProject')
+  for (const key of Object.keys(projects)) {
+    const p = projects[key]
+    if (typeof p !== 'object') continue
+    const mainGroupUuid = p.mainGroup
+    if (!mainGroupUuid) continue
+    const mg = section(project, 'PBXGroup')[mainGroupUuid]
+    if (mg) return mg
+  }
+  return null
+}
+
+function ensureContainerItemProxy(project, uuid, targetUuid, comment) {
+  const proxies = section(project, 'PBXContainerItemProxy')
+  if (proxies[uuid]) return
+  const projects = section(project, 'PBXProject')
+  const projectRefUuid = Object.keys(projects).find((k) => typeof projects[k] === 'object')
+  proxies[uuid] = {
+    isa: 'PBXContainerItemProxy',
+    containerPortal: projectRefUuid,
+    containerPortal_comment: 'Project object',
+    proxyType: 1,
+    remoteGlobalIDString: targetUuid,
+    remoteInfo: comment,
+  }
+  proxies[uuid + '_comment'] = 'PBXContainerItemProxy'
+}
+
+function ensureTargetDependency(project, uuid, targetUuid, proxyUuid, comment) {
+  const deps = section(project, 'PBXTargetDependency')
+  if (deps[uuid]) return
+  deps[uuid] = {
+    isa: 'PBXTargetDependency',
+    target: targetUuid,
+    target_comment: comment,
+    targetProxy: proxyUuid,
+    targetProxy_comment: 'PBXContainerItemProxy',
+  }
+  deps[uuid + '_comment'] = 'PBXTargetDependency'
+}
+
+function attachDependencyToTarget(project, mainTargetUuid, depUuid, comment) {
+  const target = section(project, 'PBXNativeTarget')[mainTargetUuid]
+  if (!target) return
+  target.dependencies = target.dependencies || []
+  const already = target.dependencies.some((d) => (d.value || d) === depUuid)
+  if (!already) {
+    target.dependencies.push({ value: depUuid, comment })
+  }
+}
+
+function ensureEmbedExtensionsPhase(project, mainTargetUuid, phaseUuid, files) {
+  const phases = section(project, 'PBXCopyFilesBuildPhase')
+  const target = section(project, 'PBXNativeTarget')[mainTargetUuid]
+  if (!target) return
+
+  // Reuse an existing "Embed App Extensions" phase if the project already has one
+  let existingPhaseUuid = null
+  for (const buildPhaseRef of target.buildPhases || []) {
+    const uuid = buildPhaseRef.value || buildPhaseRef
+    const phase = phases[uuid]
+    if (!phase) continue
+    if (phase.name && phase.name.replace(/"/g, '') === 'Embed App Extensions') {
+      existingPhaseUuid = uuid
+      break
+    }
+    if (phase.dstSubfolderSpec === 13 && !phase.name) {
+      existingPhaseUuid = uuid
+      break
+    }
+  }
+
+  if (existingPhaseUuid) {
+    const phase = phases[existingPhaseUuid]
+    phase.files = phase.files || []
+    for (const f of files) {
+      const already = phase.files.some((x) => (x.value || x) === f.value)
+      if (!already) phase.files.push(f)
+    }
+    return
+  }
+
+  if (phases[phaseUuid]) return
+  phases[phaseUuid] = {
+    isa: 'PBXCopyFilesBuildPhase',
+    buildActionMask: 2147483647,
+    dstPath: '""',
+    dstSubfolderSpec: 13, // PlugIns / App Extensions
+    files,
+    name: '"Embed App Extensions"',
+    runOnlyForDeploymentPostprocessing: 0,
+  }
+  phases[phaseUuid + '_comment'] = 'Embed App Extensions'
+
+  target.buildPhases = target.buildPhases || []
+  target.buildPhases.push({ value: phaseUuid, comment: 'Embed App Extensions' })
+}
+
+module.exports = withBroadcastExtension


### PR DESCRIPTION
## Summary
- New `expo-screen-capture` native module (iOS) using RPScreenRecorder for in-app capture and a ReplayKit Broadcast Upload Extension (`BroadcastUpload.appex`) for background capture, communicating with the host app through an App Group container + Darwin notifications.
- Added `sendFrame(base64Jpeg)` to `useRealtime`, forwarding JPEGs to the existing relay `frame.append` path (no relay/server changes needed).
- Call UI: new Screen-Share toggle button in realtime calls, gated on Gemini models only. Tap = in-app capture; long-press = presents the system broadcast picker for background capture.
- Frames throttled to 1 FPS, scaled to 768px max, JPEG quality 0.7 (matches the desktop reference implementation).
- New config plugin `with-broadcast-extension` programmatically registers the extension target in the Xcode project and adds the `group.com.yagudaev.voiceclaw.broadcast` App Group to the main app's entitlements.

## Files of note
- `mobile/modules/expo-screen-capture/` — Swift native module + TS bindings
- `mobile/broadcast-extension/SampleHandler.swift` — ReplayKit sample handler (1 FPS, JPEG → App Group file → Darwin notification)
- `mobile/plugins/with-broadcast-extension.js` — Expo config plugin; patches pbxproj with fixed UUIDs for idempotency
- `mobile/lib/use-realtime.ts` — new `sendFrame` method on the realtime controls
- `mobile/app/(tabs)/index.tsx` — UI toggle, event subscriptions, teardown on call-end

## Test plan
- [x] `BroadcastUpload` target compiles cleanly on iphonesimulator (verified via `xcodebuild -target BroadcastUpload`)
- [x] Prebuild runs the new config plugin without error; pbxproj additions are idempotent
- [ ] **Pending**: on-device test on iPhone 12 Pro — blocked by provisioning (the `group.com.yagudaev.voiceclaw.broadcast` App Group needs to be registered in Apple Developer portal and added to the dev provisioning profile before the main app / extension can be signed for device). Full-app simulator build is blocked on a pre-existing `swift-numerics` modulemap path-resolution issue unrelated to this change.
- [ ] Manual: after provisioning is updated, verify tap toggles in-app capture (frames visible in relay logs) and long-press launches the system broadcast picker that keeps streaming when the app backgrounds.

## Follow-ups
- Register App Group in Apple Developer portal / regenerate provisioning profiles.
- Consider exposing a distinct UI affordance for background-share vs. in-app-share (currently tap/long-press) once UX is validated.
- No OpenAI path; screen-share button is hidden when the active model isn't a Gemini realtime model (per PRD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)