### PR TITLE
docs(mobile): CLAUDE.md with TestFlight + relay notes

### DIFF
--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -1,0 +1,96 @@
+# Mobile app notes
+
+## Variants
+
+Three build variants driven by `APP_VARIANT`:
+
+| Variant       | Bundle id                         | Display name       | Scheme             |
+| ------------- | --------------------------------- | ------------------ | ------------------ |
+| `development` | `com.yagudaev.voiceclaw.dev`      | VoiceClaw (Dev)    | `voiceclaw-dev`    |
+| `staging`     | `com.yagudaev.voiceclaw.staging`  | VoiceClaw (Stg)    | `voiceclaw-staging`|
+| `production`  | `com.yagudaev.voiceclaw`          | VoiceClaw          | `voiceclaw`        |
+
+`buildNumber` is set automatically from `git rev-list --count HEAD` in
+`app.config.ts` — each commit bumps the iOS build number, so you never
+need to edit it by hand. App Store Connect rejects duplicate build
+numbers, so always **commit first, then build**.
+
+## TestFlight releases
+
+Use the package scripts, not Xcode:
+
+```bash
+# Staging: build IPA locally via xcodebuild, then submit via EAS
+yarn ios:release:staging
+
+# Production (App Store / TestFlight prod)
+yarn ios:release:production
+```
+
+Under the hood (`scripts/build-ios.sh`):
+
+1. `expo prebuild --clean` with the right `APP_VARIANT`
+2. `xcodebuild archive` → `build/VoiceClaw.xcarchive`
+3. `xcodebuild -exportArchive` → `build/export/*.ipa`
+4. `eas submit --profile <variant> --platform ios --path build/export/*.ipa`
+
+Signing uses Automatic with `DEVELOPMENT_TEAM=HN6T5KD4ND`. App Store
+Connect auth uses the API key at `~/.appstore/AuthKey_SG645CPQP8.p8`
+(configured in `eas.json`).
+
+Apple emails the build-processed confirmation within a few minutes of
+submit; the build then shows up in TestFlight → iOS builds.
+
+### Things that have bitten us
+
+- **Privacy strings**: `NSMicrophoneUsageDescription` and
+  `NSSpeechRecognitionUsageDescription` must be in the Info.plist or
+  App Store Connect rejects the submission. They live in
+  `app.config.ts` under `ios.infoPlist` and are written by prebuild.
+- **Duplicate build number**: always commit before `yarn ios:release:*`
+  so `git rev-list --count HEAD` produces a fresh number.
+- **Never edit `ios/` directly**: `prebuild --clean` wipes it. Changes
+  go in `app.config.ts` or Expo config plugins under `plugins/`.
+
+## Dev builds on a real device
+
+```bash
+# First time or after native changes
+APP_VARIANT=development npx expo prebuild --clean
+
+# Install + launch on the paired iPhone (UDID in feedback_testing.md)
+APP_VARIANT=development npx expo run:ios --device "<UDID>"
+```
+
+`expo run:ios` skips prebuild when `ios/` already exists, so if you
+change `app.config.ts` (e.g. Info.plist keys), run the explicit
+`prebuild --clean` first or the change will not land in the binary.
+
+## Relay connectivity on iOS
+
+The Realtime mode connects to a self-hosted relay server, typically
+over Tailscale (`ws://100.x.x.x:8080/ws`). Three iOS-specific things
+matter:
+
+1. `NSAllowsArbitraryLoads: true` — needed for cleartext `ws://`.
+2. `NSLocalNetworkUsageDescription` — without this key, iOS silently
+   blocks any connection to private IP ranges (including Tailscale
+   CGNAT 100.64/10). The first connection prompts for Local Network
+   permission; the user must tap Allow.
+3. **iCloud Private Relay intercepts cleartext HTTP from apps** and
+   cannot reach Tailscale addresses, but it does not touch `ws://`.
+   So the in-app "Test connection" probe uses WebSocket (the real
+   transport) instead of HTTP GET `/health`. If you need HTTP to work
+   from the app over Tailscale, either disable iCloud Private Relay,
+   serve the relay over `https://`, or use a MagicDNS hostname.
+
+## Voice mode
+
+Mobile is realtime-only. The Vapi and Custom-pipeline settings UI has
+been removed; the underlying code paths in `index.tsx` still exist but
+are unreachable through the UI. If `voice_mode` in SQLite is `vapi` or
+`custom` (from a previous version), Settings migrates it to `realtime`
+on load.
+
+Default model: `gemini-3.1-flash-live-preview`. GPT Realtime entries
+are shown disabled ("Coming Soon") to mirror the desktop.

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -51,6 +51,17 @@ submit; the build then shows up in TestFlight → iOS builds.
   so `git rev-list --count HEAD` produces a fresh number.
 - **Never edit `ios/` directly**: `prebuild --clean` wipes it. Changes
   go in `app.config.ts` or Expo config plugins under `plugins/`.
