### PR TITLE
mobile: ship staging TestFlight builds (purpose strings, pre-submit validation, EAS creds)

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -5,6 +5,8 @@ dist/
 *.p12
 *.key
 *.mobileprovision
+credentials.json
+credentials/
 *.orig.*
 web-build/
 /ios/

--- a/mobile/CLAUDE.md
+++ b/mobile/CLAUDE.md
@@ -30,9 +30,17 @@ yarn ios:release:production
 Under the hood (`scripts/build-ios.sh`):
 
 1. `expo prebuild --clean` with the right `APP_VARIANT`
-2. `xcodebuild archive` → `build/VoiceClaw.xcarchive`
-3. `xcodebuild -exportArchive` → `build/export/*.ipa`
-4. `eas submit --profile <variant> --platform ios --path build/export/*.ipa`
+2. `xcodebuild -resolvePackageDependencies` (primes SPM checkouts)
+3. Symlink `ArchiveIntermediates/SourcePackages` → DerivedData
+   SourcePackages (works around the Cmlx/swift-numerics archive bug)
+4. `xcodebuild archive` → `build/VoiceClaw.xcarchive`
+5. `xcodebuild -exportArchive` → `build/export/*.ipa` (uses
+   `method: app-store-connect` — `debugging` produces Ad Hoc IPAs
+   which ASC rejects as "Invalid Provisioning Profile")
+6. `xcrun altool --validate-app` — runs Apple's upload-time checks
+   locally so missing purpose strings / signing issues fail here
+   instead of 5-10 min after `eas submit`
+7. `eas submit --profile <variant> --platform ios --path build/export/*.ipa`
 
 Signing uses Automatic with `DEVELOPMENT_TEAM=HN6T5KD4ND`. App Store
 Connect auth uses the API key at `~/.appstore/AuthKey_SG645CPQP8.p8`
@@ -43,10 +51,17 @@ submit; the build then shows up in TestFlight → iOS builds.
 
 ### Things that have bitten us
 
-- **Privacy strings**: `NSMicrophoneUsageDescription` and
-  `NSSpeechRecognitionUsageDescription` must be in the Info.plist or
-  App Store Connect rejects the submission. They live in
+- **Privacy strings**: `NSMicrophoneUsageDescription`,
+  `NSSpeechRecognitionUsageDescription`, `NSLocalNetworkUsageDescription`,
+  and — because bundled SDKs reference the APIs even though we don't
+  call them — `NSPhotoLibraryUsageDescription` and
+  `NSCameraUsageDescription` must all be in Info.plist or App Store
+  Connect rejects the upload with error 90683 "Missing purpose string
+  in Info.plist" *after* `eas submit` reports success (the error only
+  surfaces during Apple's post-upload processing). They live in
   `app.config.ts` under `ios.infoPlist` and are written by prebuild.
+  The `xcrun altool --validate-app` step in `scripts/build-ios.sh`
+  catches this pre-submit.
 - **Duplicate build number**: always commit before `yarn ios:release:*`
   so `git rev-list --count HEAD` produces a fresh number.
 - **Never edit `ios/` directly**: `prebuild --clean` wipes it. Changes
@@ -54,29 +69,19 @@ submit; the build then shows up in TestFlight → iOS builds.
 - **SPM module map missing on archive** (`swift-numerics`, `Cmlx`, or
   any Swift package): shows up as
   `error: module map file '...swift-numerics/.../module.modulemap' not found`
-  → `** ARCHIVE FAILED **`. Xcode's archive build resolves
-  `BuildProductsPath/../../SourcePackages/checkouts/...` to a path
-  that doesn't exist if SPM packages weren't pre-resolved into the
-  archive intermediates dir. `expo prebuild --clean` wipes `ios/`
-  including the resolved Package.resolved, and a cold archive then
-  fails. Fix: pre-resolve packages, then archive directly (skipping
-  prebuild on the retry):
+  → `** ARCHIVE FAILED **`. Xcode's archive build references SPM
+  checkouts at `ArchiveIntermediates/SourcePackages/...` but SPM
+  actually places them at `DerivedData/<proj>/SourcePackages/...`.
+  `scripts/build-ios.sh` creates the missing symlink automatically
+  before archive. Manual form:
   ```bash
-  rm -rf ~/Library/Developer/Xcode/DerivedData/VoiceClaw-*
-  cd mobile
-  # If coming from a dev run, pods are already installed. Otherwise:
-  # APP_VARIANT=staging npx expo prebuild --clean && (cd ios && pod install)
-  xcodebuild -workspace ios/VoiceClaw.xcworkspace -scheme VoiceClaw \
-    -destination "generic/platform=iOS" -resolvePackageDependencies
-  xcodebuild archive \
-    -workspace ios/VoiceClaw.xcworkspace -scheme VoiceClaw \
-    -configuration Release -archivePath build/VoiceClaw.xcarchive \
-    -destination "generic/platform=iOS" \
-    DEVELOPMENT_TEAM=HN6T5KD4ND CODE_SIGN_STYLE=Automatic
-  xcodebuild -exportArchive -archivePath build/VoiceClaw.xcarchive \
-    -exportPath build/export -exportOptionsPlist scripts/ExportOptions.plist
-  yarn ios:submit:staging
+  DD=~/Library/Developer/Xcode/DerivedData/VoiceClaw-<hash>
+  ln -sfn ../../../SourcePackages \
+    "$DD/Build/Intermediates.noindex/ArchiveIntermediates/SourcePackages"
   ```
