### PR TITLE
fix(desktop): handle missing Screen Recording permission in screen share

### DIFF
--- a/desktop/src/main/screen-capture.ts
+++ b/desktop/src/main/screen-capture.ts
@@ -1,7 +1,19 @@
-import { ipcMain, desktopCapturer } from 'electron'
+import { ipcMain, desktopCapturer, systemPreferences, shell, session } from 'electron'
 
 export function registerScreenCaptureHandlers() {
   ipcMain.handle('screen:getSources', async () => {
+    if (process.platform === 'darwin') {
+      const status = systemPreferences.getMediaAccessStatus('screen')
+      if (status !== 'granted') {
+        shell.openExternal(
+          'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture'
+        )
+        throw new Error(
+          `Screen Recording permission is ${status}. Grant it in System Settings → Privacy & Security → Screen Recording, then restart the app.`
+        )
+      }
+    }
+
     const sources = await desktopCapturer.getSources({
       types: ['screen', 'window'],
       thumbnailSize: { width: 320, height: 240 },
@@ -12,4 +24,14 @@ export function registerScreenCaptureHandlers() {
       thumbnailDataURL: s.thumbnail.toDataURL(),
     }))
   })
+
+  session.defaultSession.setDisplayMediaRequestHandler(
+    (_request, callback) => {
+      desktopCapturer
+        .getSources({ types: ['screen', 'window'] })
+        .then((sources) => callback({ video: sources[0] }))
+        .catch(() => callback({}))
+    },
+    { useSystemPicker: false }
+  )
 }


### PR DESCRIPTION
## Summary
- `desktopCapturer.getSources` was throwing `Failed to get sources` on macOS because the app lacked Screen Recording permission, with no surfaced error to the user.
- Check `systemPreferences.getMediaAccessStatus('screen')` first; if not granted, open System Settings → Privacy & Security → Screen Recording and throw a clear, actionable error.
- Register `session.defaultSession.setDisplayMediaRequestHandler` so `navigator.mediaDevices.getDisplayMedia` also works (future-proofing against the legacy `chromeMediaSource: 'desktop'` path).

## Test plan
- [x] Reproduce "Failed to get sources" by revoking Screen Recording permission, then relaunch — picker now surfaces a clear error and opens System Settings.
- [x] Grant Screen Recording to Electron, restart the app — picker lists screens/windows and frames stream to the realtime relay.
- [ ] Verify on a packaged build (VoiceClaw.app) that the permission prompt path still resolves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)