+- **SPM module map missing on archive** (`swift-numerics`, `Cmlx`, or
+  any Swift package): shows up as
+  `error: module map file '...swift-numerics/.../module.modulemap' not found`
+  → `** ARCHIVE FAILED **`. Happens after switching between Debug (dev
+  run) and Release (archive) builds because Xcode reuses stale SPM
+  build intermediates. Fix: delete this project's DerivedData and
+  retry:
+  ```bash
+  rm -rf ~/Library/Developer/Xcode/DerivedData/VoiceClaw-*
+  yarn ios:release:staging
+  ```
 
 ## Dev builds on a real device
 

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -54,14 +54,37 @@ submit; the build then shows up in TestFlight → iOS builds.
 - **SPM module map missing on archive** (`swift-numerics`, `Cmlx`, or
   any Swift package): shows up as
   `error: module map file '...swift-numerics/.../module.modulemap' not found`
-  → `** ARCHIVE FAILED **`. Happens after switching between Debug (dev
-  run) and Release (archive) builds because Xcode reuses stale SPM
-  build intermediates. Fix: delete this project's DerivedData and
-  retry:
+  → `** ARCHIVE FAILED **`. Xcode's archive build resolves
+  `BuildProductsPath/../../SourcePackages/checkouts/...` to a path
+  that doesn't exist if SPM packages weren't pre-resolved into the
+  archive intermediates dir. `expo prebuild --clean` wipes `ios/`
+  including the resolved Package.resolved, and a cold archive then
+  fails. Fix: pre-resolve packages, then archive directly (skipping
+  prebuild on the retry):
   ```bash
   rm -rf ~/Library/Developer/Xcode/DerivedData/VoiceClaw-*
-  yarn ios:release:staging
+  cd mobile
+  # If coming from a dev run, pods are already installed. Otherwise:
+  # APP_VARIANT=staging npx expo prebuild --clean && (cd ios && pod install)
+  xcodebuild -workspace ios/VoiceClaw.xcworkspace -scheme VoiceClaw \
+    -destination "generic/platform=iOS" -resolvePackageDependencies
+  xcodebuild archive \
+    -workspace ios/VoiceClaw.xcworkspace -scheme VoiceClaw \
+    -configuration Release -archivePath build/VoiceClaw.xcarchive \
+    -destination "generic/platform=iOS" \
+    DEVELOPMENT_TEAM=HN6T5KD4ND CODE_SIGN_STYLE=Automatic
+  xcodebuild -exportArchive -archivePath build/VoiceClaw.xcarchive \
+    -exportPath build/export -exportOptionsPlist scripts/ExportOptions.plist
+  yarn ios:submit:staging
   ```
+- **EAS submit prompts for Apple ID** even though `eas.json` has the
+  ASC API key: happens when `ascAppId` is missing from the submit
+  profile. EAS then tries to look up the app via the ASC API; if the
+  key isn't scoped to that app or the listing fails, it falls back to
+  interactive Apple ID login. Either run `yarn ios:submit:*`
+  interactively (so you can type the Apple ID + 2FA) or add
+  `ascAppId` to each profile in `eas.json` (found in App Store Connect
+  → Apps → VoiceClaw → App Information → Apple ID).
 
 ## Dev builds on a real device
 


### PR DESCRIPTION
## Summary
Captures mobile iOS learnings so future sessions don't re-derive them:
- Variant matrix (dev / staging / production) and what each produces
- `yarn ios:release:staging|production` as the canonical TestFlight path (not Xcode)
- Commit-before-build rule (buildNumber = `git rev-list --count HEAD`)
- Required Info.plist privacy strings for TestFlight acceptance
- Dev-device build commands and when `prebuild --clean` is required
- iOS relay-connectivity gotchas: ATS, Local Network Privacy, iCloud Private Relay blocking cleartext HTTP to Tailscale IPs

## Test plan
- [x] File renders as markdown
- [x] Links and commands match current `package.json` / `scripts/build-ios.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)