### PR TITLE
Tracing UI v2: transcript + logs + cost + latency + context token breakdown tabs

### DIFF
--- a/tracing-ui/package.json
+++ b/tracing-ui/package.json
@@ -11,8 +11,10 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.0.0",
+    "chart.js": "^4.4.7",
     "next": "^15.1.0",
     "react": "^19.0.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {

--- a/tracing-ui/src/app/sessions/[id]/page.tsx
+++ b/tracing-ui/src/app/sessions/[id]/page.tsx
@@ -1,23 +1,41 @@
 import Link from "next/link"
-import { listObservationsForSession, listTracesForSession } from "@/lib/db"
+import {
+  getVoiceTurnsForSession,
+  listObservationsForSession,
+  listTracesWithObservationsForSession,
+  type ObservationRow,
+} from "@/lib/db"
+import { SessionTabs, TABS, type TabKey } from "@/components/SessionTabs"
+import { TranscriptTab } from "@/components/TranscriptTab"
+import { LogsTab, type LogRow } from "@/components/LogsTab"
+import { CostTab } from "@/components/CostTab"
+import { LatencyTab } from "@/components/LatencyTab"
+import { ContextTab } from "@/components/ContextTab"
+import { RawTab } from "@/components/RawTab"
 
 export const dynamic = "force-dynamic"
 
 export default async function SessionDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>