+  A symlink at `ArchiveIntermediates/VoiceClaw/SourcePackages` (one
+  level deeper) gets wiped by xcodebuild on archive start; the sibling
+  location `ArchiveIntermediates/SourcePackages` survives.
 - **EAS submit prompts for Apple ID** even though `eas.json` has the
   ASC API key: happens when `ascAppId` is missing from the submit
   profile. EAS then tries to look up the app via the ASC API; if the

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -45,6 +45,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       NSMicrophoneUsageDescription: 'VoiceClaw needs microphone access for voice calls with your AI assistant.',
       NSSpeechRecognitionUsageDescription: 'VoiceClaw uses speech recognition to transcribe your voice for the AI assistant.',
       NSLocalNetworkUsageDescription: 'VoiceClaw connects to your self-hosted relay server on your local or Tailscale network.',
+      NSPhotoLibraryUsageDescription: 'VoiceClaw does not access your photo library. This string is required because a bundled SDK references the API.',
+      NSCameraUsageDescription: 'VoiceClaw does not access your camera. This string is required because a bundled SDK references the API.',
       UIBackgroundModes: ['audio', 'voip'],
       NSAppTransportSecurity: {
         NSAllowsArbitraryLoads: true,

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -42,7 +42,8 @@
     },
     "staging": {
       "ios": {
-        "ascApiKeyPath": "~/.appstore/AuthKey_SG645CPQP8.p8",
+        "ascAppId": "6762490226",
+        "ascApiKeyPath": "/Users/michaelyagudaev/.appstore/AuthKey_SG645CPQP8.p8",
         "ascApiKeyIssuerId": "69a6de83-015f-47e3-e053-5b8c7c11a4d1",
         "ascApiKeyId": "SG645CPQP8"
       }

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -16,12 +16,13 @@
     },
     "staging": {
       "distribution": "store",
+      "node": "22.14.0",
       "env": {
         "APP_VARIANT": "staging"
       },
       "ios": {
         "buildConfiguration": "Release"
-      },
+      }
     },
     "production": {
       "env": {

--- a/mobile/scripts/ExportOptions.plist
+++ b/mobile/scripts/ExportOptions.plist
@@ -3,10 +3,14 @@
 <plist version="1.0">
 <dict>
 	<key>method</key>
-	<string>debugging</string>
+	<string>app-store-connect</string>
 	<key>signingStyle</key>
 	<string>automatic</string>
 	<key>teamID</key>
 	<string>HN6T5KD4ND</string>
+	<key>uploadSymbols</key>
+	<true/>
+	<key>stripSwiftSymbols</key>
+	<true/>
 </dict>
 </plist>

--- a/mobile/scripts/build-ios.sh
+++ b/mobile/scripts/build-ios.sh
@@ -10,13 +10,36 @@ SCHEME="VoiceClaw"
 ARCHIVE_PATH="${BUILD_DIR}/VoiceClaw.xcarchive"
 EXPORT_DIR="${BUILD_DIR}/export"
 EXPORT_PLIST="${MOBILE_DIR}/scripts/ExportOptions.plist"
+ASC_KEY_PATH="${ASC_API_KEY_PATH:-$HOME/.appstore/AuthKey_SG645CPQP8.p8}"
+ASC_KEY_ID="${ASC_API_KEY_ID:-SG645CPQP8}"
+ASC_ISSUER_ID="${ASC_API_ISSUER_ID:-69a6de83-015f-47e3-e053-5b8c7c11a4d1}"
 
 echo "==> Building VoiceClaw ($VARIANT)"
 echo "==> Step 1: Prebuild with APP_VARIANT=$VARIANT"
 cd "$MOBILE_DIR"
 APP_VARIANT="$VARIANT" npx expo prebuild --clean
 
-echo "==> Step 2: Archive"
+echo "==> Step 2: Resolve SPM packages"
+xcodebuild \
+  -workspace "$WORKSPACE" \
+  -scheme "$SCHEME" \
+  -destination "generic/platform=iOS" \
+  -resolvePackageDependencies
+
+echo "==> Step 3: Symlink SourcePackages into ArchiveIntermediates"
+# xcodebuild archive references SPM checkouts at
+# ArchiveIntermediates/SourcePackages/ but actually places them under
+# DerivedData/<proj>/SourcePackages/. Without this symlink, Cmlx and
+# swift-numerics fail with "module map file ... not found".
+DD_BASE=$(xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -showBuildSettings 2>/dev/null | awk -F' = ' '/ BUILD_DIR =/ {print $2; exit}' | sed 's|/Build/Products$||')
+if [ -z "$DD_BASE" ]; then
+  echo "!! Could not resolve DerivedData path; archive may fail with SPM module map error" >&2
+else
+  mkdir -p "$DD_BASE/Build/Intermediates.noindex/ArchiveIntermediates"
+  ln -sfn ../../../SourcePackages "$DD_BASE/Build/Intermediates.noindex/ArchiveIntermediates/SourcePackages"
+fi
+
+echo "==> Step 4: Archive"
 mkdir -p "$BUILD_DIR"
 xcodebuild archive \
   -workspace "$WORKSPACE" \
@@ -27,7 +50,7 @@ xcodebuild archive \
   DEVELOPMENT_TEAM=HN6T5KD4ND \
   CODE_SIGN_STYLE=Automatic
 
-echo "==> Step 3: Export IPA"
+echo "==> Step 5: Export IPA"
 rm -rf "$EXPORT_DIR"
 xcodebuild -exportArchive \
   -archivePath "$ARCHIVE_PATH" \
@@ -36,4 +59,19 @@ xcodebuild -exportArchive \
   -quiet
 
 IPA_PATH=$(find "$EXPORT_DIR" -name "*.ipa" -print -quit)
+
+echo "==> Step 6: Pre-submit validation with Apple"
+# altool --validate-app runs ASC's upload-time checks (missing purpose
+# strings, bad signing, bundle issues) without actually submitting —
+# catches post-upload rejections locally instead of after eas submit.
+if [ ! -f "$ASC_KEY_PATH" ]; then
+  echo "!! ASC API key not found at $ASC_KEY_PATH — skipping validation" >&2
+else
+  xcrun altool --validate-app \
+    -f "$IPA_PATH" \
+    -t ios \
+    --apiKey "$ASC_KEY_ID" \
+    --apiIssuer "$ASC_ISSUER_ID"
+fi
+
 echo "==> Build complete: $IPA_PATH"

--- a/mobile/scripts/build-ios.sh
+++ b/mobile/scripts/build-ios.sh
@@ -64,10 +64,13 @@ echo "==> Step 6: Pre-submit validation with Apple"
 # altool --validate-app runs ASC's upload-time checks (missing purpose
 # strings, bad signing, bundle issues) without actually submitting —
 # catches post-upload rejections locally instead of after eas submit.
+# altool looks for AuthKey_<ID>.p8 in $API_PRIVATE_KEYS_DIR (and a few
+# hard-coded dirs), not via flag.
 if [ ! -f "$ASC_KEY_PATH" ]; then
   echo "!! ASC API key not found at $ASC_KEY_PATH — skipping validation" >&2
 else
-  xcrun altool --validate-app \
+  API_PRIVATE_KEYS_DIR="$(dirname "$ASC_KEY_PATH")" \
+    xcrun altool --validate-app \
     -f "$IPA_PATH" \
     -t ios \
     --apiKey "$ASC_KEY_ID" \


### PR DESCRIPTION
## Summary
- Add missing iOS purpose strings (`NSPhotoLibraryUsageDescription`, `NSCameraUsageDescription`, expanded `NSLocalNetworkUsageDescription`) so ASC stops rejecting uploads with error 90683 after `eas submit` reports success
- Rewrite `scripts/build-ios.sh`: SPM symlink workaround for swift-numerics/Cmlx archive bug, switch ExportOptions `method` to `app-store-connect`, add `xcrun altool --validate-app` pre-submit check
- `eas.json`: add `ascAppId` to staging submit profile, pin `node: 22.14.0` for staging cloud builds, absolute `ascApiKeyPath`
- Gitignore `credentials.json` + `credentials/` so EAS-downloaded Distribution `.p12` + provisioning profile stay out of the repo
- CLAUDE.md: document the full TestFlight flow + pitfalls (purpose strings, SPM symlink, Ad Hoc vs App Store export, ASC interactive fallback)

Supersedes #159 (which only touched `ascAppId`).

## Test plan
- [ ] `yarn ios:release:staging` produces a Distribution-signed IPA locally (Apple Distribution cert installed via `eas credentials`)
- [ ] `xcrun altool --validate-app` passes locally
- [ ] `eas submit` uploads cleanly
- [ ] Build appears in TestFlight without 90161 / 90683 rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)