+  searchParams: Promise<{ tab?: string }>
 }) {
   const { id } = await params
+  const { tab: tabParam } = await searchParams
   const sessionId = decodeURIComponent(id)
+  const activeTab = resolveTab(tabParam)
 
-  let traces: ReturnType<typeof listTracesForSession> = []
-  let observations: ReturnType<typeof listObservationsForSession> = []
+  let traces: ReturnType<typeof listTracesWithObservationsForSession> = []
+  let observations: ObservationRow[] = []
+  let voiceTurns: ReturnType<typeof getVoiceTurnsForSession> = []
   let error: string | null = null
 
   try {
-    traces = listTracesForSession(sessionId)
+    traces = listTracesWithObservationsForSession(sessionId)
     observations = listObservationsForSession(sessionId)
+    voiceTurns = getVoiceTurnsForSession(sessionId)
   } catch (err) {
     error = err instanceof Error ? err.message : String(err)
   }
@@ -43,101 +61,163 @@ export default async function SessionDetailPage({
 
   const startNs = Math.min(...traces.map((t) => t.start_time_ns))
   const endNs = Math.max(...traces.map((t) => Number(t.end_time_ns ?? t.start_time_ns)))
-  const totalMs = Math.round((endNs - startNs) / 1e6)
+  const totalMs = Math.max(0, Math.round((endNs - startNs) / 1e6))
   const totalTokens = observations.reduce(
     (acc, o) => acc + (o.tokens_input ?? 0) + (o.tokens_output ?? 0),
     0,
   )
   const totalCost = observations.reduce((acc, o) => acc + (o.cost_usd ?? 0), 0)
+  const userId = traces.find((t) => t.user_id)?.user_id ?? null
 
   return (
     <div className="flex h-[calc(100vh-49px)]">
-      <aside className="w-[380px] border-r border-zinc-800 p-5 space-y-4 overflow-y-auto">
+      <aside className="w-[360px] shrink-0 border-r border-zinc-800 p-5 space-y-4 overflow-y-auto">
         <Link href="/sessions" className="text-sm text-zinc-400 hover:text-zinc-100">
           ← Sessions
         </Link>
         <div>
           <div className="text-xs uppercase tracking-wide text-zinc-500">Session</div>
-          <div className="font-mono text-xs break-all">{sessionId}</div>
+          <div className="font-mono text-xs break-all mt-0.5">{sessionId}</div>
         </div>
+        {userId && (
+          <div>
+            <div className="text-xs uppercase tracking-wide text-zinc-500">User</div>
+            <div className="font-mono text-xs break-all mt-0.5">{userId}</div>
+          </div>
+        )}
         <div className="grid grid-cols-2 gap-3 text-sm">
           <Stat label="Turns" value={String(traces.length)} />
           <Stat label="Observations" value={String(observations.length)} />
           <Stat label="Duration" value={formatDuration(totalMs)} />
           <Stat label="Tokens" value={totalTokens.toLocaleString()} />
-          <Stat label="Cost" value={totalCost > 0 ? `$${totalCost.toFixed(4)}` : "—"} />
+          <Stat
+            label="Cost"
+            value={totalCost > 0 ? `$${totalCost.toFixed(4)}` : "—"}
+          />
+          <Stat
+            label="Started"
+            value={new Date(Number(startNs) / 1e6).toLocaleTimeString()}
+          />
         </div>
         <div>
           <div className="text-xs uppercase tracking-wide text-zinc-500 mb-2">Turns</div>
           <ul className="space-y-1 text-xs">
-            {traces.map((t) => (
-              <li key={t.trace_id} className="px-2 py-1 rounded bg-zinc-900">
-                <div className="font-mono text-zinc-400">{t.trace_id.slice(0, 16)}…</div>
-                <div>{t.name ?? "(unnamed)"}</div>
+            {traces.map((t, i) => (
+              <li
+                key={t.trace_id}
+                className="rounded bg-zinc-900 border border-zinc-800 px-2 py-1"
+              >
+                <div className="flex items-center justify-between text-zinc-400">
+                  <span>#{i + 1}</span>
+                  <span className="tabular-nums text-zinc-500">
+                    +{Math.round((t.start_time_ns - startNs) / 1e6).toLocaleString()}ms
+                  </span>
+                </div>
+                <div className="text-zinc-300 truncate">{t.name ?? "(unnamed)"}</div>
+                <div className="font-mono text-[10px] text-zinc-600">
+                  {t.trace_id.slice(0, 16)}…
+                </div>
               </li>
             ))}
           </ul>
         </div>
       </aside>
-      <section className="flex-1 overflow-y-auto p-5">
-        <h2 className="text-lg font-semibold">Trace observations</h2>
-        <p className="text-xs text-zinc-400 mt-1">
-          Flat list of all spans across this session&apos;s traces. Transcript, logs, cost, latency, and swim-lane
-          views are implemented incrementally — see{" "}
-          <code className="bg-zinc-900 rounded px-1">docs/tracing-ui/SPEC.md</code> for the full feature set.
-        </p>
-        <table className="mt-4 w-full text-xs border border-zinc-800 rounded overflow-hidden">
-          <thead className="bg-zinc-900 text-zinc-400 text-left">
-            <tr>
-              <th className="px-3 py-2 font-medium">Start</th>
-              <th className="px-3 py-2 font-medium">Service</th>
-              <th className="px-3 py-2 font-medium">Name</th>
-              <th className="px-3 py-2 font-medium">Type</th>
-              <th className="px-3 py-2 font-medium">Model</th>
-              <th className="px-3 py-2 font-medium text-right">Duration</th>
-              <th className="px-3 py-2 font-medium text-right">Tokens</th>
-              <th className="px-3 py-2 font-medium text-right">Cost</th>
-            </tr>
-          </thead>
-          <tbody>
-            {observations.map((o) => (
-              <tr key={o.span_id} className="border-t border-zinc-800 align-top">
-                <td className="px-3 py-2 font-mono text-zinc-500 tabular-nums">
-                  +{Math.round((o.start_time_ns - startNs) / 1e6)}ms
-                </td>
-                <td className="px-3 py-2">{o.service_name ?? "—"}</td>
-                <td className="px-3 py-2">{o.name ?? "—"}</td>
-                <td className="px-3 py-2">
-                  {o.observation_type ?? <span className="text-zinc-600">SPAN</span>}
-                </td>
-                <td className="px-3 py-2 font-mono text-xs">{o.model ?? "—"}</td>
-                <td className="px-3 py-2 text-right tabular-nums">
-                  {o.duration_ms != null ? `${o.duration_ms}ms` : "—"}
-                </td>
-                <td className="px-3 py-2 text-right tabular-nums">
-                  {o.tokens_input != null || o.tokens_output != null
-                    ? `${o.tokens_input ?? 0}→${o.tokens_output ?? 0}`
-                    : "—"}
-                </td>
-                <td className="px-3 py-2 text-right tabular-nums">
-                  {o.cost_usd != null && o.cost_usd > 0 ? `$${o.cost_usd.toFixed(4)}` : "—"}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <section className="flex-1 overflow-y-auto">
+        <SessionTabs sessionId={sessionId} active={activeTab} />
+        <TabContent
+          tab={activeTab}
+          voiceTurns={voiceTurns}
+          observations={observations}
+          traces={traces}
+          startNs={startNs}
+          totalMs={totalMs}
+        />
       </section>
     </div>
   )
+}
+
+function TabContent({
+  tab,
+  voiceTurns,
+  observations,
+  traces,
+  startNs,
+  totalMs,
+}: {
+  tab: TabKey
+  voiceTurns: ReturnType<typeof getVoiceTurnsForSession>
+  observations: ObservationRow[]
+  traces: ReturnType<typeof listTracesWithObservationsForSession>
+  startNs: number
+  totalMs: number
+}) {
+  switch (tab) {
+    case "transcript":
+      return <TranscriptTab turns={voiceTurns} sessionStartNs={startNs} />
+    case "logs":
+      return <LogsTab rows={toLogRows(observations, startNs)} />
+    case "cost":
+      return <CostTab observations={observations} durationMs={totalMs} />
+    case "latency":
+      return <LatencyTab traces={traces} />
+    case "context":
+      return <ContextTab observations={observations} />
+    case "raw":
+      return <RawTab observations={observations} sessionStartNs={startNs} />
+  }
 }
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded border border-zinc-800 p-2">
       <div className="text-[10px] uppercase tracking-wide text-zinc-500">{label}</div>
-      <div className="text-sm tabular-nums mt-0.5">{value}</div>
+      <div className="text-sm tabular-nums mt-0.5 break-all">{value}</div>
     </div>
   )
+}
+
+function resolveTab(raw: string | undefined): TabKey {
+  const match = TABS.find((t) => t.key === raw)
+  return match ? match.key : "transcript"
+}
+
+function toLogRows(observations: ObservationRow[], startNs: number): LogRow[] {
+  return observations.map((o) => ({
+    span_id: o.span_id,
+    rel_ms: Math.max(0, Math.round((o.start_time_ns - startNs) / 1e6)),
+    level: o.status_code === "2" || o.status_code === "ERROR" ? "ERROR" : "OK",
+    service: o.service_name ?? "(unknown)",
+    category: (o.name ?? "").split(".")[0] || "(none)",
+    name: o.name ?? "—",
+    summary: summarise(o),
+    duration_ms: o.duration_ms,
+    attributes_json: o.attributes_json,
+  }))
+}
+
+// Compress a span's attributes into a one-line preview for the Logs table.
+// Prefers the input/output shipped via langfuse.observation.* over the full
+// attribute dump so the summary column stays legible.
+function summarise(o: ObservationRow): string {
+  if (!o.attributes_json) return ""
+  try {
+    const attrs = JSON.parse(o.attributes_json) as Record<string, unknown>
+    const input = attrs["langfuse.observation.input"]
+    const output = attrs["langfuse.observation.output"]
+    const preferred = output ?? input
+    if (typeof preferred === "string") {
+      const trimmed = preferred.replace(/\s+/g, " ").trim()
+      return trimmed.length > 140 ? trimmed.slice(0, 137) + "…" : trimmed
+    }
+    if (preferred != null) {
+      const s = JSON.stringify(preferred).replace(/\s+/g, " ")
+      return s.length > 140 ? s.slice(0, 137) + "…" : s
+    }
+  } catch {
+    // fall through to empty
+  }
+  return ""
 }
 
 function formatDuration(ms: number): string {

--- a/tracing-ui/src/components/ContextStackedBar.tsx
+++ b/tracing-ui/src/components/ContextStackedBar.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import type { ContextSection } from "@/lib/context-breakdown"
+
+const SECTION_COLORS: Record<ContextSection["kind"], string> = {
+  system: "#60a5fa",
+  workspace_bootstrap: "#a78bfa",
+  tools: "#34d399",
+  history: "#fbbf24",
+  user: "#f472b6",
+  other: "#71717a",
+}
+
+export function ContextStackedBar({ sections }: { sections: ContextSection[] }) {
+  const total = sections.reduce((acc, s) => acc + s.chars, 0)
+  if (total === 0) {
+    return (
+      <div className="h-7 rounded border border-dashed border-zinc-800 flex items-center justify-center text-xs text-zinc-600">
+        no input captured
+      </div>
+    )
+  }
+  return (
+    <div className="space-y-2">
+      <div className="h-7 rounded overflow-hidden flex border border-zinc-800">
+        {sections.map((s) => {
+          const pct = (s.chars / total) * 100
+          if (pct <= 0) return null
+          return (
+            <div
+              key={s.kind + s.label}
+              title={`${s.label}: ${s.chars.toLocaleString()} chars (${pct.toFixed(1)}%)`}
+              style={{ width: `${pct}%`, background: SECTION_COLORS[s.kind] }}
+              className="flex items-center justify-center text-[10px] font-medium text-zinc-900"
+            >
+              {pct >= 10 ? s.label.split(" ")[0] : ""}
+            </div>
+          )
+        })}
+      </div>
+      <div className="flex flex-wrap gap-3 text-[11px] text-zinc-400">
+        {sections.map((s) => (
+          <span key={s.kind + s.label} className="flex items-center gap-1.5">
+            <span
+              className="inline-block h-2.5 w-2.5 rounded-sm"
+              style={{ background: SECTION_COLORS[s.kind] }}
+            />
+            {s.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/tracing-ui/src/components/ContextTab.tsx
+++ b/tracing-ui/src/components/ContextTab.tsx
@@ -1,0 +1,222 @@
+import type { ObservationRow } from "@/lib/db"
+import { parseContextBreakdown, type ContextBreakdown } from "@/lib/context-breakdown"
+import { ContextStackedBar } from "./ContextStackedBar"
+
+export function ContextTab({ observations }: { observations: ObservationRow[] }) {
+  const llmSpans = observations.filter((o) => o.name === "openclaw.llm")
+  if (llmSpans.length === 0) {
+    return (
+      <div className="px-6 py-8 text-sm text-zinc-400">
+        No <code className="rounded bg-zinc-900 px-1">openclaw.llm</code> spans on this session —
+        context breakdown is brain-only for now.
+      </div>
+    )
+  }
+
+  type Entry = {
+    span_id: string
+    trace_id: string
+    rel_ms: number
+    model: string | null
+    breakdown: ContextBreakdown
+  }
+
+  const minStart = Math.min(...llmSpans.map((o) => o.start_time_ns))
+  const entries: Entry[] = llmSpans.map((o) => {
+    const attrs = parseAttributes(o.attributes_json)
+    const input = attrs["langfuse.observation.input"]
+    const usage = attrs["langfuse.observation.usage_details"]
+    const cacheRead = coerceNumber(attrs["gen_ai.usage.cache_read_input_tokens"])
+    const cacheCreation = coerceNumber(attrs["gen_ai.usage.cache_creation_input_tokens"])
+    return {
+      span_id: o.span_id,
+      trace_id: o.trace_id,
+      rel_ms: Math.max(0, Math.round((o.start_time_ns - minStart) / 1e6)),
+      model: o.model,
+      breakdown: parseContextBreakdown(input, usage, {
+        read: cacheRead ?? undefined,
+        creation: cacheCreation ?? undefined,
+      }),
+    }
+  })
+
+  // Session-wide cache gauge: cache_read / (cache_read + fresh_input), summed
+  // across every openclaw.llm span that reported provider tokens. Spans
+  // without usage_details are skipped so one empty span doesn't tank the
+  // gauge.
+  let totalInput = 0
+  let totalCached = 0
+  for (const e of entries) {
+    const p = e.breakdown.provider_tokens
+    if (!p) continue
+    totalInput += p.input
+    totalCached += p.cached
+  }
+  const sessionCachePct = totalInput > 0 ? (totalCached / totalInput) * 100 : null
+
+  return (
+    <div className="px-6 py-6 space-y-6">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <KpiCard
+          label="Session cache hit"
+          value={sessionCachePct != null ? `${sessionCachePct.toFixed(1)}%` : "—"}
+        />
+        <KpiCard label="Brain turns" value={String(entries.length)} />
+        <KpiCard label="Input tokens" value={totalInput.toLocaleString()} />
+        <KpiCard label="Cache-read tokens" value={totalCached.toLocaleString()} />
+      </div>
+
+      {sessionCachePct != null && <CacheGauge pct={sessionCachePct} />}
+
+      <div className="space-y-4">
+        {entries.map((e, idx) => (
+          <TurnCard key={e.span_id} index={idx + 1} entry={e} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+type Entry = {
+  span_id: string
+  trace_id: string
+  rel_ms: number
+  model: string | null
+  breakdown: ContextBreakdown
+}
+
+function TurnCard({ index, entry }: { index: number; entry: Entry }) {
+  const { breakdown } = entry
+  const provider = breakdown.provider_tokens
+  return (
+    <div className="rounded border border-zinc-800 p-4 space-y-3">
+      <div className="flex items-center gap-3 text-xs text-zinc-500">
+        <span className="rounded bg-zinc-900 px-2 py-0.5 text-zinc-400">Brain turn {index}</span>
+        <span className="font-mono tabular-nums">+{entry.rel_ms.toLocaleString()}ms</span>
+        {entry.model && <span className="font-mono text-zinc-600">· {entry.model}</span>}
+        {provider && (
+          <span className="tabular-nums text-zinc-600">
+            · {provider.input.toLocaleString()} in / {provider.output.toLocaleString()} out
+          </span>
+        )}
+      </div>
+
+      <ContextStackedBar sections={breakdown.sections} />
+
+      {provider && (
+        <CacheBar cached={provider.cached} fresh={Math.max(0, provider.input - provider.cached)} />
+      )}
+
+      <table className="w-full text-xs">
+        <thead className="text-zinc-500 text-left">
+          <tr>
+            <th className="px-1 py-1 font-medium">Section</th>
+            <th className="px-1 py-1 font-medium text-right">Chars</th>
+            <th className="px-1 py-1 font-medium text-right">Tokens (est)</th>
+            <th className="px-1 py-1 font-medium text-right">% of ctx</th>
+          </tr>
+        </thead>
+        <tbody>
+          {breakdown.sections.map((s) => {
+            const pct =
+              breakdown.total_chars > 0 ? (s.chars / breakdown.total_chars) * 100 : 0
+            return (
+              <tr key={s.kind + s.label} className="border-t border-zinc-900">
+                <td className="px-1 py-1 text-zinc-300">{s.label}</td>
+                <td className="px-1 py-1 text-right tabular-nums text-zinc-300">
+                  {s.chars.toLocaleString()}
+                </td>
+                <td className="px-1 py-1 text-right tabular-nums text-zinc-400">
+                  {s.tokens_est.toLocaleString()}
+                </td>
+                <td className="px-1 py-1 text-right tabular-nums text-zinc-400">
+                  {pct.toFixed(1)}%
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function CacheBar({ cached, fresh }: { cached: number; fresh: number }) {
+  const total = cached + fresh
+  if (total === 0) return null
+  const cachedPct = (cached / total) * 100
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-[11px] text-zinc-400">
+        <span>Cache utilisation</span>
+        <span className="tabular-nums">
+          {cached.toLocaleString()} cached / {fresh.toLocaleString()} fresh
+          <span className="text-zinc-600"> ({cachedPct.toFixed(1)}% hit)</span>
+        </span>
+      </div>
+      <div className="h-3 rounded overflow-hidden flex border border-zinc-800">
+        {cached > 0 && (
+          <div
+            title={`Cache-read: ${cached.toLocaleString()}`}
+            style={{ width: `${cachedPct}%`, background: "#22c55e" }}
+          />
+        )}
+        {fresh > 0 && (
+          <div
+            title={`Fresh input: ${fresh.toLocaleString()}`}
+            style={{ width: `${100 - cachedPct}%`, background: "#f97316" }}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function CacheGauge({ pct }: { pct: number }) {
+  const clamped = Math.max(0, Math.min(100, pct))
+  return (
+    <div className="rounded border border-zinc-800 p-4 space-y-2">
+      <div className="flex items-center justify-between text-xs">
+        <span className="uppercase tracking-wide text-zinc-500">Cache hit — session</span>
+        <span className="tabular-nums text-zinc-200">{clamped.toFixed(1)}%</span>
+      </div>
+      <div className="h-3 rounded overflow-hidden flex border border-zinc-800">
+        <div style={{ width: `${clamped}%`, background: "#22c55e" }} />
+        <div style={{ width: `${100 - clamped}%`, background: "#f97316" }} />
+      </div>
+      <p className="text-[11px] text-zinc-500">
+        Green = cache-read tokens (paid at cache rate). Orange = fresh input (paid full).
+      </p>
+    </div>
+  )
+}
+
+function KpiCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-zinc-800 p-3">
+      <div className="text-[10px] uppercase tracking-wide text-zinc-500">{label}</div>
+      <div className="text-lg tabular-nums mt-0.5">{value}</div>
+    </div>
+  )
+}
+
+function parseAttributes(raw: string | null): Record<string, unknown> {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+  } catch {
+    // ignore
+  }
+  return {}
+}
+
+function coerceNumber(raw: unknown): number | null {
+  if (typeof raw === "number" && !Number.isNaN(raw)) return raw
+  if (typeof raw === "string" && raw.trim() !== "" && !Number.isNaN(Number(raw))) {
+    return Number(raw)
+  }
+  return null
+}

--- a/tracing-ui/src/components/CostDonut.tsx
+++ b/tracing-ui/src/components/CostDonut.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import {
+  Chart,
+  DoughnutController,
+  ArcElement,
+  Tooltip,
+  Legend,
+} from "chart.js"
+
+// Register only the pieces we use. Chart.js is tree-shakeable but each chart
+// component has to register its own controllers up front.
+Chart.register(DoughnutController, ArcElement, Tooltip, Legend)
+
+export type CostSlice = {
+  label: string
+  value: number
+  color: string
+}
+
+export function CostDonut({ slices }: { slices: CostSlice[] }) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const chartRef = useRef<Chart | null>(null)
+
+  useEffect(() => {
+    if (!canvasRef.current) return
+    const ctx = canvasRef.current.getContext("2d")
+    if (!ctx) return
+    // Tear down any prior chart instance bound to this canvas. Chart.js keeps
+    // a singleton-per-canvas registry and will throw if we try to mount twice.
+    chartRef.current?.destroy()
+    chartRef.current = new Chart(ctx, {
+      type: "doughnut",
+      data: {
+        labels: slices.map((s) => s.label),
+        datasets: [
+          {
+            data: slices.map((s) => s.value),
+            backgroundColor: slices.map((s) => s.color),
+            borderColor: "#18181b",
+            borderWidth: 2,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        cutout: "62%",
+        plugins: {
+          legend: {
+            position: "right",
+            labels: { color: "#d4d4d8", font: { size: 12 } },
+          },
+          tooltip: {
+            callbacks: {
+              label: (ctx) => {
+                const value = Number(ctx.parsed)
+                return ` ${ctx.label}: $${value.toFixed(4)}`
+              },
+            },
+          },
+        },
+      },
+    })
+    return () => {
+      chartRef.current?.destroy()
+      chartRef.current = null
+    }
+  }, [slices])
+
+  return (
+    <div className="relative h-72 w-full">
+      <canvas ref={canvasRef} />
+    </div>
+  )
+}

--- a/tracing-ui/src/components/CostTab.tsx
+++ b/tracing-ui/src/components/CostTab.tsx
@@ -1,0 +1,156 @@
+import type { ObservationRow } from "@/lib/db"
+import { computeCost, loadPricingCatalog } from "@/lib/pricing"
+import { CostDonut } from "./CostDonut"
+
+// Category colour palette. Tuned to Tailwind zinc/slate accents so it blends
+// with the dark app shell instead of fighting it.
+const CATEGORY_COLORS: Record<string, string> = {
+  "Realtime AI": "#60a5fa", // blue-400
+  "Brain LLM": "#a78bfa", // violet-400
+  STT: "#34d399", // emerald-400
+  TTS: "#f59e0b", // amber-500
+}
+
+type Bucket = {
+  label: string
+  cost_usd: number
+  tokens: number
+}
+
+export async function CostTab({
+  observations,
+  durationMs,
+}: {
+  observations: ObservationRow[]
+  durationMs: number
+}) {
+  const catalog = await loadPricingCatalog()
+
+  // Categorise by span name. Relay voice-turn spans = realtime AI. openclaw.llm
+  // = the brain's Haiku/Sonnet call. openclaw.tool / chat_completions are
+  // internal plumbing we don't bill directly. STT/TTS stay as placeholders
+  // until we add those spans on the relay side.
+  const buckets: Record<string, Bucket> = {
+    "Realtime AI": { label: "Realtime AI", cost_usd: 0, tokens: 0 },
+    "Brain LLM": { label: "Brain LLM", cost_usd: 0, tokens: 0 },
+    STT: { label: "STT (placeholder)", cost_usd: 0, tokens: 0 },
+    TTS: { label: "TTS (placeholder)", cost_usd: 0, tokens: 0 },
+  }
+
+  for (const o of observations) {
+    const tokensIn = o.tokens_input ?? 0
+    const tokensOut = o.tokens_output ?? 0
+    const cached = o.tokens_cached ?? 0
+    const reported = o.cost_usd ?? 0
+
+    if (o.name === "voice-turn") {
+      // Prefer the collector-resolved cost_usd; if it's zero (e.g. audio-token
+      // pricing gap) fall back to the pricing helper.
+      const cost =
+        reported > 0
+          ? reported
+          : computeCost(catalog, o.model, { input: tokensIn, output: tokensOut, cached }).total_usd
+      buckets["Realtime AI"].cost_usd += cost
+      buckets["Realtime AI"].tokens += tokensIn + tokensOut
+    } else if (o.name === "openclaw.llm") {
+      const cost =
+        reported > 0
+          ? reported
+          : computeCost(catalog, o.model, { input: tokensIn, output: tokensOut, cached }).total_usd
+      buckets["Brain LLM"].cost_usd += cost
+      buckets["Brain LLM"].tokens += tokensIn + tokensOut
+    }
+  }
+
+  const entries = Object.values(buckets)
+  const total = entries.reduce((acc, b) => acc + b.cost_usd, 0)
+  const totalTokens = entries.reduce((acc, b) => acc + b.tokens, 0)
+  const slices = entries
+    .filter((b) => b.cost_usd > 0)
+    .map((b) => ({
+      label: b.label,
+      value: b.cost_usd,
+      color: CATEGORY_COLORS[b.label.replace(" (placeholder)", "")] ?? "#71717a",
+    }))
+
+  return (
+    <div className="px-6 py-6 grid gap-6 md:grid-cols-[minmax(0,1fr)_320px] items-start">
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-3">
+          <KpiCard label="Total cost" value={total > 0 ? `$${total.toFixed(4)}` : "$0"} />
+          <KpiCard label="Session duration" value={formatDuration(durationMs)} />
+          <KpiCard label="Total tokens" value={totalTokens.toLocaleString()} />
+          <KpiCard
+            label="$ / minute"
+            value={
+              durationMs > 0 && total > 0
+                ? `$${(total / (durationMs / 60000)).toFixed(4)}`
+                : "—"
+            }
+          />
+        </div>
+
+        <div className="rounded border border-zinc-800 p-4">
+          {slices.length === 0 ? (
+            <div className="py-16 text-center text-sm text-zinc-400">
+              No cost data yet. The collector fills in <code>cost_usd</code> from{" "}
+              <code>gen_ai.usage.*</code> once model pricing resolves.
+            </div>
+          ) : (
+            <CostDonut slices={slices} />
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-xs uppercase tracking-wide text-zinc-500">Breakdown</div>
+        <table className="w-full text-xs border border-zinc-800 rounded overflow-hidden">
+          <thead className="bg-zinc-900 text-zinc-400 text-left">
+            <tr>
+              <th className="px-3 py-2 font-medium">Category</th>
+              <th className="px-3 py-2 font-medium text-right">Tokens</th>
+              <th className="px-3 py-2 font-medium text-right">$</th>
+              <th className="px-3 py-2 font-medium text-right">%</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((b) => {
+              const pct = total > 0 ? (b.cost_usd / total) * 100 : 0
+              return (
+                <tr key={b.label} className="border-t border-zinc-800">
+                  <td className="px-3 py-2 text-zinc-300">{b.label}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{b.tokens.toLocaleString()}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">
+                    {b.cost_usd > 0 ? `$${b.cost_usd.toFixed(4)}` : "—"}
+                  </td>
+                  <td className="px-3 py-2 text-right tabular-nums text-zinc-400">
+                    {b.cost_usd > 0 ? `${pct.toFixed(1)}%` : "—"}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function KpiCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-zinc-800 p-3">
+      <div className="text-[10px] uppercase tracking-wide text-zinc-500">{label}</div>
+      <div className="text-lg tabular-nums mt-0.5">{value}</div>
+    </div>
+  )
+}
+
+function formatDuration(ms: number): string {
+  if (!ms || ms < 0) return "—"
+  if (ms < 1000) return `${ms}ms`
+  const s = Math.round(ms / 100) / 10
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  const rem = Math.round(s - m * 60)
+  return `${m}m ${rem}s`
+}

--- a/tracing-ui/src/components/LatencyStackedBar.tsx
+++ b/tracing-ui/src/components/LatencyStackedBar.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { LATENCY_CATEGORIES, type LatencyCategory } from "./LatencyTab.shared"
+
+// A pure-CSS horizontal stacked bar. Uses flexbox so each segment's width is
+// proportional to its duration without pulling in another Chart.js dataset.
+// Segments with zero duration are skipped so the bar doesn't render
+// zero-width flex children with tooltips attached.
+export function LatencyStackedBar({ values }: { values: Record<LatencyCategory, number> }) {
+  const total = LATENCY_CATEGORIES.reduce((acc, c) => acc + values[c.key], 0)
+
+  if (total === 0) {
+    return (
+      <div className="h-8 rounded border border-dashed border-zinc-800 flex items-center justify-center text-xs text-zinc-600">
+        no latency data
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-8 rounded overflow-hidden flex border border-zinc-800">
+      {LATENCY_CATEGORIES.map((c) => {
+        const v = values[c.key]
+        if (v <= 0) return null
+        const pct = (v / total) * 100
+        return (
+          <div
+            key={c.key}
+            title={`${c.label}: ${v.toLocaleString()}ms (${pct.toFixed(1)}%)`}
+            style={{ width: `${pct}%`, background: c.color }}
+            className="flex items-center justify-center text-[10px] font-medium text-zinc-900"
+          >
+            {pct >= 6 ? `${c.label.split(" ")[0]}` : ""}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/tracing-ui/src/components/LatencyTab.shared.ts
+++ b/tracing-ui/src/components/LatencyTab.shared.ts
@@ -1,0 +1,21 @@
+// Shared latency-category constants. Lives in its own file (no "use client",
+// no "use server") so it can be imported from both the LatencyTab server
+// component and the LatencyStackedBar client component without Next.js
+// complaining about mixed server/client boundaries.
+
+export type LatencyCategory =
+  | "endpointing"
+  | "voice"
+  | "transcriber"
+  | "llm_realtime"
+  | "brain"
+  | "transport"
+
+export const LATENCY_CATEGORIES: { key: LatencyCategory; label: string; color: string }[] = [
+  { key: "endpointing", label: "Endpointing", color: "#fbbf24" },
+  { key: "voice", label: "Voice (TTS)", color: "#f472b6" },
+  { key: "transcriber", label: "Transcriber (STT)", color: "#34d399" },
+  { key: "llm_realtime", label: "LLM (realtime)", color: "#60a5fa" },
+  { key: "brain", label: "Brain (async)", color: "#a78bfa" },
+  { key: "transport", label: "To-Transport", color: "#71717a" },
+]

--- a/tracing-ui/src/components/LatencyTab.tsx
+++ b/tracing-ui/src/components/LatencyTab.tsx
@@ -1,0 +1,153 @@
+import type { ObservationRow, TraceWithObservations } from "@/lib/db"
+import { LATENCY_CATEGORIES, type LatencyCategory } from "./LatencyTab.shared"
+import { LatencyStackedBar } from "./LatencyStackedBar"
+
+export function LatencyTab({ traces }: { traces: TraceWithObservations[] }) {
+  if (traces.length === 0) {
+    return <div className="px-6 py-8 text-sm text-zinc-400">No turns on this session yet.</div>
+  }
+
+  const perTurn = traces.map((t) => ({
+    trace_id: t.trace_id,
+    start_ns: t.start_time_ns,
+    name: t.name ?? "(unnamed)",
+    total_ms:
+      t.end_time_ns != null ? Math.max(0, Math.round((t.end_time_ns - t.start_time_ns) / 1e6)) : 0,
+    split: categorise(t.observations),
+  }))
+
+  const turnCount = traces.length
+  const avgTurnMs =
+    turnCount > 0
+      ? Math.round(perTurn.reduce((acc, t) => acc + t.total_ms, 0) / turnCount)
+      : 0
+
+  // Overall split = sum across all turns per category. Rendered as a single
+  // fat stacked bar up top so you can see where cumulative time goes.
+  const overall: Record<LatencyCategory, number> = {
+    endpointing: 0,
+    voice: 0,
+    transcriber: 0,
+    llm_realtime: 0,
+    brain: 0,
+    transport: 0,
+  }
+  for (const t of perTurn) {
+    for (const cat of LATENCY_CATEGORIES) overall[cat.key] += t.split[cat.key]
+  }
+
+  return (
+    <div className="px-6 py-6 space-y-6">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <KpiCard label="Total turns" value={turnCount.toLocaleString()} />
+        <KpiCard label="Avg turn latency" value={`${avgTurnMs.toLocaleString()}ms`} />
+        <KpiCard
+          label="Total time"
+          value={`${perTurn.reduce((acc, t) => acc + t.total_ms, 0).toLocaleString()}ms`}
+        />
+        <KpiCard label="Tracked categories" value={String(LATENCY_CATEGORIES.length)} />
+      </div>
+
+      <div className="rounded border border-zinc-800 p-4 space-y-3">
+        <div className="text-xs uppercase tracking-wide text-zinc-500">Overall split</div>
+        <LatencyStackedBar values={overall} />
+        <Legend />
+      </div>
+
+      <div className="rounded border border-zinc-800 overflow-hidden">
+        <table className="w-full text-xs">
+          <thead className="bg-zinc-900 text-zinc-400 text-left">
+            <tr>
+              <th className="px-3 py-2 font-medium">#</th>
+              <th className="px-3 py-2 font-medium">Trace</th>
+              <th className="px-3 py-2 font-medium text-right">Total</th>
+              {LATENCY_CATEGORIES.map((c) => (
+                <th key={c.key} className="px-3 py-2 font-medium text-right">
+                  {c.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {perTurn.map((t, i) => (
+              <tr key={t.trace_id} className="border-t border-zinc-800">
+                <td className="px-3 py-2 tabular-nums text-zinc-400">{i + 1}</td>
+                <td className="px-3 py-2 font-mono text-zinc-500">
+                  {t.trace_id.slice(0, 12)}…{" "}
+                  <span className="text-zinc-600">({t.name})</span>
+                </td>
+                <td className="px-3 py-2 text-right tabular-nums text-zinc-100">
+                  {t.total_ms.toLocaleString()}ms
+                </td>
+                {LATENCY_CATEGORIES.map((c) => (
+                  <td
+                    key={c.key}
+                    className="px-3 py-2 text-right tabular-nums text-zinc-300"
+                  >
+                    {t.split[c.key] > 0 ? `${t.split[c.key].toLocaleString()}ms` : "—"}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function Legend() {
+  return (
+    <div className="flex flex-wrap gap-3 text-[11px] text-zinc-400">
+      {LATENCY_CATEGORIES.map((c) => (
+        <span key={c.key} className="flex items-center gap-1.5">
+          <span
+            className="inline-block h-2.5 w-2.5 rounded-sm"
+            style={{ background: c.color }}
+          />
+          {c.label}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function KpiCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-zinc-800 p-3">
+      <div className="text-[10px] uppercase tracking-wide text-zinc-500">{label}</div>
+      <div className="text-lg tabular-nums mt-0.5">{value}</div>
+    </div>
+  )
+}
+
+// Map span names onto latency buckets. Names come from the relay/openclaw
+// instrumentation conventions. Anything we don't recognise falls into
+// "transport" so it's visible but doesn't mis-label.
+function categorise(observations: ObservationRow[]): Record<LatencyCategory, number> {
+  const out: Record<LatencyCategory, number> = {
+    endpointing: 0,
+    voice: 0,
+    transcriber: 0,
+    llm_realtime: 0,
+    brain: 0,
+    transport: 0,
+  }
+  for (const o of observations) {
+    const dur = o.duration_ms ?? 0
+    if (dur <= 0) continue
+    const name = (o.name ?? "").toLowerCase()
+    const cat = mapNameToCategory(name)
+    out[cat] += dur
+  }
+  return out
+}
+
+function mapNameToCategory(name: string): LatencyCategory {
+  if (name.includes("endpoint")) return "endpointing"
+  if (name.includes("tts") || name.includes("voice-out") || name.includes("voice_out")) return "voice"
+  if (name.includes("stt") || name.includes("transcrib")) return "transcriber"
+  if (name === "voice-turn" || name.includes("realtime")) return "llm_realtime"
+  if (name.startsWith("openclaw") || name.includes("brain") || name === "ask_brain") return "brain"
+  return "transport"
+}

--- a/tracing-ui/src/components/LogsTab.tsx
+++ b/tracing-ui/src/components/LogsTab.tsx
@@ -1,0 +1,218 @@
+"use client"
+
+import { Fragment, useMemo, useState } from "react"
+
+export type LogRow = {
+  span_id: string
+  rel_ms: number
+  level: "ERROR" | "OK"
+  service: string
+  category: string
+  name: string
+  summary: string
+  duration_ms: number | null
+  attributes_json: string | null
+}
+
+export function LogsTab({ rows }: { rows: LogRow[] }) {
+  const [level, setLevel] = useState<string>("all")
+  const [service, setService] = useState<string>("all")
+  const [category, setCategory] = useState<string>("all")
+  const [sortBy, setSortBy] = useState<"time" | "duration">("time")
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc")
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+
+  const services = useMemo(() => uniqueSorted(rows.map((r) => r.service)), [rows])
+  const categories = useMemo(() => uniqueSorted(rows.map((r) => r.category)), [rows])
+
+  const filtered = useMemo(() => {
+    return rows.filter((r) => {
+      if (level !== "all" && r.level !== level) return false
+      if (service !== "all" && r.service !== service) return false
+      if (category !== "all" && r.category !== category) return false
+      return true
+    })
+  }, [rows, level, service, category])
+
+  const sorted = useMemo(() => {
+    const out = [...filtered]
+    out.sort((a, b) => {
+      const av = sortBy === "time" ? a.rel_ms : (a.duration_ms ?? -1)
+      const bv = sortBy === "time" ? b.rel_ms : (b.duration_ms ?? -1)
+      return sortDir === "asc" ? av - bv : bv - av
+    })
+    return out
+  }, [filtered, sortBy, sortDir])
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  if (rows.length === 0) {
+    return <div className="px-6 py-8 text-sm text-zinc-400">No observations for this session.</div>
+  }
+
+  return (
+    <div className="px-6 py-6 space-y-4">
+      <div className="flex flex-wrap gap-3 items-center text-xs">
+        <Filter label="Level" value={level} onChange={setLevel} options={["all", "ERROR", "OK"]} />
+        <Filter label="Service" value={service} onChange={setService} options={["all", ...services]} />
+        <Filter label="Category" value={category} onChange={setCategory} options={["all", ...categories]} />
+        <span className="text-zinc-500 ml-auto tabular-nums">
+          Showing {sorted.length.toLocaleString()} of {rows.length.toLocaleString()}
+        </span>
+      </div>
+
+      <table className="w-full text-xs border border-zinc-800 rounded overflow-hidden">
+        <thead className="bg-zinc-900 text-zinc-400 text-left">
+          <tr>
+            <th className="px-3 py-2 font-medium w-10"></th>
+            <SortHeader label="Time" active={sortBy === "time"} dir={sortDir} onClick={() => toggleSort("time")} />
+            <th className="px-3 py-2 font-medium">Level</th>
+            <th className="px-3 py-2 font-medium">Service</th>
+            <th className="px-3 py-2 font-medium">Category</th>
+            <th className="px-3 py-2 font-medium">Name</th>
+            <th className="px-3 py-2 font-medium">Summary</th>
+            <SortHeader
+              label="Dur"
+              active={sortBy === "duration"}
+              dir={sortDir}
+              onClick={() => toggleSort("duration")}
+              align="right"
+            />
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((r) => {
+            const isExpanded = expanded.has(r.span_id)
+            return (
+              <Fragment key={r.span_id}>
+                <tr
+                  className="border-t border-zinc-800 align-top cursor-pointer hover:bg-zinc-900/40"
+                  onClick={() => toggle(r.span_id)}
+                >
+                  <td className="px-3 py-2 text-zinc-500 select-none">{isExpanded ? "▾" : "▸"}</td>
+                  <td className="px-3 py-2 font-mono text-zinc-500 tabular-nums">
+                    +{r.rel_ms.toLocaleString()}ms
+                  </td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={[
+                        "rounded px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                        r.level === "ERROR"
+                          ? "bg-red-950 text-red-300 border border-red-900"
+                          : "bg-zinc-900 text-zinc-400 border border-zinc-800",
+                      ].join(" ")}
+                    >
+                      {r.level}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 text-zinc-300">{r.service}</td>
+                  <td className="px-3 py-2 text-zinc-300 font-mono">{r.category}</td>
+                  <td className="px-3 py-2 font-mono text-zinc-200">{r.name}</td>
+                  <td className="px-3 py-2 text-zinc-400 max-w-xs truncate">{r.summary}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-zinc-300">
+                    {r.duration_ms != null ? `${r.duration_ms}ms` : "—"}
+                  </td>
+                </tr>
+                {isExpanded && (
+                  <tr className="border-t border-zinc-900 bg-zinc-950">
+                    <td></td>
+                    <td colSpan={7} className="px-3 py-3">
+                      <pre className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded bg-zinc-900/50 border border-zinc-800 p-3 font-mono text-[11px] text-zinc-300">
+                        {prettyJson(r.attributes_json)}
+                      </pre>
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+
+  function toggleSort(col: "time" | "duration") {
+    if (sortBy === col) setSortDir(sortDir === "asc" ? "desc" : "asc")
+    else {
+      setSortBy(col)
+      setSortDir(col === "time" ? "asc" : "desc")
+    }
+  }
+}
+
+function Filter({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  options: string[]
+}) {
+  return (
+    <label className="flex items-center gap-2">
+      <span className="text-zinc-500 uppercase tracking-wide text-[10px]">{label}</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="bg-zinc-900 border border-zinc-800 rounded px-2 py-1 text-xs text-zinc-200"
+      >
+        {options.map((o) => (
+          <option key={o} value={o}>
+            {o}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function SortHeader({
+  label,
+  active,
+  dir,
+  onClick,
+  align,
+}: {
+  label: string
+  active: boolean
+  dir: "asc" | "desc"
+  onClick: () => void
+  align?: "left" | "right"
+}) {
+  return (
+    <th
+      onClick={onClick}
+      className={[
+        "px-3 py-2 font-medium cursor-pointer select-none",
+        align === "right" ? "text-right" : "",
+        active ? "text-zinc-100" : "",
+      ].join(" ")}
+    >
+      {label}
+      {active && <span className="ml-1 text-zinc-500">{dir === "asc" ? "↑" : "↓"}</span>}
+    </th>
+  )
+}
+
+function uniqueSorted(arr: string[]): string[] {
+  return Array.from(new Set(arr.filter(Boolean))).sort()
+}
+
+function prettyJson(raw: string | null): string {
+  if (!raw) return "(no attributes)"
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2)
+  } catch {
+    return raw
+  }
+}

--- a/tracing-ui/src/components/RawTab.tsx
+++ b/tracing-ui/src/components/RawTab.tsx
@@ -1,0 +1,65 @@
+import type { ObservationRow } from "@/lib/db"
+
+// Backwards-compatible "Raw" tab — the original flat observation table from
+// the v1 session-detail page. Kept so the debugging workflow of scrolling
+// through every span still exists alongside the richer tabs.
+export function RawTab({
+  observations,
+  sessionStartNs,
+}: {
+  observations: ObservationRow[]
+  sessionStartNs: number
+}) {
+  if (observations.length === 0) {
+    return <div className="px-6 py-8 text-sm text-zinc-400">No observations for this session.</div>
+  }
+
+  return (
+    <div className="px-6 py-6">
+      <p className="text-xs text-zinc-400 mb-3">
+        Flat list of every span across this session&apos;s traces. Same content as the Logs tab
+        minus the filter chrome.
+      </p>
+      <table className="w-full text-xs border border-zinc-800 rounded overflow-hidden">
+        <thead className="bg-zinc-900 text-zinc-400 text-left">
+          <tr>
+            <th className="px-3 py-2 font-medium">Start</th>
+            <th className="px-3 py-2 font-medium">Service</th>
+            <th className="px-3 py-2 font-medium">Name</th>
+            <th className="px-3 py-2 font-medium">Type</th>
+            <th className="px-3 py-2 font-medium">Model</th>
+            <th className="px-3 py-2 font-medium text-right">Duration</th>
+            <th className="px-3 py-2 font-medium text-right">Tokens</th>
+            <th className="px-3 py-2 font-medium text-right">Cost</th>
+          </tr>
+        </thead>
+        <tbody>
+          {observations.map((o) => (
+            <tr key={o.span_id} className="border-t border-zinc-800 align-top">
+              <td className="px-3 py-2 font-mono text-zinc-500 tabular-nums">
+                +{Math.round((o.start_time_ns - sessionStartNs) / 1e6)}ms
+              </td>
+              <td className="px-3 py-2">{o.service_name ?? "—"}</td>
+              <td className="px-3 py-2">{o.name ?? "—"}</td>
+              <td className="px-3 py-2">
+                {o.observation_type ?? <span className="text-zinc-600">SPAN</span>}
+              </td>
+              <td className="px-3 py-2 font-mono text-xs">{o.model ?? "—"}</td>
+              <td className="px-3 py-2 text-right tabular-nums">
+                {o.duration_ms != null ? `${o.duration_ms}ms` : "—"}
+              </td>
+              <td className="px-3 py-2 text-right tabular-nums">
+                {o.tokens_input != null || o.tokens_output != null
+                  ? `${o.tokens_input ?? 0}→${o.tokens_output ?? 0}`
+                  : "—"}
+              </td>
+              <td className="px-3 py-2 text-right tabular-nums">
+                {o.cost_usd != null && o.cost_usd > 0 ? `$${o.cost_usd.toFixed(4)}` : "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/tracing-ui/src/components/SessionTabs.tsx
+++ b/tracing-ui/src/components/SessionTabs.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link"
+
+export type TabKey =
+  | "transcript"
+  | "logs"
+  | "cost"
+  | "latency"
+  | "context"
+  | "raw"
+
+export const TABS: { key: TabKey; label: string }[] = [
+  { key: "transcript", label: "Transcript" },
+  { key: "logs", label: "Logs" },
+  { key: "cost", label: "Cost" },
+  { key: "latency", label: "Latency" },
+  { key: "context", label: "Context" },
+  { key: "raw", label: "Raw" },
+]
+
+export function SessionTabs({ sessionId, active }: { sessionId: string; active: TabKey }) {
+  const base = `/sessions/${encodeURIComponent(sessionId)}`
+  return (
+    <div className="flex gap-1 border-b border-zinc-800 px-1">
+      {TABS.map((t) => {
+        const isActive = t.key === active
+        return (
+          <Link
+            key={t.key}
+            href={`${base}?tab=${t.key}`}
+            prefetch={false}
+            className={[
+              "px-4 py-2 text-sm border-b-2 -mb-px transition-colors",
+              isActive
+                ? "border-blue-400 text-zinc-100"
+                : "border-transparent text-zinc-400 hover:text-zinc-200",
+            ].join(" ")}
+          >
+            {t.label}
+          </Link>
+        )
+      })}
+    </div>
+  )
+}

--- a/tracing-ui/src/components/TranscriptTab.tsx
+++ b/tracing-ui/src/components/TranscriptTab.tsx
@@ -1,0 +1,113 @@
+import type { VoiceTurn } from "@/lib/db"
+
+export function TranscriptTab({
+  turns,
+  sessionStartNs,
+}: {
+  turns: VoiceTurn[]
+  sessionStartNs: number
+}) {
+  if (turns.length === 0) {
+    return (
+      <div className="px-6 py-8 text-sm text-zinc-400">
+        No <code className="rounded bg-zinc-900 px-1">voice-turn</code> spans on this session.
+        Transcript is derived from those — make sure the relay is emitting them.
+      </div>
+    )
+  }
+
+  return (
+    <div className="px-6 py-6 space-y-8 max-w-3xl">
+      {turns.map((turn, idx) => (
+        <TurnBlock key={turn.span_id} turn={turn} index={idx + 1} sessionStartNs={sessionStartNs} />
+      ))}
+    </div>
+  )
+}
+
+function TurnBlock({
+  turn,
+  index,
+  sessionStartNs,
+}: {
+  turn: VoiceTurn
+  index: number
+  sessionStartNs: number
+}) {
+  const relMs = Math.max(0, Math.round((turn.start_time_ns - sessionStartNs) / 1e6))
+  const sys = turn.input_messages.find((m) => m.role === "system")
+  const userMsgs = turn.input_messages.filter((m) => m.role === "user")
+  const userText = userMsgs.map((m) => m.content).join("\n\n")
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-3 text-xs text-zinc-500">
+        <span className="rounded bg-zinc-900 px-2 py-0.5 text-zinc-400">Turn {index}</span>
+        <span className="font-mono tabular-nums">+{formatOffset(relMs)}</span>
+        {turn.duration_ms != null && (
+          <span className="tabular-nums text-zinc-600">· {turn.duration_ms}ms</span>
+        )}
+        {turn.model && <span className="font-mono text-zinc-600">· {turn.model}</span>}
+      </div>
+
+      {sys && <SystemBubble text={sys.content} />}
+
+      {userText && <Bubble role="user" text={userText} />}
+
+      {turn.output_text && <Bubble role="assistant" text={turn.output_text} />}
+
+      {!userText && !turn.output_text && (
+        <div className="text-xs text-zinc-500 italic">
+          This turn has no captured text. Check raw attributes on the{" "}
+          <code className="rounded bg-zinc-900 px-1">voice-turn</code> span.
+        </div>
+      )}
+    </div>
+  )
+}
+
+function SystemBubble({ text }: { text: string }) {
+  // Collapsible <details> keeps the system prompt out of the way but one click
+  // away. Dark-mode-friendly styling to match the rest of the app.
+  return (
+    <details className="rounded border border-zinc-800 bg-zinc-950/50 text-xs">
+      <summary className="cursor-pointer select-none px-3 py-2 text-zinc-400 hover:text-zinc-200">
+        System prompt{" "}
+        <span className="text-zinc-600 tabular-nums">({text.length.toLocaleString()} chars)</span>
+      </summary>
+      <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words border-t border-zinc-800 px-3 py-2 font-mono text-[11px] text-zinc-400">
+        {text}
+      </pre>
+    </details>
+  )
+}
+
+function Bubble({ role, text }: { role: "user" | "assistant"; text: string }) {
+  const isUser = role === "user"
+  return (
+    <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+      <div
+        className={[
+          "max-w-[85%] rounded-2xl px-4 py-2 text-sm whitespace-pre-wrap break-words",
+          isUser
+            ? "bg-blue-600/20 border border-blue-500/30 text-zinc-50"
+            : "bg-zinc-900 border border-zinc-800 text-zinc-100",
+        ].join(" ")}
+      >
+        <div className="mb-1 text-[10px] uppercase tracking-wide text-zinc-500">
+          {isUser ? "User" : "Assistant"}
+        </div>
+        <div>{text}</div>
+      </div>
+    </div>
+  )
+}
+
+function formatOffset(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const s = ms / 1000
+  if (s < 60) return `${s.toFixed(1)}s`
+  const m = Math.floor(s / 60)
+  const rem = Math.round(s - m * 60)
+  return `${m}m${rem.toString().padStart(2, "0")}s`
+}

--- a/tracing-ui/src/lib/context-breakdown.ts
+++ b/tracing-ui/src/lib/context-breakdown.ts
@@ -1,0 +1,334 @@
+// Parses the `langfuse.observation.input` chat array on an openclaw.llm span
+// and breaks it down into the sections we care about for the context-token
+// breakdown tab: system prompt, workspace bootstrap, tool definitions, user
+// message, conversation history.
+//
+// Section sizes are reported in characters plus an estimated token count
+// (chars / 4 — rough but fine for a relative-sized bar). When the provider
+// reports real token totals via usage_details we surface those alongside.
+
+export type ContextSection = {
+  kind: "system" | "workspace_bootstrap" | "tools" | "history" | "user" | "other"
+  label: string
+  chars: number
+  tokens_est: number
+  detail?: string
+}
+
+export type ContextBreakdown = {
+  sections: ContextSection[]
+  total_chars: number
+  total_tokens_est: number
+  provider_tokens?: {
+    input: number
+    output: number
+    total: number
+    cached: number
+  }
+  cache_hit_pct: number | null
+}
+
+// Approximate tokens-per-char for English LLM content. Good enough for visual
+// ratio bars; real counts come from provider usage_details where available.
+const CHARS_PER_TOKEN = 4
+
+export function parseContextBreakdown(
+  input: unknown,
+  usageDetailsRaw: unknown,
+  extraCacheAttrs?: { read?: number; creation?: number },
+): ContextBreakdown {
+  const messages = normaliseMessages(input)
+  const sections: ContextSection[] = []
+
+  // Walk through messages. The layout we expect from openclaw:
+  //   [system, ...history, user]
+  // The "system" message contains the full system prompt + tooling rules +
+  // workspace bootstrap merged as plain text. We try to split that up.
+  if (messages.length === 0) {
+    return emptyBreakdown(usageDetailsRaw, extraCacheAttrs)
+  }
+
+  // First system message — split into system prompt vs workspace bootstrap.
+  const firstSystem = messages.find((m) => m.role === "system")
+  if (firstSystem) {
+    const split = splitSystemMessage(firstSystem.content)
+    sections.push({
+      kind: "system",
+      label: "System prompt",
+      chars: split.systemChars,
+      tokens_est: Math.round(split.systemChars / CHARS_PER_TOKEN),
+      detail: split.systemPreview,
+    })
+    if (split.bootstrapChars > 0) {
+      sections.push({
+        kind: "workspace_bootstrap",
+        label: "Workspace bootstrap",
+        chars: split.bootstrapChars,
+        tokens_est: Math.round(split.bootstrapChars / CHARS_PER_TOKEN),
+        detail: split.bootstrapPreview,
+      })
+    }
+    if (split.toolsChars > 0) {
+      sections.push({
+        kind: "tools",
+        label: "Tool definitions",
+        chars: split.toolsChars,
+        tokens_est: Math.round(split.toolsChars / CHARS_PER_TOKEN),
+      })
+    }
+  }
+
+  // Conversation history = everything except system and the final user turn.
+  const nonSystem = messages.filter((m) => m.role !== "system")
+  const lastUserIdx = nonSystem.findLastIndex((m) => m.role === "user")
+  const history = lastUserIdx >= 0 ? nonSystem.slice(0, lastUserIdx) : nonSystem
+  const current = lastUserIdx >= 0 ? nonSystem[lastUserIdx] : null
+
+  if (history.length > 0) {
+    const historyChars = history.reduce((acc, m) => acc + m.content.length, 0)
+    sections.push({
+      kind: "history",
+      label: `Conversation history (${history.length} msg)`,
+      chars: historyChars,
+      tokens_est: Math.round(historyChars / CHARS_PER_TOKEN),
+    })
+  }
+
+  if (current) {
+    sections.push({
+      kind: "user",
+      label: "Current user message",
+      chars: current.content.length,
+      tokens_est: Math.round(current.content.length / CHARS_PER_TOKEN),
+      detail: current.content.slice(0, 240),
+    })
+  }
+
+  const total_chars = sections.reduce((acc, s) => acc + s.chars, 0)
+  const total_tokens_est = sections.reduce((acc, s) => acc + s.tokens_est, 0)
+
+  const providerTokens = parseUsageDetails(usageDetailsRaw, extraCacheAttrs)
+  const cache_hit_pct =
+    providerTokens && providerTokens.input > 0
+      ? (providerTokens.cached / providerTokens.input) * 100
+      : null
+
+  return {
+    sections,
+    total_chars,
+    total_tokens_est,
+    provider_tokens: providerTokens ?? undefined,
+    cache_hit_pct,
+  }
+}
+
+export type Role = "system" | "user" | "assistant" | "tool" | (string & {})
+export type NormalisedMessage = { role: Role; content: string }
+
+export function normaliseMessages(raw: unknown): NormalisedMessage[] {
+  if (raw == null) return []
+  if (typeof raw === "string") {
+    const parsed = safeJsonParse(raw)
+    if (parsed == null) return [{ role: "user", content: raw }]
+    return normaliseMessages(parsed)
+  }
+  if (Array.isArray(raw)) {
+    return raw
+      .map((m) => {
+        if (m && typeof m === "object") {
+          const obj = m as Record<string, unknown>
+          const role = typeof obj.role === "string" ? obj.role : "user"
+          const content = contentToText(obj.content)
+          return { role, content }
+        }
+        return { role: "user", content: String(m) }
+      })
+      .filter((m) => m.content.length > 0)
+  }
+  if (typeof raw === "object") {
+    const obj = raw as Record<string, unknown>
+    if (typeof obj.role === "string") {
+      return [{ role: obj.role, content: contentToText(obj.content) }]
+    }
+  }
+  return []
+}
+
+// Rough sectional split of the system message. openclaw's system prompt has a
+// stable shape: <system prompt text> then a "<workspace-bootstrap>...</>" or
+// "# Dynamic Project Context" block for MEMORY.md injections, and sometimes
+// an "# Tools" or "# Tool definitions" block. We use regex fingerprints
+// instead of a hard AST parse so the heuristics degrade gracefully.
+type SystemSplit = {
+  systemChars: number
+  systemPreview: string
+  bootstrapChars: number
+  bootstrapPreview: string
+  toolsChars: number
+}
+
+function splitSystemMessage(content: string): SystemSplit {
+  let remaining = content
+  let bootstrapChars = 0
+  let bootstrapPreview = ""
+
+  // 1. Explicit <workspace-bootstrap>…</workspace-bootstrap> block.
+  const wsMatch = remaining.match(/<workspace-bootstrap>[\s\S]*?<\/workspace-bootstrap>/i)
+  if (wsMatch) {
+    bootstrapChars = wsMatch[0].length
+    bootstrapPreview = wsMatch[0].slice(0, 200)
+    remaining = remaining.replace(wsMatch[0], "")
+  } else {
+    // 2. Look for `MEMORY.md:` or "Dynamic Project Context" section.
+    const memIdx = remaining.search(/(^|\n)#{0,3}\s*Dynamic Project Context\b/i)
+    const mdIdx = remaining.search(/\bMEMORY\.md(\s*:|\s*\n)/)
+    const boundary = [memIdx, mdIdx].filter((i) => i >= 0).sort((a, b) => a - b)[0]
+    if (boundary != null && boundary >= 0) {
+      const bootstrap = remaining.slice(boundary)
+      bootstrapChars = bootstrap.length
+      bootstrapPreview = bootstrap.slice(0, 200)
+      remaining = remaining.slice(0, boundary)
+    }
+  }
+
+  // 3. Tool definitions block: a hand-full of common fingerprints from the
+  //    openclaw/Anthropic tool-injection style. We look for the first
+  //    contiguous tool-definitions region and strip it.
+  let toolsChars = 0
+  const toolMatch = remaining.match(/##\s*Tool(ing| definitions| Call Style)[\s\S]*?(?=\n##\s|\n#\s|$)/i)
+  if (toolMatch) {
+    toolsChars = toolMatch[0].length
+    remaining = remaining.replace(toolMatch[0], "")
+  }
+
+  return {
+    systemChars: remaining.length,
+    systemPreview: remaining.slice(0, 200),
+    bootstrapChars,
+    bootstrapPreview,
+    toolsChars,
+  }
+}
+
+function contentToText(raw: unknown): string {
+  if (raw == null) return ""
+  if (typeof raw === "string") return raw
+  if (Array.isArray(raw)) {
+    return raw
+      .map((b) => {
+        if (b && typeof b === "object") {
+          const bb = b as Record<string, unknown>
+          if (typeof bb.text === "string") return bb.text
+          if (typeof bb.content === "string") return bb.content
+        }
+        return typeof b === "string" ? b : ""
+      })
+      .filter(Boolean)
+      .join("\n")
+  }
+  if (typeof raw === "object") {
+    const obj = raw as Record<string, unknown>
+    if (typeof obj.text === "string") return obj.text
+    if (typeof obj.content === "string") return obj.content
+    return JSON.stringify(raw)
+  }
+  return String(raw)
+}
+
+function safeJsonParse(s: string): unknown {
+  try {
+    return JSON.parse(s)
+  } catch {
+    return null
+  }
+}
+
+type ProviderTokens = { input: number; output: number; total: number; cached: number }
+
+function parseUsageDetails(
+  raw: unknown,
+  extra?: { read?: number; creation?: number },
+): ProviderTokens | null {
+  let input = 0
+  let output = 0
+  let total = 0
+  let cached = 0
+  let matched = false
+
+  const usage = coerceJsonObject(raw)
+  if (usage) {
+    const i = pickNumber(usage, ["input", "input_tokens", "prompt_tokens"])
+    const o = pickNumber(usage, ["output", "output_tokens", "completion_tokens"])
+    const t = pickNumber(usage, ["total", "total_tokens"])
+    const c = pickNumber(usage, [
+      "cache_read",
+      "cache_read_input_tokens",
+      "cached",
+      "cached_tokens",
+      "input_cached",
+    ])
+    if (i != null) {
+      input = i
+      matched = true
+    }
+    if (o != null) {
+      output = o
+      matched = true
+    }
+    if (t != null) total = t
+    if (c != null) cached = c
+  }
+
+  if (extra?.read != null) {
+    cached = Math.max(cached, extra.read)
+    matched = true
+  }
+  if (extra?.creation != null && input === 0) {
+    // If only creation-tokens are known, treat as fresh input.
+    input = extra.creation
+    matched = true
+  }
+
+  if (!matched) return null
+  if (total === 0) total = input + output
+  return { input, output, total, cached }
+}
+
+function coerceJsonObject(raw: unknown): Record<string, unknown> | null {
+  if (raw == null) return null
+  if (typeof raw === "string") {
+    const parsed = safeJsonParse(raw)
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+    return null
+  }
+  if (typeof raw === "object" && !Array.isArray(raw)) return raw as Record<string, unknown>
+  return null
+}
+
+function pickNumber(obj: Record<string, unknown>, keys: string[]): number | null {
+  for (const k of keys) {
+    const v = obj[k]
+    if (typeof v === "number" && !Number.isNaN(v)) return v
+    if (typeof v === "string" && v.trim() !== "" && !Number.isNaN(Number(v))) return Number(v)
+  }
+  return null
+}
+
+function emptyBreakdown(
+  usageDetailsRaw: unknown,
+  extraCacheAttrs?: { read?: number; creation?: number },
+): ContextBreakdown {
+  const providerTokens = parseUsageDetails(usageDetailsRaw, extraCacheAttrs)
+  return {
+    sections: [],
+    total_chars: 0,
+    total_tokens_est: 0,
+    provider_tokens: providerTokens ?? undefined,
+    cache_hit_pct:
+      providerTokens && providerTokens.input > 0
+        ? (providerTokens.cached / providerTokens.input) * 100
+        : null,
+  }
+}

--- a/tracing-ui/src/lib/db.ts
+++ b/tracing-ui/src/lib/db.ts
@@ -168,3 +168,131 @@ export function listObservationsForSession(sessionId: string): ObservationRow[] 
     `)
     .all(sessionId) as ObservationRow[]
 }
+
+// Grouped fetch: traces for the session with their observations nested under
+// each trace. Returned in trace-start order, observations in span-start order.
+export type TraceWithObservations = TraceRow & { observations: ObservationRow[] }
+
+export function listTracesWithObservationsForSession(sessionId: string): TraceWithObservations[] {
+  const traces = listTracesForSession(sessionId)
+  if (traces.length === 0) return []
+  const byTrace = new Map<string, ObservationRow[]>()
+  for (const t of traces) byTrace.set(t.trace_id, [])
+  const obs = listObservationsForSession(sessionId)
+  for (const o of obs) {
+    const bucket = byTrace.get(o.trace_id)
+    if (bucket) bucket.push(o)
+  }
+  return traces.map((t) => ({ ...t, observations: byTrace.get(t.trace_id) ?? [] }))
+}
+
+// Voice-turn spans only, with parsed input/output. The `voice-turn` span is
+// emitted once per turn by the relay and carries the user utterance (input as
+// chat-format JSON) and the assistant reply (output as plain text or JSON).
+export type VoiceTurn = {
+  trace_id: string
+  span_id: string
+  start_time_ns: number
+  end_time_ns: number | null
+  duration_ms: number | null
+  status_code: string | null
+  model: string | null
+  // Parsed messages from langfuse.observation.input — usually a JSON array of
+  // {role, content} messages, though callers may send a single string.
+  input_messages: ChatMessage[]
+  // Parsed output — string by default, but some services emit JSON.
+  output_text: string
+  attributes: Record<string, unknown>
+}
+
+export type ChatMessage = {
+  role: string
+  content: string
+}
+
+export function getVoiceTurnsForSession(sessionId: string): VoiceTurn[] {
+  const obs = listObservationsForSession(sessionId).filter((o) => o.name === "voice-turn")
+  return obs.map((o) => {
+    const attrs = parseJson<Record<string, unknown>>(o.attributes_json) ?? {}
+    const rawInput = (attrs["langfuse.observation.input"] as unknown) ?? null
+    const rawOutput = (attrs["langfuse.observation.output"] as unknown) ?? null
+    return {
+      trace_id: o.trace_id,
+      span_id: o.span_id,
+      start_time_ns: o.start_time_ns,
+      end_time_ns: o.end_time_ns,
+      duration_ms: o.duration_ms,
+      status_code: o.status_code,
+      model: o.model,
+      input_messages: coerceMessages(rawInput),
+      output_text: coerceText(rawOutput),
+      attributes: attrs,
+    }
+  })
+}
+
+function parseJson<T>(s: string | null | undefined): T | null {
+  if (!s) return null
+  try {
+    return JSON.parse(s) as T
+  } catch {
+    return null
+  }
+}
+
+function coerceMessages(raw: unknown): ChatMessage[] {
+  if (raw == null) return []
+  // langfuse stores input as a string-encoded JSON blob in attributes_json.
+  if (typeof raw === "string") {
+    const parsed = parseJson<unknown>(raw)
+    if (parsed == null) return [{ role: "user", content: raw }]
+    return coerceMessages(parsed)
+  }
+  if (Array.isArray(raw)) {
+    return raw
+      .map((m) => {
+        if (m && typeof m === "object") {
+          const role = String((m as { role?: unknown }).role ?? "user")
+          const content = coerceText((m as { content?: unknown }).content)
+          return { role, content }
+        }
+        return { role: "user", content: coerceText(m) }
+      })
+      .filter((m) => m.content.length > 0)
+  }
+  if (typeof raw === "object") {
+    const obj = raw as Record<string, unknown>
+    if (typeof obj.role === "string") {
+      return [{ role: obj.role, content: coerceText(obj.content) }]
+    }
+    return [{ role: "user", content: JSON.stringify(raw) }]
+  }
+  return [{ role: "user", content: String(raw) }]
+}
+
+function coerceText(raw: unknown): string {
+  if (raw == null) return ""
+  if (typeof raw === "string") return raw
+  if (Array.isArray(raw)) {
+    // Anthropic-style content blocks: [{type:"text", text:"…"}]
+    return raw
+      .map((b) => {
+        if (b && typeof b === "object") {
+          const bb = b as Record<string, unknown>
+          if (typeof bb.text === "string") return bb.text
+          if (typeof bb.content === "string") return bb.content
+        }
+        if (typeof b === "string") return b
+        return ""
+      })
+      .filter(Boolean)
+      .join("\n")
+  }
+  if (typeof raw === "object") {
+    const obj = raw as Record<string, unknown>
+    if (typeof obj.text === "string") return obj.text
+    if (typeof obj.content === "string") return obj.content
+    return JSON.stringify(raw)
+  }
+  return String(raw)
+}

--- a/tracing-ui/src/lib/pricing.ts
+++ b/tracing-ui/src/lib/pricing.ts
@@ -40,12 +40,22 @@ export type PricingCatalog = Record<string, ModelEntry>
 // Fallback table for models/modalities models.dev either doesn't cover or
 // undercounts. Keep minimal and override-friendly (extend as new costs come
 // up). Values are $/MTok.
+//
+// Realtime/live voice models are priced at their AUDIO rate — the dominant
+// modality for this app. Text-only reasoning models (Claude) use their
+// standard text rates.
 const FALLBACK_PRICING: PricingCatalog = {
-  "gemini-2.5-flash-native-audio": { id: "gemini-2.5-flash-native-audio", cost: { input: 3, output: 12 } },
-  "gemini-live-2.5-flash": { id: "gemini-live-2.5-flash", cost: { input: 0.5, output: 2 } },
-  "gpt-4o-realtime-preview": { id: "gpt-4o-realtime-preview", cost: { input: 5, output: 20 } },
+  // Google Gemini — realtime / live only
+  "gemini-3.1-flash-live-preview": { id: "gemini-3.1-flash-live-preview", cost: { input: 3, output: 12 } },
+
+  // OpenAI Realtime
+  "gpt-realtime": { id: "gpt-realtime", cost: { input: 32, output: 64, cache_read: 0.4 } },
+  "gpt-realtime-mini": { id: "gpt-realtime-mini", cost: { input: 10, output: 20, cache_read: 0.3 } },
+
+  // Anthropic Claude (text)
+  "claude-opus-4-7": { id: "claude-opus-4-7", cost: { input: 5, output: 25, cache_read: 0.5, cache_write: 6.25 } },
+  "claude-sonnet-4-6": { id: "claude-sonnet-4-6", cost: { input: 3, output: 15, cache_read: 0.3, cache_write: 3.75 } },
   "claude-haiku-4-5": { id: "claude-haiku-4-5", cost: { input: 1, output: 5, cache_read: 0.1, cache_write: 1.25 } },
-  "claude-sonnet-4-5": { id: "claude-sonnet-4-5", cost: { input: 3, output: 15, cache_read: 0.3, cache_write: 3.75 } },
 }
 
 let cached: { at: number; catalog: PricingCatalog } | null = null

--- a/tracing-ui/src/lib/pricing.ts
+++ b/tracing-ui/src/lib/pricing.ts
@@ -1,0 +1,168 @@
+// Server-only pricing helpers. Fetches the models.dev catalog once per app
+// lifetime, caches to `~/.voiceclaw/pricing_cache.json` so we don't re-fetch on
+// every dev reload, and exposes a few small cost-computation helpers used by
+// the cost breakdown tab.
+//
+// The tracing-collector already writes a `cost_usd` column onto each
+// observation for models it recognises. This module is a best-effort
+// complement: for spans that don't carry a resolved cost (e.g. Gemini Live
+// audio tokens) we look up the model in the cached catalog and estimate.
+
+import { promises as fs } from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+
+const CACHE_PATH = join(homedir(), ".voiceclaw", "pricing_cache.json")
+const CATALOG_URL = "https://models.dev/api/models"
+// Don't refetch more than once every 24h — the catalog is slow-moving and the
+// collector side also refreshes, so being aggressive here is pointless.
+const REFRESH_MS = 24 * 60 * 60 * 1000
+
+// models.dev returns a provider→models map. The per-model shape we care about
+// is the `cost` record: { input, output, cache_read?, cache_write? } in $/MTok.
+export type ModelEntry = {
+  id: string
+  name?: string
+  cost?: {
+    input?: number
+    output?: number
+    cache_read?: number
+    cache_write?: number
+  }
+  modalities?: {
+    input?: string[]
+    output?: string[]
+  }
+}
+
+export type PricingCatalog = Record<string, ModelEntry>
+
+// Fallback table for models/modalities models.dev either doesn't cover or
+// undercounts. Keep minimal and override-friendly (extend as new costs come
+// up). Values are $/MTok.
+const FALLBACK_PRICING: PricingCatalog = {
+  "gemini-2.5-flash-native-audio": { id: "gemini-2.5-flash-native-audio", cost: { input: 3, output: 12 } },
+  "gemini-live-2.5-flash": { id: "gemini-live-2.5-flash", cost: { input: 0.5, output: 2 } },
+  "gpt-4o-realtime-preview": { id: "gpt-4o-realtime-preview", cost: { input: 5, output: 20 } },
+  "claude-haiku-4-5": { id: "claude-haiku-4-5", cost: { input: 1, output: 5, cache_read: 0.1, cache_write: 1.25 } },
+  "claude-sonnet-4-5": { id: "claude-sonnet-4-5", cost: { input: 3, output: 15, cache_read: 0.3, cache_write: 3.75 } },
+}
+
+let cached: { at: number; catalog: PricingCatalog } | null = null
+let inflight: Promise<PricingCatalog> | null = null
+
+export async function loadPricingCatalog(): Promise<PricingCatalog> {
+  if (cached && Date.now() - cached.at < REFRESH_MS) return cached.catalog
+  if (inflight) return inflight
+  inflight = doLoad().finally(() => {
+    inflight = null
+  })
+  return inflight
+}
+
+export type CostDetail = {
+  input_usd: number
+  output_usd: number
+  cache_read_usd: number
+  total_usd: number
+  model_matched: boolean
+}
+
+// Compute USD cost from token counts + a model id. Falls back to 0 if the
+// model isn't in the catalog and we don't have a fallback. `cached_input` is
+// counted at the cache_read rate (if provided) rather than the full input
+// rate — matches Anthropic/OpenAI billing.
+export function computeCost(
+  catalog: PricingCatalog,
+  modelId: string | null | undefined,
+  tokens: { input: number; output: number; cached?: number },
+): CostDetail {
+  const zero: CostDetail = {
+    input_usd: 0,
+    output_usd: 0,
+    cache_read_usd: 0,
+    total_usd: 0,
+    model_matched: false,
+  }
+  if (!modelId) return zero
+  const entry = catalog[modelId] ?? FALLBACK_PRICING[modelId]
+  if (!entry?.cost) return zero
+  const { input = 0, output = 0, cache_read } = entry.cost
+  const cached = tokens.cached ?? 0
+  const fresh = Math.max(0, tokens.input - cached)
+  const input_usd = (fresh / 1_000_000) * input
+  const cache_read_usd = cache_read != null ? (cached / 1_000_000) * cache_read : 0
+  const output_usd = (tokens.output / 1_000_000) * output
+  const total_usd = input_usd + output_usd + cache_read_usd
+  return { input_usd, output_usd, cache_read_usd, total_usd, model_matched: true }
+}
+
+async function doLoad(): Promise<PricingCatalog> {
+  // Try the on-disk cache first so cold starts don't stall on the network.
+  const disk = await readDiskCache()
+  if (disk && Date.now() - disk.at < REFRESH_MS) {
+    cached = disk
+    return disk.catalog
+  }
+  // Fetch fresh — but on failure fall back to whatever we had on disk, or the
+  // fallback table. We don't want a network blip to break the UI.
+  try {
+    const catalog = await fetchCatalog()
+    const record = { at: Date.now(), catalog }
+    cached = record
+    await writeDiskCache(record).catch(() => {})
+    return catalog
+  } catch {
+    if (disk) {
+      cached = disk
+      return disk.catalog
+    }
+    cached = { at: Date.now(), catalog: FALLBACK_PRICING }
+    return FALLBACK_PRICING
+  }
+}
+
+async function fetchCatalog(): Promise<PricingCatalog> {
+  const res = await fetch(CATALOG_URL, { headers: { accept: "application/json" } })
+  if (!res.ok) throw new Error(`models.dev ${res.status}`)
+  const raw = (await res.json()) as unknown
+  return flattenCatalog(raw)
+}
+
+// models.dev returns { providerId: { models: { modelId: ModelEntry } } }.
+// Flatten to a flat id→entry map so lookups match the `gen_ai.request.model`
+// value written into our spans (which is just the short model id).
+function flattenCatalog(raw: unknown): PricingCatalog {
+  const out: PricingCatalog = {}
+  if (!raw || typeof raw !== "object") return out
+  const providers = raw as Record<string, unknown>
+  for (const providerValue of Object.values(providers)) {
+    if (!providerValue || typeof providerValue !== "object") continue
+    const models = (providerValue as { models?: unknown }).models
+    if (!models || typeof models !== "object") continue
+    for (const [id, entry] of Object.entries(models as Record<string, unknown>)) {
+      if (entry && typeof entry === "object") {
+        out[id] = { id, ...(entry as Omit<ModelEntry, "id">) }
+      }
+    }
+  }
+  // Layer fallbacks on top so our hand-tuned entries win over empty/partial
+  // catalog rows.
+  return { ...out, ...FALLBACK_PRICING }
+}
+
+async function readDiskCache(): Promise<{ at: number; catalog: PricingCatalog } | null> {
+  try {
+    const raw = await fs.readFile(CACHE_PATH, "utf8")
+    const parsed = JSON.parse(raw) as { at?: number; catalog?: PricingCatalog }
+    if (!parsed?.catalog || typeof parsed.at !== "number") return null
+    return { at: parsed.at, catalog: parsed.catalog }
+  } catch {
+    return null
+  }
+}
+
+async function writeDiskCache(record: { at: number; catalog: PricingCatalog }): Promise<void> {
+  await fs.mkdir(dirname(CACHE_PATH), { recursive: true })
+  await fs.writeFile(CACHE_PATH, JSON.stringify(record), "utf8")
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3076,6 +3076,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@kurkle/color@npm:^0.3.0":
+  version: 0.3.4
+  resolution: "@kurkle/color@npm:0.3.4"
+  checksum: 10c0/0e9fd55c614b005c5f0c4c755bca19ec0293bc7513b4ea3ec1725234f9c2fa81afbc78156baf555c8b9cb0d305619253c3f5bca016067daeebb3d00ebb4ea683
+  languageName: node
+  linkType: hard
+
 "@langfuse/core@npm:^5.1.0":
   version: 5.1.0
   resolution: "@langfuse/core@npm:5.1.0"
@@ -8067,6 +8074,15 @@ __metadata:
   version: 2.0.1
   resolution: "character-reference-invalid@npm:2.0.1"
   checksum: 10c0/2ae0dec770cd8659d7e8b0ce24392d83b4c2f0eb4a3395c955dce5528edd4cc030a794cfa06600fcdd700b3f2de2f9b8e40e309c0011c4180e3be64a0b42e6a1
+  languageName: node
+  linkType: hard
+
+"chart.js@npm:^4.4.7":
+  version: 4.5.1
+  resolution: "chart.js@npm:4.5.1"
+  dependencies:
+    "@kurkle/color": "npm:^0.3.0"
+  checksum: 10c0/3f2a11dcaae9079e8e6b8ad077e2ae311f04996f9da14815730891e66215ee8b5f2c0eb70b5a156e5bde0f89a41bae13506dc6153e50fd22dcb282b21eec706f
   languageName: node
   linkType: hard
 
@@ -17318,6 +17334,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-chartjs-2@npm:^5.3.0":
+  version: 5.3.1
+  resolution: "react-chartjs-2@npm:5.3.1"
+  peerDependencies:
+    chart.js: ^4.1.1
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/40fac3fe23a163232d952bf5cd2a14d7baceadea326b57909d5e556ed2481b7cfb177582ac8f39b8dc51ac11f3d19a6127784746f35f5771181ab700110e7326
+  languageName: node
+  linkType: hard
+
 "react-devtools-core@npm:^6.1.5":
   version: 6.1.5
   resolution: "react-devtools-core@npm:6.1.5"
@@ -21016,9 +21042,11 @@ __metadata:
     "@types/react-dom": "npm:^19.0.0"
     autoprefixer: "npm:^10.4.20"
     better-sqlite3: "npm:^12.0.0"
+    chart.js: "npm:^4.4.7"
     next: "npm:^15.1.0"
     postcss: "npm:^8.5.1"
     react: "npm:^19.0.0"
+    react-chartjs-2: "npm:^5.3.0"
     react-dom: "npm:^19.0.0"
     tailwindcss: "npm:^3.4.17"
     typescript: "npm:^5.7.2"


### PR DESCRIPTION
## Summary

Stacks on top of PR #171 to turn the session detail page into a Vapi-style debugging surface. Six tabs, all hung off `/sessions/[id]?tab=…` so state survives reloads and deep-links work.

- **Transcript** — alternating user / assistant bubbles per `voice-turn` span with relative timestamps and a collapsible system-prompt bubble per turn.
- **Logs** — filterable + sortable observation table (level / service / category) with expandable JSON attribute viewer per row.
- **Cost** — Chart.js donut of cost by category: Realtime AI (voice-turn) + Brain LLM (openclaw.llm), with STT/TTS placeholders. Falls back to a local models.dev catalog + disk cache (`~/.voiceclaw/pricing_cache.json`) when the collector didn't resolve `cost_usd` (e.g. Claude Haiku rates for now).
- **Latency** — overall stacked bar + per-turn breakdown by Endpointing / Voice / Transcriber / LLM realtime / Brain async / To-Transport, mapped off span names.
- **Context** — per-brain-turn stacked bar showing relative sizes of system prompt / workspace bootstrap / tool definitions / user message. Cache-utilisation bar per turn (green = `cache_read_input_tokens`, orange = fresh) plus a session-wide cache-hit gauge.
- **Raw** — preserves the v1 flat observation table so the original debugging workflow still works.

## New libs

- `tracing-ui/src/lib/pricing.ts` — models.dev loader, 24h on-disk cache, fallback table for models where the catalog undercounts (Gemini Live audio / Claude Haiku cache rates).
- `tracing-ui/src/lib/context-breakdown.ts` — parses `langfuse.observation.input` into system / workspace bootstrap / tools / history / user sections via regex fingerprints, plus provider-token parsing from `usage_details` + `gen_ai.usage.cache_*`.
- `tracing-ui/src/lib/db.ts` — `listTracesWithObservationsForSession` (nested) and `getVoiceTurnsForSession` (parsed chat input/output).

## Design choices (ambiguous bits)

- **Tabs via search param** instead of nested route segments: keeps server-component streaming simple and avoids a layout.tsx rewrite for one feature.
- **Latency category mapping is name-based** (`endpoint` / `tts` / `stt` / `voice-turn` / `openclaw.*`) — the relay doesn't tag span categories explicitly yet. Unknown spans fall into "To-Transport" so they're visible but don't mislabel.
- **Cost falls back to pricing.ts** when `cost_usd` is 0 on a span. Right now the collector doesn't write Claude Haiku costs, so the Cost tab shows real $ via the fallback table; once the collector catches up the fallback becomes redundant.
- **Context breakdown estimates tokens at chars/4** when the provider doesn't report per-section counts. Labelled "Tokens (est)" in the UI to make that clear.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Dev server (port 4320) renders all six tabs against the live `~/.voiceclaw/tracing.db` — smoke-tested via Playwright, no console errors after key-prop fix
- [x] Cost tab resolves Haiku pricing from fallback table ($0.0264 for the e2e test session, matches 25,885 in / 94 out at $1/MTok input, $5/MTok output)
- [x] Context tab correctly splits the openclaw system prompt into System (67%) / Workspace bootstrap (29%) / Tools (3%) / User (<1%)
- [ ] Test against a production session with real cache-hit data (all test data here is fresh-input only)
- [ ] Test with multi-turn sessions (all current test data has a single voice-turn)

## Gotchas

- `better-sqlite3` in this worktree had to be rebuilt for node v25 after `yarn install` — the existing build was for v24. If you pull this branch and hit a `NODE_MODULE_VERSION` error, `yarn rebuild better-sqlite3`.
- Screenshots are in the agent transcript, not attached — MCP playwright screenshots don't persist to disk in this env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)