### PR TITLE
refactor(tracing-ui): migrate reader from raw SQL to Prisma

### DIFF
--- a/tracing-ui/.env.example
+++ b/tracing-ui/.env.example
@@ -1,0 +1,4 @@
+# Prisma datasource for the tracing-ui reader. Points at the SQLite file the
+# tracing-collector writes. Default matches the collector's default path; set
+# this explicitly if you moved the DB or run against a snapshot.
+VOICECLAW_TRACING_DB_URL="file:/Users/you/.voiceclaw/tracing.db"

--- a/tracing-ui/.gitignore
+++ b/tracing-ui/.gitignore
@@ -2,3 +2,5 @@
 out/
 next-env.d.ts
 *.tsbuildinfo
+.env
+.env.local

--- a/tracing-ui/next.config.ts
+++ b/tracing-ui/next.config.ts
@@ -2,8 +2,9 @@ import { dirname } from "node:path"
 import { fileURLToPath } from "node:url"
 import type { NextConfig } from "next"
 
-// better-sqlite3 is a native module. Next.js's server-components bundler needs
-// to treat it as external so it isn't re-bundled for the server runtime.
+// @prisma/client ships native engine binaries; Next.js's server-components
+// bundler needs to treat it as external so the engines aren't re-bundled for
+// the server runtime (and so runtime file resolution works).
 //
 // `outputFileTracingRoot` is pinned to this workspace to silence Next's
 // "multiple lockfiles" warning when the repo is opened inside a broader yarn
@@ -11,7 +12,7 @@ import type { NextConfig } from "next"
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const nextConfig: NextConfig = {
-  serverExternalPackages: ["better-sqlite3"],
+  serverExternalPackages: ["@prisma/client", ".prisma/client"],
   outputFileTracingRoot: __dirname,
 }
 

--- a/tracing-ui/package.json
+++ b/tracing-ui/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "better-sqlite3": "^12.0.0",
+    "@prisma/client": "^6.0.0",
     "chart.js": "^4.4.7",
     "next": "^15.1.0",
     "react": "^19.0.0",
@@ -18,12 +18,12 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.9.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.5.1",
+    "prisma": "^6.0.0",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2"
   }

--- a/tracing-ui/package.json
+++ b/tracing-ui/package.json
@@ -10,7 +10,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@prisma/adapter-better-sqlite3": "^7.8.0",
     "@prisma/client": "^6.0.0",
+    "better-sqlite3": "^12.9.0",
     "chart.js": "^4.4.7",
     "next": "^15.1.0",
     "react": "^19.0.0",
@@ -18,6 +20,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.9.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/tracing-ui/prisma/schema.prisma
+++ b/tracing-ui/prisma/schema.prisma
@@ -12,9 +12,13 @@ generator client {
   provider = "prisma-client-js"
 }
 
+// The runtime connection is owned by `@prisma/adapter-better-sqlite3` (see
+// src/lib/db.ts). Prisma 6's schema validator still requires a `url` on the
+// datasource block at generate time, so we use a harmless placeholder that's
+// never consulted at runtime — the adapter opens the real DB from env vars.
 datasource db {
   provider = "sqlite"
-  url      = env("VOICECLAW_TRACING_DB_URL")
+  url      = "file:./__unused.db"
 }
 
 model Trace {

--- a/tracing-ui/prisma/schema.prisma
+++ b/tracing-ui/prisma/schema.prisma
@@ -1,0 +1,98 @@
+// Schema for the tracing-ui reader. The tracing-collector owns the schema;
+// this file is a hand-written mirror so Prisma can type the read path.
+//
+// DO NOT run `prisma migrate` here — the collector is authoritative. This
+// schema must stay in lock-step with tracing-collector/src/db.ts.
+//
+// WAL mode is set once by the collector at startup. Prisma's SQLite connector
+// does not re-issue `journal_mode` on connect, so opening this DB from the UI
+// is safe for concurrent reads while the collector writes.
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("VOICECLAW_TRACING_DB_URL")
+}
+
+model Trace {
+  id           Int     @id @default(autoincrement())
+  traceId      String  @unique @map("trace_id")
+  sessionId    String? @map("session_id")
+  userId       String? @map("user_id")
+  name         String?
+  startTimeNs  BigInt? @map("start_time_ns")
+  endTimeNs    BigInt? @map("end_time_ns")
+  inputJson    String? @map("input_json")
+  outputJson   String? @map("output_json")
+  metadataJson String? @map("metadata_json")
+  status       String?
+
+  @@index([sessionId, startTimeNs], map: "traces_session")
+  @@index([userId, startTimeNs], map: "traces_user")
+  @@map("traces")
+}
+
+model Observation {
+  id              Int     @id @default(autoincrement())
+  spanId          String  @unique @map("span_id")
+  traceId         String  @map("trace_id")
+  parentSpanId    String? @map("parent_span_id")
+  name            String?
+  kind            String?
+  observationType String? @map("observation_type")
+  serviceName     String? @map("service_name")
+  startTimeNs     BigInt? @map("start_time_ns")
+  endTimeNs       BigInt? @map("end_time_ns")
+  durationMs      Int?    @map("duration_ms")
+  statusCode      String? @map("status_code")
+  statusMessage   String? @map("status_message")
+  attributesJson  String? @map("attributes_json")
+  eventsJson      String? @map("events_json")
+  model           String?
+  tokensInput     Int?    @map("tokens_input")
+  tokensOutput    Int?    @map("tokens_output")
+  tokensCached    Int?    @map("tokens_cached")
+  costUsd         Float?  @map("cost_usd")
+
+  @@index([traceId, startTimeNs], map: "obs_trace")
+  @@index([parentSpanId], map: "obs_parent")
+  @@index([serviceName, startTimeNs], map: "obs_service")
+  @@map("observations")
+}
+
+model Session {
+  id           Int     @id @default(autoincrement())
+  sessionId    String  @unique @map("session_id")
+  userId       String? @map("user_id")
+  startedAtNs  BigInt? @map("started_at_ns")
+  lastActivity BigInt? @map("last_activity")
+  turnCount    Int?    @map("turn_count")
+  totalCostUsd Float?  @map("total_cost_usd")
+  totalTokens  Int?    @map("total_tokens")
+  durationMs   Int?    @map("duration_ms")
+
+  @@index([userId, lastActivity(sort: Desc)], map: "sessions_user")
+  @@map("sessions")
+}
+
+model Media {
+  id              Int     @id @default(autoincrement())
+  traceId         String  @map("trace_id")
+  spanId          String? @map("span_id")
+  sessionId       String? @map("session_id")
+  kind            String
+  codec           String?
+  sampleRateHz    Int?    @map("sample_rate_hz")
+  bytes           Int?
+  durationMs      Int?    @map("duration_ms")
+  startOffsetMs   Int?    @map("start_offset_ms")
+  filePath        String? @map("file_path")
+  langfuseMediaId String? @map("langfuse_media_id")
+  createdAt       BigInt? @map("created_at")
+
+  @@index([sessionId, kind, startOffsetMs], map: "media_session")
+  @@map("media")
+}

--- a/tracing-ui/src/app/dashboard/page.tsx
+++ b/tracing-ui/src/app/dashboard/page.tsx
@@ -1,12 +1,12 @@
 export const dynamic = "force-dynamic"
 
-import { listSessions } from "@/lib/db"
+import { listSessions, type SessionRow } from "@/lib/db"
 
-export default function DashboardPage() {
-  let sessions: ReturnType<typeof listSessions> = []
+export default async function DashboardPage() {
+  let sessions: SessionRow[] = []
   let error: string | null = null
   try {
-    sessions = listSessions(1000)
+    sessions = await listSessions(1000)
   } catch (err) {
     error = err instanceof Error ? err.message : String(err)
   }

--- a/tracing-ui/src/app/sessions/[id]/page.tsx
+++ b/tracing-ui/src/app/sessions/[id]/page.tsx
@@ -4,6 +4,8 @@ import {
   listObservationsForSession,
   listTracesWithObservationsForSession,
   type ObservationRow,
+  type TraceWithObservations,
+  type VoiceTurn,
 } from "@/lib/db"
 import { SessionTabs, TABS, type TabKey } from "@/components/SessionTabs"
 import { TranscriptTab } from "@/components/TranscriptTab"
@@ -27,15 +29,17 @@ export default async function SessionDetailPage({
   const sessionId = decodeURIComponent(id)
   const activeTab = resolveTab(tabParam)
 
-  let traces: ReturnType<typeof listTracesWithObservationsForSession> = []
+  let traces: TraceWithObservations[] = []
   let observations: ObservationRow[] = []
-  let voiceTurns: ReturnType<typeof getVoiceTurnsForSession> = []
+  let voiceTurns: VoiceTurn[] = []
   let error: string | null = null
 
   try {
-    traces = listTracesWithObservationsForSession(sessionId)
-    observations = listObservationsForSession(sessionId)
-    voiceTurns = getVoiceTurnsForSession(sessionId)
+    ;[traces, observations, voiceTurns] = await Promise.all([
+      listTracesWithObservationsForSession(sessionId),
+      listObservationsForSession(sessionId),
+      getVoiceTurnsForSession(sessionId),
+    ])
   } catch (err) {
     error = err instanceof Error ? err.message : String(err)
   }
@@ -146,9 +150,9 @@ function TabContent({
   totalMs,
 }: {
   tab: TabKey
-  voiceTurns: ReturnType<typeof getVoiceTurnsForSession>
+  voiceTurns: VoiceTurn[]
   observations: ObservationRow[]
-  traces: ReturnType<typeof listTracesWithObservationsForSession>
+  traces: TraceWithObservations[]
   startNs: number
   totalMs: number
 }) {

--- a/tracing-ui/src/app/sessions/page.tsx
+++ b/tracing-ui/src/app/sessions/page.tsx
@@ -1,13 +1,13 @@
 import Link from "next/link"
-import { listSessions } from "@/lib/db"
+import { listSessions, type SessionRow } from "@/lib/db"
 
 export const dynamic = "force-dynamic"
 
-export default function SessionsPage() {
-  let sessions: ReturnType<typeof listSessions> = []
+export default async function SessionsPage() {
+  let sessions: SessionRow[] = []
   let error: string | null = null
   try {
-    sessions = listSessions(100)
+    sessions = await listSessions(100)
   } catch (err) {
     error = err instanceof Error ? err.message : String(err)
   }

--- a/tracing-ui/src/app/users/page.tsx
+++ b/tracing-ui/src/app/users/page.tsx
@@ -1,12 +1,12 @@
 export const dynamic = "force-dynamic"
 
 import Link from "next/link"
-import { listSessions } from "@/lib/db"
+import { listSessions, type SessionRow } from "@/lib/db"
 
-export default function UsersPage() {
-  let sessions: ReturnType<typeof listSessions> = []
+export default async function UsersPage() {
+  let sessions: SessionRow[] = []
   try {
-    sessions = listSessions(1000)
+    sessions = await listSessions(1000)
   } catch {
     /* no-op; handled below */
   }

--- a/tracing-ui/src/lib/db.ts
+++ b/tracing-ui/src/lib/db.ts
@@ -3,10 +3,17 @@
 // safe because the collector sets WAL mode at startup — Prisma's SQLite
 // driver does not re-issue `journal_mode` on connect.
 //
+// The runtime connection is owned by `@prisma/adapter-better-sqlite3`, not
+// Prisma's bundled Rust engine. That lets us open the DB read-only and keeps
+// the connection config in one place (this file) instead of being smeared
+// across schema.prisma + env vars. The `url` on the datasource block in
+// schema.prisma is an unused placeholder — the adapter is the source of truth.
+//
 // This module must only be imported from Server Components, Route Handlers,
 // or server actions. Public function signatures match the previous raw-SQL
 // reader so no caller changes are required.
 
+import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3"
 import { Prisma, PrismaClient } from "@prisma/client"
 import { homedir } from "node:os"
 import { join } from "node:path"
@@ -18,11 +25,7 @@ const DEFAULT_PATH = join(homedir(), ".voiceclaw", "tracing.db")
 const globalForPrisma = globalThis as unknown as { __vcTracingPrisma?: PrismaClient }
 
 export const prisma: PrismaClient =
-  globalForPrisma.__vcTracingPrisma ??
-  new PrismaClient({
-    datasources: { db: { url: resolveDbUrl() } },
-    log: process.env.NODE_ENV === "development" ? ["error", "warn"] : ["error"],
-  })
+  globalForPrisma.__vcTracingPrisma ?? createPrisma()
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.__vcTracingPrisma = prisma
 
@@ -93,14 +96,19 @@ export type TraceRow = {
   status: string | null
 }
 
-// We use $queryRaw for the trace/observation fetches because Prisma's SQLite
-// connector rejects INTEGER column values > INT32 even on raw queries — the
-// engine performs a range check based on the live column type regardless of
-// the schema field type or cast level. Our start_time_ns values are
-// nanosecond timestamps (≈ 1.8e18), so we CAST them to REAL in SQL so Prisma
-// sees a REAL column at the wire level. Precision loss is below the
-// microsecond floor, which is well below the display resolution the UI uses
-// (everything is shown in ms). See the PR description for the writeup.
+// We use $queryRaw + CAST for every fetch that projects a timestamp. Prisma
+// rejects any INTEGER column whose declared DDL type is `INTEGER` when the
+// value exceeds INT32 — even through the `@prisma/adapter-better-sqlite3`
+// driver adapter. The adapter reports the column type by mapping SQLite's
+// DDL decltype to ColumnTypeEnum.Int32 (see
+// node_modules/@prisma/adapter-better-sqlite3 `mapDeclType`), and the engine
+// then applies the i32 range check before we ever see the row. Neither
+// fluent reads nor `$queryRaw` without CAST survive this path — the only
+// fixes are (a) change the collector's DDL to `BIGINT`, which is outside
+// this package's ownership, or (b) project through `CAST(... AS REAL)` so
+// the column arrives at the engine as Double. We use (b). Precision loss is
+// below the microsecond floor, which is well below the ms display the UI
+// uses. See the PR description for the writeup.
 export async function listTracesForSession(sessionId: string): Promise<TraceRow[]> {
   if (sessionId === "(no session)") {
     const rows = await prisma.$queryRaw<RawTraceRow[]>(Prisma.sql`
@@ -246,14 +254,26 @@ export async function getVoiceTurnsForSession(sessionId: string): Promise<VoiceT
 
 // -- helpers ---------------------------------------------------------------
 
-// We accept VOICECLAW_TRACING_DB (legacy, plain path used by the collector)
-// or VOICECLAW_TRACING_DB_URL (Prisma-style, already `file:…` prefixed).
-// Falling back to the default path keeps local dev friction-free.
-function resolveDbUrl(): string {
-  const fromUrl = process.env.VOICECLAW_TRACING_DB_URL
-  if (fromUrl && fromUrl.length > 0) return fromUrl
-  const fromPath = process.env.VOICECLAW_TRACING_DB ?? DEFAULT_PATH
-  return fromPath.startsWith("file:") ? fromPath : `file:${fromPath}`
+// VOICECLAW_TRACING_DB is the same env var the collector reads — a plain
+// filesystem path (no `file:` prefix). With the driver adapter owning the
+// connection there is no Prisma-style URL involved.
+function resolveDbPath(): string {
+  const fromEnv = process.env.VOICECLAW_TRACING_DB
+  if (fromEnv && fromEnv.length > 0) return fromEnv
+  return DEFAULT_PATH
+}
+
+function createPrisma(): PrismaClient {
+  const adapter = new PrismaBetterSqlite3({
+    url: `file:${resolveDbPath()}`,
+    readonly: true,
+    fileMustExist: false,
+    timeout: 5000,
+  })
+  return new PrismaClient({
+    adapter,
+    log: process.env.NODE_ENV === "development" ? ["error", "warn"] : ["error"],
+  })
 }
 
 type RawSessionRow = {

--- a/tracing-ui/src/lib/db.ts
+++ b/tracing-ui/src/lib/db.ts
@@ -1,29 +1,30 @@
-// Server-only SQLite reader. The tracing-collector is the writer; we open
-// the same DB file in read-only WAL mode so concurrent reads are safe.
+// Server-only Prisma reader. The tracing-collector is the writer; we open
+// the same SQLite file through Prisma for typed reads. Concurrent reads are
+// safe because the collector sets WAL mode at startup — Prisma's SQLite
+// driver does not re-issue `journal_mode` on connect.
 //
-// This module is safe to import only from Server Components, Route Handlers,
-// or server actions. Never from client code — `better-sqlite3` is a native
-// module, listed in `serverExternalPackages`.
+// This module must only be imported from Server Components, Route Handlers,
+// or server actions. Public function signatures match the previous raw-SQL
+// reader so no caller changes are required.
 
-import Database from "better-sqlite3"
+import { Prisma, PrismaClient } from "@prisma/client"
 import { homedir } from "node:os"
 import { join } from "node:path"
 
 const DEFAULT_PATH = join(homedir(), ".voiceclaw", "tracing.db")
 
-let handle: Database.Database | null = null
+// Singleton Prisma client. In dev, Next.js hot-reloads the module graph on
+// every request; stash the client on globalThis to avoid connection churn.
+const globalForPrisma = globalThis as unknown as { __vcTracingPrisma?: PrismaClient }
 
-export function db(): Database.Database {
-  if (handle) return handle
-  const path = process.env.VOICECLAW_TRACING_DB ?? DEFAULT_PATH
-  handle = new Database(path, { readonly: true, fileMustExist: false })
-  // WAL mode is persistent at the database level — set once by the collector.
-  // Readers don't need to (and shouldn't) set it; we just configure a busy
-  // timeout so lock contention under concurrent writes yields a clean retry
-  // instead of an immediate SQLITE_BUSY.
-  handle.pragma("busy_timeout = 5000")
-  return handle
-}
+export const prisma: PrismaClient =
+  globalForPrisma.__vcTracingPrisma ??
+  new PrismaClient({
+    datasources: { db: { url: resolveDbUrl() } },
+    log: process.env.NODE_ENV === "development" ? ["error", "warn"] : ["error"],
+  })
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.__vcTracingPrisma = prisma
 
 export type SessionRow = {
   session_id: string
@@ -36,46 +37,48 @@ export type SessionRow = {
   duration_ms: number
 }
 
-// Sessions view is derived from observations at query time (no materialized
-// `sessions` table in v1). Groups by session_id present on any observation,
-// aggregates across all traces for that session. Orphan traces without a
-// session_id (e.g. direct HTTP probes bypassing the voice relay) get grouped
-// into a synthetic "(no session)" bucket so they're not invisible.
-export function listSessions(limit = 50, offset = 0): SessionRow[] {
-  // Aggregate per session via a two-step CTE: first pre-aggregate each trace
-  // so `turn_count` is one-per-trace (otherwise the JOIN fans out and turn
-  // count = number of observations, not turns).
-  const rows = db()
-    .prepare(`
-      WITH trace_totals AS (
-        SELECT
-          t.trace_id,
-          t.session_id,
-          t.user_id,
-          t.start_time_ns,
-          COALESCE(t.end_time_ns, t.start_time_ns) AS end_time_ns,
-          COALESCE(SUM(o.cost_usd), 0) AS cost_usd,
-          COALESCE(SUM(COALESCE(o.tokens_input, 0) + COALESCE(o.tokens_output, 0)), 0) AS tokens
-        FROM traces t
-        LEFT JOIN observations o ON o.trace_id = t.trace_id
-        GROUP BY t.trace_id
-      )
+// Sessions view is derived from traces + observations at query time. Uses a
+// CTE to aggregate per-trace first so `turn_count` stays one-per-trace and
+// doesn't fan out over the observations join.
+export async function listSessions(limit = 50, offset = 0): Promise<SessionRow[]> {
+  const rows = await prisma.$queryRaw<RawSessionRow[]>(Prisma.sql`
+    WITH trace_totals AS (
       SELECT
-        COALESCE(session_id, '(no session)')         AS session_id,
-        MAX(user_id)                                 AS user_id,
-        MIN(start_time_ns)                           AS started_at_ns,
-        MAX(end_time_ns)                             AS last_activity_ns,
-        COUNT(*)                                     AS turn_count,
-        COALESCE(SUM(cost_usd), 0)                   AS total_cost_usd,
-        COALESCE(SUM(tokens), 0)                     AS total_tokens,
-        CAST((MAX(end_time_ns) - MIN(start_time_ns)) / 1000000 AS INTEGER) AS duration_ms
-      FROM trace_totals
-      GROUP BY COALESCE(session_id, '(no session)')
-      ORDER BY last_activity_ns DESC
-      LIMIT ? OFFSET ?
-    `)
-    .all(limit, offset) as SessionRow[]
-  return rows
+        t.trace_id,
+        t.session_id,
+        t.user_id,
+        CAST(t.start_time_ns AS REAL) AS start_time_ns,
+        CAST(COALESCE(t.end_time_ns, t.start_time_ns) AS REAL) AS end_time_ns,
+        COALESCE(SUM(o.cost_usd), 0) AS cost_usd,
+        COALESCE(SUM(COALESCE(o.tokens_input, 0) + COALESCE(o.tokens_output, 0)), 0) AS tokens
+      FROM traces t
+      LEFT JOIN observations o ON o.trace_id = t.trace_id
+      GROUP BY t.trace_id
+    )
+    SELECT
+      COALESCE(session_id, '(no session)')         AS session_id,
+      MAX(user_id)                                 AS user_id,
+      MIN(start_time_ns)                           AS started_at_ns,
+      MAX(end_time_ns)                             AS last_activity_ns,
+      COUNT(*)                                     AS turn_count,
+      COALESCE(SUM(cost_usd), 0)                   AS total_cost_usd,
+      COALESCE(SUM(tokens), 0)                     AS total_tokens,
+      CAST((MAX(end_time_ns) - MIN(start_time_ns)) / 1000000 AS REAL) AS duration_ms
+    FROM trace_totals
+    GROUP BY COALESCE(session_id, '(no session)')
+    ORDER BY last_activity_ns DESC
+    LIMIT ${limit} OFFSET ${offset}
+  `)
+  return rows.map((r) => ({
+    session_id: r.session_id,
+    user_id: r.user_id,
+    started_at_ns: toNumber(r.started_at_ns) ?? 0,
+    last_activity_ns: toNumber(r.last_activity_ns) ?? 0,
+    turn_count: toNumber(r.turn_count) ?? 0,
+    total_cost_usd: toNumber(r.total_cost_usd) ?? 0,
+    total_tokens: toNumber(r.total_tokens) ?? 0,
+    duration_ms: toNumber(r.duration_ms) ?? 0,
+  }))
 }
 
 export type TraceRow = {
@@ -90,25 +93,37 @@ export type TraceRow = {
   status: string | null
 }
 
-export function listTracesForSession(sessionId: string): TraceRow[] {
+// We use $queryRaw for the trace/observation fetches because Prisma's SQLite
+// connector rejects INTEGER column values > INT32 even on raw queries — the
+// engine performs a range check based on the live column type regardless of
+// the schema field type or cast level. Our start_time_ns values are
+// nanosecond timestamps (≈ 1.8e18), so we CAST them to REAL in SQL so Prisma
+// sees a REAL column at the wire level. Precision loss is below the
+// microsecond floor, which is well below the display resolution the UI uses
+// (everything is shown in ms). See the PR description for the writeup.
+export async function listTracesForSession(sessionId: string): Promise<TraceRow[]> {
   if (sessionId === "(no session)") {
-    return db()
-      .prepare(`
-        SELECT trace_id, session_id, user_id, name, start_time_ns, end_time_ns, input_json, output_json, status
-        FROM traces
-        WHERE session_id IS NULL
-        ORDER BY start_time_ns ASC
-      `)
-      .all() as TraceRow[]
-  }
-  return db()
-    .prepare(`
-      SELECT trace_id, session_id, user_id, name, start_time_ns, end_time_ns, input_json, output_json, status
+    const rows = await prisma.$queryRaw<RawTraceRow[]>(Prisma.sql`
+      SELECT trace_id, session_id, user_id, name,
+             CAST(start_time_ns AS REAL) AS start_time_ns,
+             CAST(end_time_ns   AS REAL) AS end_time_ns,
+             input_json, output_json, status
       FROM traces
-      WHERE session_id = ?
+      WHERE session_id IS NULL
       ORDER BY start_time_ns ASC
     `)
-    .all(sessionId) as TraceRow[]
+    return rows.map(toTraceRow)
+  }
+  const rows = await prisma.$queryRaw<RawTraceRow[]>(Prisma.sql`
+    SELECT trace_id, session_id, user_id, name,
+           CAST(start_time_ns AS REAL) AS start_time_ns,
+           CAST(end_time_ns   AS REAL) AS end_time_ns,
+           input_json, output_json, status
+    FROM traces
+    WHERE session_id = ${sessionId}
+    ORDER BY start_time_ns ASC
+  `)
+  return rows.map(toTraceRow)
 }
 
 export type ObservationRow = {
@@ -130,55 +145,51 @@ export type ObservationRow = {
   cost_usd: number | null
 }
 
-export function listObservationsForTrace(traceId: string): ObservationRow[] {
-  return db()
-    .prepare(`
-      SELECT span_id, trace_id, parent_span_id, name, observation_type, service_name,
-             start_time_ns, end_time_ns, duration_ms, status_code, attributes_json,
-             model, tokens_input, tokens_output, tokens_cached, cost_usd
-      FROM observations
-      WHERE trace_id = ?
-      ORDER BY start_time_ns ASC
-    `)
-    .all(traceId) as ObservationRow[]
+export async function listObservationsForTrace(traceId: string): Promise<ObservationRow[]> {
+  const rows = await prisma.$queryRaw<RawObservationRow[]>(Prisma.sql`
+    SELECT ${OBSERVATION_COLS}
+    FROM observations
+    WHERE trace_id = ${traceId}
+    ORDER BY start_time_ns ASC
+  `)
+  return rows.map(toObservationRow)
 }
 
-export function listObservationsForSession(sessionId: string): ObservationRow[] {
-  const cols = `o.span_id, o.trace_id, o.parent_span_id, o.name, o.observation_type, o.service_name,
-                o.start_time_ns, o.end_time_ns, o.duration_ms, o.status_code, o.attributes_json,
-                o.model, o.tokens_input, o.tokens_output, o.tokens_cached, o.cost_usd`
+export async function listObservationsForSession(sessionId: string): Promise<ObservationRow[]> {
   if (sessionId === "(no session)") {
-    return db()
-      .prepare(`
-        SELECT ${cols}
-        FROM observations o
-        JOIN traces t ON t.trace_id = o.trace_id
-        WHERE t.session_id IS NULL
-        ORDER BY o.start_time_ns ASC
-      `)
-      .all() as ObservationRow[]
-  }
-  return db()
-    .prepare(`
-      SELECT ${cols}
+    const rows = await prisma.$queryRaw<RawObservationRow[]>(Prisma.sql`
+      SELECT ${OBSERVATION_COLS_PREFIXED}
       FROM observations o
       JOIN traces t ON t.trace_id = o.trace_id
-      WHERE t.session_id = ?
+      WHERE t.session_id IS NULL
       ORDER BY o.start_time_ns ASC
     `)
-    .all(sessionId) as ObservationRow[]
+    return rows.map(toObservationRow)
+  }
+  const rows = await prisma.$queryRaw<RawObservationRow[]>(Prisma.sql`
+    SELECT ${OBSERVATION_COLS_PREFIXED}
+    FROM observations o
+    JOIN traces t ON t.trace_id = o.trace_id
+    WHERE t.session_id = ${sessionId}
+    ORDER BY o.start_time_ns ASC
+  `)
+  return rows.map(toObservationRow)
 }
 
 // Grouped fetch: traces for the session with their observations nested under
 // each trace. Returned in trace-start order, observations in span-start order.
 export type TraceWithObservations = TraceRow & { observations: ObservationRow[] }
 
-export function listTracesWithObservationsForSession(sessionId: string): TraceWithObservations[] {
-  const traces = listTracesForSession(sessionId)
+export async function listTracesWithObservationsForSession(
+  sessionId: string,
+): Promise<TraceWithObservations[]> {
+  const [traces, obs] = await Promise.all([
+    listTracesForSession(sessionId),
+    listObservationsForSession(sessionId),
+  ])
   if (traces.length === 0) return []
   const byTrace = new Map<string, ObservationRow[]>()
   for (const t of traces) byTrace.set(t.trace_id, [])
-  const obs = listObservationsForSession(sessionId)
   for (const o of obs) {
     const bucket = byTrace.get(o.trace_id)
     if (bucket) bucket.push(o)
@@ -210,8 +221,10 @@ export type ChatMessage = {
   content: string
 }
 
-export function getVoiceTurnsForSession(sessionId: string): VoiceTurn[] {
-  const obs = listObservationsForSession(sessionId).filter((o) => o.name === "voice-turn")
+export async function getVoiceTurnsForSession(sessionId: string): Promise<VoiceTurn[]> {
+  const obs = (await listObservationsForSession(sessionId)).filter(
+    (o) => o.name === "voice-turn",
+  )
   return obs.map((o) => {
     const attrs = parseJson<Record<string, unknown>>(o.attributes_json) ?? {}
     const rawInput = (attrs["langfuse.observation.input"] as unknown) ?? null
@@ -229,6 +242,120 @@ export function getVoiceTurnsForSession(sessionId: string): VoiceTurn[] {
       attributes: attrs,
     }
   })
+}
+
+// -- helpers ---------------------------------------------------------------
+
+// We accept VOICECLAW_TRACING_DB (legacy, plain path used by the collector)
+// or VOICECLAW_TRACING_DB_URL (Prisma-style, already `file:…` prefixed).
+// Falling back to the default path keeps local dev friction-free.
+function resolveDbUrl(): string {
+  const fromUrl = process.env.VOICECLAW_TRACING_DB_URL
+  if (fromUrl && fromUrl.length > 0) return fromUrl
+  const fromPath = process.env.VOICECLAW_TRACING_DB ?? DEFAULT_PATH
+  return fromPath.startsWith("file:") ? fromPath : `file:${fromPath}`
+}
+
+type RawSessionRow = {
+  session_id: string
+  user_id: string | null
+  started_at_ns: bigint | number | null
+  last_activity_ns: bigint | number | null
+  turn_count: bigint | number
+  total_cost_usd: bigint | number | null
+  total_tokens: bigint | number | null
+  duration_ms: bigint | number | null
+}
+
+type RawTraceRow = {
+  trace_id: string
+  session_id: string | null
+  user_id: string | null
+  name: string | null
+  start_time_ns: bigint | number | null
+  end_time_ns: bigint | number | null
+  input_json: string | null
+  output_json: string | null
+  status: string | null
+}
+
+type RawObservationRow = {
+  span_id: string
+  trace_id: string
+  parent_span_id: string | null
+  name: string | null
+  observation_type: string | null
+  service_name: string | null
+  start_time_ns: bigint | number | null
+  end_time_ns: bigint | number | null
+  duration_ms: bigint | number | null
+  status_code: string | null
+  attributes_json: string | null
+  model: string | null
+  tokens_input: bigint | number | null
+  tokens_output: bigint | number | null
+  tokens_cached: bigint | number | null
+  cost_usd: number | null
+}
+
+// start_time_ns / end_time_ns are cast to REAL so Prisma's INT overflow
+// check on the SQLite column doesn't fire — see listTracesForSession for
+// the writeup. duration_ms, tokens_* stay INTEGER because they never come
+// close to the INT32 boundary.
+const OBSERVATION_COLS = Prisma.raw(
+  `span_id, trace_id, parent_span_id, name, observation_type, service_name,
+   CAST(start_time_ns AS REAL) AS start_time_ns,
+   CAST(end_time_ns   AS REAL) AS end_time_ns,
+   duration_ms, status_code, attributes_json,
+   model, tokens_input, tokens_output, tokens_cached, cost_usd`,
+)
+
+const OBSERVATION_COLS_PREFIXED = Prisma.raw(
+  `o.span_id, o.trace_id, o.parent_span_id, o.name, o.observation_type, o.service_name,
+   CAST(o.start_time_ns AS REAL) AS start_time_ns,
+   CAST(o.end_time_ns   AS REAL) AS end_time_ns,
+   o.duration_ms, o.status_code, o.attributes_json,
+   o.model, o.tokens_input, o.tokens_output, o.tokens_cached, o.cost_usd`,
+)
+
+function toTraceRow(r: RawTraceRow): TraceRow {
+  return {
+    trace_id: r.trace_id,
+    session_id: r.session_id,
+    user_id: r.user_id,
+    name: r.name,
+    start_time_ns: toNumber(r.start_time_ns) ?? 0,
+    end_time_ns: toNumber(r.end_time_ns),
+    input_json: r.input_json,
+    output_json: r.output_json,
+    status: r.status,
+  }
+}
+
+function toObservationRow(r: RawObservationRow): ObservationRow {
+  return {
+    span_id: r.span_id,
+    trace_id: r.trace_id,
+    parent_span_id: r.parent_span_id,
+    name: r.name,
+    observation_type: r.observation_type,
+    service_name: r.service_name,
+    start_time_ns: toNumber(r.start_time_ns) ?? 0,
+    end_time_ns: toNumber(r.end_time_ns),
+    duration_ms: toNumber(r.duration_ms),
+    status_code: r.status_code,
+    attributes_json: r.attributes_json,
+    model: r.model,
+    tokens_input: toNumber(r.tokens_input),
+    tokens_output: toNumber(r.tokens_output),
+    tokens_cached: toNumber(r.tokens_cached),
+    cost_usd: r.cost_usd,
+  }
+}
+
+function toNumber(v: bigint | number | null | undefined): number | null {
+  if (v == null) return null
+  return typeof v === "bigint" ? Number(v) : v
 }
 
 function parseJson<T>(s: string | null | undefined): T | null {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3998,6 +3998,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@prisma/adapter-better-sqlite3@npm:^7.8.0":
+  version: 7.8.0
+  resolution: "@prisma/adapter-better-sqlite3@npm:7.8.0"
+  dependencies:
+    "@prisma/driver-adapter-utils": "npm:7.8.0"
+    better-sqlite3: "npm:^12.6.0"
+  checksum: 10c0/0dc18de1c924a96ee5bb2a9bd6339d27775d1cb22c19edce5db2afd798e901c0eddb9625e0b8427badc884cd07d929b406e331e87a0c4170fd2aa7ea1961c04c
+  languageName: node
+  linkType: hard
+
 "@prisma/client@npm:^6.0.0":
   version: 6.19.3
   resolution: "@prisma/client@npm:6.19.3"
@@ -4029,6 +4039,22 @@ __metadata:
   version: 6.19.3
   resolution: "@prisma/debug@npm:6.19.3"
   checksum: 10c0/5be746e0c2a1bb4c10eaa5e6584c90626090d437b4570503845e31776239fa52f04cf224cf8278e3f738c9e7e39ab78594dd7a4db2cd4ae8ddf863ef1f8c18a1
+  languageName: node
+  linkType: hard
+
+"@prisma/debug@npm:7.8.0":
+  version: 7.8.0
+  resolution: "@prisma/debug@npm:7.8.0"
+  checksum: 10c0/ca4e9d42e65567944927fb8fe3ffc448e777654130afa5cd8f2cc507f2d97dece685714d5a82951592c1a08edd6ba3cfb3d52c5c8c344c46f1469913d0c37f4b
+  languageName: node
+  linkType: hard
+
+"@prisma/driver-adapter-utils@npm:7.8.0":
+  version: 7.8.0
+  resolution: "@prisma/driver-adapter-utils@npm:7.8.0"
+  dependencies:
+    "@prisma/debug": "npm:7.8.0"
+  checksum: 10c0/d8db769e63df3072942b1369641e9eba4a00607dfce66ddce822992d0bbd77507acd6a08b6d7ee32cdab7f27767f8e86afa1016e347f2732362e71337330d1ec
   languageName: node
   linkType: hard
 
@@ -7707,7 +7733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:^12.0.0, better-sqlite3@npm:^12.9.0":
+"better-sqlite3@npm:^12.0.0, better-sqlite3@npm:^12.6.0, better-sqlite3@npm:^12.9.0":
   version: 12.9.0
   resolution: "better-sqlite3@npm:12.9.0"
   dependencies:
@@ -21315,11 +21341,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "voiceclaw-tracing-ui@workspace:tracing-ui"
   dependencies:
+    "@prisma/adapter-better-sqlite3": "npm:^7.8.0"
     "@prisma/client": "npm:^6.0.0"
+    "@types/better-sqlite3": "npm:^7.6.12"
     "@types/node": "npm:^22.9.0"
     "@types/react": "npm:^19.0.0"
     "@types/react-dom": "npm:^19.0.0"
     autoprefixer: "npm:^10.4.20"
+    better-sqlite3: "npm:^12.9.0"
     chart.js: "npm:^4.4.7"
     next: "npm:^15.1.0"
     postcss: "npm:^8.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3998,6 +3998,79 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@prisma/client@npm:^6.0.0":
+  version: 6.19.3
+  resolution: "@prisma/client@npm:6.19.3"
+  peerDependencies:
+    prisma: "*"
+    typescript: ">=5.1.0"
+  peerDependenciesMeta:
+    prisma:
+      optional: true
+    typescript:
+      optional: true
+  checksum: 10c0/50dbdd80181d5f020e311f3055a3664a2a36afda39e9e14cf1e2be80e11253bbfce5f6e1cb4fbfbdc955a91be26cb4c55cae659e950ce1b58085e38ca567878c
+  languageName: node
+  linkType: hard
+
+"@prisma/config@npm:6.19.3":
+  version: 6.19.3
+  resolution: "@prisma/config@npm:6.19.3"
+  dependencies:
+    c12: "npm:3.1.0"
+    deepmerge-ts: "npm:7.1.5"
+    effect: "npm:3.21.0"
+    empathic: "npm:2.0.0"
+  checksum: 10c0/5177e2e63021ccdb3f6e03344242ba8859382031c958cc7d3a7f70d0b414fbf8892a76d0381bcb4d948dc3a45f6e605a9fa0a1dec12dfbaffa88ec0267d94dd9
+  languageName: node
+  linkType: hard
+
+"@prisma/debug@npm:6.19.3":
+  version: 6.19.3
+  resolution: "@prisma/debug@npm:6.19.3"
+  checksum: 10c0/5be746e0c2a1bb4c10eaa5e6584c90626090d437b4570503845e31776239fa52f04cf224cf8278e3f738c9e7e39ab78594dd7a4db2cd4ae8ddf863ef1f8c18a1
+  languageName: node
+  linkType: hard
+
+"@prisma/engines-version@npm:7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7":
+  version: 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
+  resolution: "@prisma/engines-version@npm:7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7"
+  checksum: 10c0/7bf85d9a33b6be89ab2941d2ae7f2bab29bee0166badddba878245b326a5d82966cebca9124a0cf982696b0be9572fe14ce7fe95ba82c59bb8ea0946ad296452
+  languageName: node
+  linkType: hard
+
+"@prisma/engines@npm:6.19.3":
+  version: 6.19.3
+  resolution: "@prisma/engines@npm:6.19.3"
+  dependencies:
+    "@prisma/debug": "npm:6.19.3"
+    "@prisma/engines-version": "npm:7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7"
+    "@prisma/fetch-engine": "npm:6.19.3"
+    "@prisma/get-platform": "npm:6.19.3"
+  checksum: 10c0/337dea12de75e1075eeda7321b265d92e41139c14498c597738b55d75a2dd98fd593dfe03d51f2090d0c070080c82895b60955f7e9e006d9e3e89d2e597b9027
+  languageName: node
+  linkType: hard
+
+"@prisma/fetch-engine@npm:6.19.3":
+  version: 6.19.3
+  resolution: "@prisma/fetch-engine@npm:6.19.3"
+  dependencies:
+    "@prisma/debug": "npm:6.19.3"
+    "@prisma/engines-version": "npm:7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7"
+    "@prisma/get-platform": "npm:6.19.3"
+  checksum: 10c0/e42f7e5fbc4d18cc87362e60f24dee201664d384e5c4ce9c051cf26b7bb11fd9be8720addeb6f916835b41c775b3a8b024ed0c3de0a57fbc39b367f8b17caba9
+  languageName: node
+  linkType: hard
+
+"@prisma/get-platform@npm:6.19.3":
+  version: 6.19.3
+  resolution: "@prisma/get-platform@npm:6.19.3"
+  dependencies:
+    "@prisma/debug": "npm:6.19.3"
+  checksum: 10c0/06e831c254add864ad7c06ccf2a02809d9d4e70d581a133e1201470ad925e90a547ab505d3866d68d1f6f4003f579a3eb84fe8688cf92f5b2fb8c0664c268888
+  languageName: node
+  linkType: hard
+
 "@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
   version: 1.1.2
   resolution: "@protobufjs/aspromise@npm:1.1.2"
@@ -5563,6 +5636,13 @@ __metadata:
   dependencies:
     "@sinonjs/commons": "npm:^3.0.0"
   checksum: 10c0/2e2fb6cc57f227912814085b7b01fede050cd4746ea8d49a1e44d5a0e56a804663b0340ae2f11af7559ea9bf4d087a11f2f646197a660ea3cb04e19efc04aa63
+  languageName: node
+  linkType: hard
+
+"@standard-schema/spec@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@standard-schema/spec@npm:1.1.0"
+  checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
   languageName: node
   linkType: hard
 
@@ -7855,6 +7935,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"c12@npm:3.1.0":
+  version: 3.1.0
+  resolution: "c12@npm:3.1.0"
+  dependencies:
+    chokidar: "npm:^4.0.3"
+    confbox: "npm:^0.2.2"
+    defu: "npm:^6.1.4"
+    dotenv: "npm:^16.6.1"
+    exsolve: "npm:^1.0.7"
+    giget: "npm:^2.0.0"
+    jiti: "npm:^2.4.2"
+    ohash: "npm:^2.0.11"
+    pathe: "npm:^2.0.3"
+    perfect-debounce: "npm:^1.0.0"
+    pkg-types: "npm:^2.2.0"
+    rc9: "npm:^2.1.2"
+  peerDependencies:
+    magicast: ^0.3.5
+  peerDependenciesMeta:
+    magicast:
+      optional: true
+  checksum: 10c0/a84d6cb5cb6171e9b5be67388b24c6945da8bf3d37b1e4db885ceb1db019da13b9af093d8bbed6b536fd9c4a9202a2ed8c14fb15d4d94fb2e5e7c83b6c88f05b
+  languageName: node
+  linkType: hard
+
 "cac@npm:^6.7.14":
   version: 6.7.14
   resolution: "cac@npm:6.7.14"
@@ -8129,6 +8234,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chokidar@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "chokidar@npm:4.0.3"
+  dependencies:
+    readdirp: "npm:^4.0.1"
+  checksum: 10c0/a58b9df05bb452f7d105d9e7229ac82fa873741c0c40ddcc7bb82f8a909fbe3f7814c9ebe9bc9a2bef9b737c0ec6e2d699d179048ef06ad3ec46315df0ebe6ad
+  languageName: node
+  linkType: hard
+
 "chokidar@npm:^5.0.0":
   version: 5.0.0
   resolution: "chokidar@npm:5.0.0"
@@ -8198,6 +8312,22 @@ __metadata:
   version: 4.4.0
   resolution: "ci-info@npm:4.4.0"
   checksum: 10c0/44156201545b8dde01aa8a09ee2fe9fc7a73b1bef9adbd4606c9f61c8caeeb73fb7a575c88b0443f7b4edb5ee45debaa59ed54ba5f99698339393ca01349eb3a
+  languageName: node
+  linkType: hard
+
+"citty@npm:^0.1.6":
+  version: 0.1.6
+  resolution: "citty@npm:0.1.6"
+  dependencies:
+    consola: "npm:^3.2.3"
+  checksum: 10c0/d26ad82a9a4a8858c7e149d90b878a3eceecd4cfd3e2ed3cd5f9a06212e451fb4f8cbe0fa39a3acb1b3e8f18e22db8ee5def5829384bad50e823d4b301609b48
+  languageName: node
+  linkType: hard
+
+"citty@npm:^0.2.0":
+  version: 0.2.2
+  resolution: "citty@npm:0.2.2"
+  checksum: 10c0/c896c9dcd187d2a16685706d11428dcdec9eb59aa13fe50aff7b12e1d3521f1bf434d6a5316fe75a341f8ba5ce1d2beceb84f7f261d018985a73d3f6f2a793e3
   languageName: node
   linkType: hard
 
@@ -8493,6 +8623,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"confbox@npm:^0.2.2":
+  version: 0.2.4
+  resolution: "confbox@npm:0.2.4"
+  checksum: 10c0/4c36af33d9df7034300c452f7b289179264493bd0671fa81b995a0d70dc897b1d37f1af10d3ffb187f178d17ba1ed2ba167ed0f599ba3a139c271205dd553f73
+  languageName: node
+  linkType: hard
+
 "connect@npm:^3.6.5, connect@npm:^3.7.0":
   version: 3.7.0
   resolution: "connect@npm:3.7.0"
@@ -8502,6 +8639,13 @@ __metadata:
     parseurl: "npm:~1.3.3"
     utils-merge: "npm:1.0.1"
   checksum: 10c0/f120c6116bb16a0a7d2703c0b4a0cd7ed787dc5ec91978097bf62aa967289020a9f41a9cd3c3276a7b92aaa36f382d2cd35fed7138fd466a55c8e9fdbed11ca8
+  languageName: node
+  linkType: hard
+
+"consola@npm:^3.2.3, consola@npm:^3.4.0":
+  version: 3.4.2
+  resolution: "consola@npm:3.4.2"
+  checksum: 10c0/7cebe57ecf646ba74b300bcce23bff43034ed6fbec9f7e39c27cee1dc00df8a21cd336b466ad32e304ea70fba04ec9e890c200270de9a526ce021ba8a7e4c11a
   languageName: node
   linkType: hard
 
@@ -9255,6 +9399,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deepmerge-ts@npm:7.1.5":
+  version: 7.1.5
+  resolution: "deepmerge-ts@npm:7.1.5"
+  checksum: 10c0/3a265a2086f334e3ecf43a7d4138c950cb99e0b39e816fa7fd7f5326161364e51b13010906908212667619066f5b48de738ed42543212323fbbb5d4ed7ebdc84
+  languageName: node
+  linkType: hard
+
 "deepmerge@npm:^4.3.1":
   version: 4.3.1
   resolution: "deepmerge@npm:4.3.1"
@@ -9331,7 +9482,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"defu@npm:^6.1.6":
+"defu@npm:^6.1.4, defu@npm:^6.1.6":
   version: 6.1.7
   resolution: "defu@npm:6.1.7"
   checksum: 10c0/e6635388103c8be3c574ac31302f6930e5e6eeedba32cb1b30cf993c7d9fb571aec2485446dfa23bfa63e55e66156fe109027a9695db82a50f931e91e8d4bedb
@@ -9361,7 +9512,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"destr@npm:^2.0.5":
+"destr@npm:^2.0.3, destr@npm:^2.0.5":
   version: 2.0.5
   resolution: "destr@npm:2.0.5"
   checksum: 10c0/efabffe7312a45ad90d79975376be958c50069f1156b94c181199763a7f971e113bd92227c26b94a169c71ca7dbc13583b7e96e5164743969fc79e1ff153e646
@@ -9517,6 +9668,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv@npm:^16.6.1":
+  version: 16.6.1
+  resolution: "dotenv@npm:16.6.1"
+  checksum: 10c0/15ce56608326ea0d1d9414a5c8ee6dcf0fffc79d2c16422b4ac2268e7e2d76ff5a572d37ffe747c377de12005f14b3cc22361e79fc7f1061cce81f77d2c973dc
+  languageName: node
+  linkType: hard
+
 "dotenv@npm:^17.2.1, dotenv@npm:^17.4.2":
   version: 17.4.2
   resolution: "dotenv@npm:17.4.2"
@@ -9565,6 +9723,16 @@ __metadata:
   version: 1.1.1
   resolution: "ee-first@npm:1.1.1"
   checksum: 10c0/b5bb125ee93161bc16bfe6e56c6b04de5ad2aa44234d8f644813cc95d861a6910903132b05093706de2b706599367c4130eb6d170f6b46895686b95f87d017b7
+  languageName: node
+  linkType: hard
+
+"effect@npm:3.21.0":
+  version: 3.21.0
+  resolution: "effect@npm:3.21.0"
+  dependencies:
+    "@standard-schema/spec": "npm:^1.0.0"
+    fast-check: "npm:^3.23.1"
+  checksum: 10c0/665cb8fd0862f334eeb1d0fbadb14913de358948c08929bfd079fd38903132ba54daa99da4c453f738c318fa5ce0de862bf8db08974d97a05d868f6bc685eb50
   languageName: node
   linkType: hard
 
@@ -9635,6 +9803,13 @@ __metadata:
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
   checksum: 10c0/af014e759a72064cf66e6e694a7fc6b0ed3d8db680427b021a89727689671cefe9d04151b2cad51dbaf85d5ba790d061cd167f1cf32eb7b281f6368b3c181639
+  languageName: node
+  linkType: hard
+
+"empathic@npm:2.0.0":
+  version: 2.0.0
+  resolution: "empathic@npm:2.0.0"
+  checksum: 10c0/7d3b14b04a93b35c47bcc950467ec914fd241cd9acc0269b0ea160f13026ec110f520c90fae64720fde72cc1757b57f3f292fb606617b7fccac1f4d008a76506
   languageName: node
   linkType: hard
 
@@ -10987,6 +11162,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"exsolve@npm:^1.0.7":
+  version: 1.0.8
+  resolution: "exsolve@npm:1.0.8"
+  checksum: 10c0/65e44ae05bd4a4a5d87cfdbbd6b8f24389282cf9f85fa5feb17ca87ad3f354877e6af4cd99e02fc29044174891f82d1d68c77f69234410eb8f163530e6278c67
+  languageName: node
+  linkType: hard
+
 "extend@npm:^3.0.0":
   version: 3.0.2
   resolution: "extend@npm:3.0.2"
@@ -11008,6 +11190,15 @@ __metadata:
   bin:
     extract-zip: cli.js
   checksum: 10c0/9afbd46854aa15a857ae0341a63a92743a7b89c8779102c3b4ffc207516b2019337353962309f85c66ee3d9092202a83cdc26dbf449a11981272038443974aee
+  languageName: node
+  linkType: hard
+
+"fast-check@npm:^3.23.1":
+  version: 3.23.2
+  resolution: "fast-check@npm:3.23.2"
+  dependencies:
+    pure-rand: "npm:^6.1.0"
+  checksum: 10c0/16fcff3c80321ee765e23c3aebd0f6427f175c9c6c1753104ec658970162365dc2d56bda046d815e8f2e90634c07ba7d6f0bcfd327fbd576d98c56a18a9765ed
   languageName: node
   linkType: hard
 
@@ -11626,6 +11817,22 @@ __metadata:
   version: 2.0.0
   resolution: "getenv@npm:2.0.0"
   checksum: 10c0/397ff641dd70cd78e414430258651e9a2228d3c5553a8cf15ae7840f75d3f10dfcb83f668f84829e84ea665b0fce2f08a9eddda3c9dcd7faa2d3da1c182c1854
+  languageName: node
+  linkType: hard
+
+"giget@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "giget@npm:2.0.0"
+  dependencies:
+    citty: "npm:^0.1.6"
+    consola: "npm:^3.4.0"
+    defu: "npm:^6.1.4"
+    node-fetch-native: "npm:^1.6.6"
+    nypm: "npm:^0.6.0"
+    pathe: "npm:^2.0.3"
+  bin:
+    giget: dist/cli.mjs
+  checksum: 10c0/606d81652643936ee7f76653b4dcebc09703524ff7fd19692634ce69e3fc6775a377760d7508162379451c03bf43cc6f46716aeadeb803f7cef3fc53d0671396
   languageName: node
   linkType: hard
 
@@ -13221,7 +13428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:^2.6.1":
+"jiti@npm:^2.4.2, jiti@npm:^2.6.1":
   version: 2.6.1
   resolution: "jiti@npm:2.6.1"
   bin:
@@ -15889,7 +16096,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch-native@npm:^1.6.7":
+"node-fetch-native@npm:^1.6.6, node-fetch-native@npm:^1.6.7":
   version: 1.6.7
   resolution: "node-fetch-native@npm:1.6.7"
   checksum: 10c0/8b748300fb053d21ca4d3db9c3ff52593d5e8f8a2d9fe90cbfad159676e324b954fdaefab46aeca007b5b9edab3d150021c4846444e4e8ab1f4e44cd3807be87
@@ -16076,6 +16283,19 @@ __metadata:
   version: 1.1.1
   resolution: "nullthrows@npm:1.1.1"
   checksum: 10c0/56f34bd7c3dcb3bd23481a277fa22918120459d3e9d95ca72976c72e9cac33a97483f0b95fc420e2eb546b9fe6db398273aba9a938650cdb8c98ee8f159dcb30
+  languageName: node
+  linkType: hard
+
+"nypm@npm:^0.6.0":
+  version: 0.6.5
+  resolution: "nypm@npm:0.6.5"
+  dependencies:
+    citty: "npm:^0.2.0"
+    pathe: "npm:^2.0.3"
+    tinyexec: "npm:^1.0.2"
+  bin:
+    nypm: dist/cli.mjs
+  checksum: 10c0/47a945e83085dc34e8f92c19afb21fc36230d9186af071dffff6e727332c49eb2df1f9abbd71eabfa366cd00d4cf314ba41a202dd111e5c25c2c5f117808b8c7
   languageName: node
   linkType: hard
 
@@ -16720,6 +16940,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"perfect-debounce@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "perfect-debounce@npm:1.0.0"
+  checksum: 10c0/e2baac416cae046ef1b270812cf9ccfb0f91c04ea36ac7f5b00bc84cb7f41bdbba087c0ab21b4e02a7ef3a1f1f6db399f137cecec46868bd7d8d88c2a9ee431f
+  languageName: node
+  linkType: hard
+
 "piccolore@npm:^0.1.3":
   version: 0.1.3
   resolution: "piccolore@npm:0.1.3"
@@ -16784,6 +17011,17 @@ __metadata:
     mlly: "npm:^1.7.4"
     pathe: "npm:^2.0.1"
   checksum: 10c0/19e6cb8b66dcc66c89f2344aecfa47f2431c988cfa3366bdfdcfb1dd6695f87dcce37fbd90fe9d1605e2f4440b77f391e83c23255347c35cf84e7fd774d7fcea
+  languageName: node
+  linkType: hard
+
+"pkg-types@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "pkg-types@npm:2.3.0"
+  dependencies:
+    confbox: "npm:^0.2.2"
+    exsolve: "npm:^1.0.7"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/d2bbddc5b81bd4741e1529c08ef4c5f1542bbdcf63498b73b8e1d84cff71806d1b8b1577800549bb569cb7aa20056257677b979bff48c97967cba7e64f72ae12
   languageName: node
   linkType: hard
 
@@ -17092,6 +17330,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prisma@npm:^6.0.0":
+  version: 6.19.3
+  resolution: "prisma@npm:6.19.3"
+  dependencies:
+    "@prisma/config": "npm:6.19.3"
+    "@prisma/engines": "npm:6.19.3"
+  peerDependencies:
+    typescript: ">=5.1.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    prisma: build/index.js
+  checksum: 10c0/454802479a7adc76bd9ee202c760acb25ecc317d138af0fb4e80e05086d96af2b758058cf58d58df6e0b127ce763a6d546b111f3b16afd02a1b13481b1a23e85
+  languageName: node
+  linkType: hard
+
 "prismjs@npm:^1.30.0":
   version: 1.30.0
   resolution: "prismjs@npm:1.30.0"
@@ -17250,6 +17505,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pure-rand@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "pure-rand@npm:6.1.0"
+  checksum: 10c0/1abe217897bf74dcb3a0c9aba3555fe975023147b48db540aa2faf507aee91c03bf54f6aef0eb2bf59cc259a16d06b28eca37f0dc426d94f4692aeff02fb0e65
+  languageName: node
+  linkType: hard
+
 "qs@npm:^6.14.0, qs@npm:^6.14.1":
   version: 6.15.0
   resolution: "qs@npm:6.15.0"
@@ -17317,6 +17579,16 @@ __metadata:
     iconv-lite: "npm:~0.7.0"
     unpipe: "npm:~1.0.0"
   checksum: 10c0/d266678d08e1e7abea62c0ce5864344e980fa81c64f6b481e9842c5beaed2cdcf975f658a3ccd67ad35fc919c1f6664ccc106067801850286a6cbe101de89f29
+  languageName: node
+  linkType: hard
+
+"rc9@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "rc9@npm:2.1.2"
+  dependencies:
+    defu: "npm:^6.1.4"
+    destr: "npm:^2.0.3"
+  checksum: 10c0/a2ead3b94bf033e35e4ea40d70062a09feddb8f589c3f5a8fe4e9342976974296aee9f6e9e72bd5e78e6ae4b7bc16dc244f63699fd7322c16314e3238db982c9
   languageName: node
   linkType: hard
 
@@ -17681,6 +17953,13 @@ __metadata:
     string_decoder: "npm:^1.1.1"
     util-deprecate: "npm:^1.0.1"
   checksum: 10c0/e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
+  languageName: node
+  linkType: hard
+
+"readdirp@npm:^4.0.1":
+  version: 4.1.2
+  resolution: "readdirp@npm:4.1.2"
+  checksum: 10c0/60a14f7619dec48c9c850255cd523e2717001b0e179dc7037cfa0895da7b9e9ab07532d324bfb118d73a710887d1e35f79c495fa91582784493e085d18c72c62
   languageName: node
   linkType: hard
 
@@ -19832,7 +20111,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyexec@npm:^1.0.1, tinyexec@npm:^1.0.4":
+"tinyexec@npm:^1.0.1, tinyexec@npm:^1.0.2, tinyexec@npm:^1.0.4":
   version: 1.1.1
   resolution: "tinyexec@npm:1.1.1"
   checksum: 10c0/48433cb32573a767e2b63bb92343cbbae4240d05a19a63f7869f9447491305e7bd82d11daccb79b2628b596ad703a25798226c50bfd1d8e63477fb42af6a5b35
@@ -21036,15 +21315,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "voiceclaw-tracing-ui@workspace:tracing-ui"
   dependencies:
-    "@types/better-sqlite3": "npm:^7.6.12"
+    "@prisma/client": "npm:^6.0.0"
     "@types/node": "npm:^22.9.0"
     "@types/react": "npm:^19.0.0"
     "@types/react-dom": "npm:^19.0.0"
     autoprefixer: "npm:^10.4.20"
-    better-sqlite3: "npm:^12.0.0"
     chart.js: "npm:^4.4.7"
     next: "npm:^15.1.0"
     postcss: "npm:^8.5.1"
+    prisma: "npm:^6.0.0"
     react: "npm:^19.0.0"
     react-chartjs-2: "npm:^5.3.0"
     react-dom: "npm:^19.0.0"


### PR DESCRIPTION
## Why

Raw SQL in `tracing-ui/src/lib/db.ts` was fine for the scaffold, but we already know where this is going: once the collector grows beyond a single-host SQLite file we want to point the reader at Postgres without rewriting every query. Prisma gets us typed queries now and a clean migration path later. This PR does the reader migration and owns the connection via a driver adapter so the Prisma config stops leaking into env vars.

## How

- Generated a Prisma schema that mirrors the collector's DDL (traces / observations / sessions / media). The schema is read-only from this package — the collector owns migrations.
- Adopted `@prisma/adapter-better-sqlite3` so the runtime connection is constructed in `src/lib/db.ts` with `readonly: true`, `fileMustExist: false`, and a 5s busy timeout. No more `VOICECLAW_TRACING_DB_URL` indirection — we take the same `VOICECLAW_TRACING_DB` path the collector reads, with `~/.voiceclaw/tracing.db` as a fallback. The `url` on the datasource block in `schema.prisma` is now a placeholder the adapter never consults.
- Most reads stay on `$queryRaw` + `CAST(start_time_ns AS REAL)` for the reason documented below; the aggregation in `listSessions` also remains raw because Prisma's fluent API can't express the trace-level CTE without an N+1.

## Tradeoffs

- **BigInt on SQLite INTEGER columns is still the blocker.** I verified with a throwaway test that the driver adapter does *not* sidestep the engine's INT32 range check — the adapter inspects the DDL decltype via `stmt.columns()`, maps `INTEGER` → `ColumnTypeEnum.Int32`, and the engine rejects the string-encoded i64 value before we see it. This fails identically for fluent reads, `$queryRaw` without CAST, and even `select` projections of a single BigInt column. The only real fix is migrating the collector's DDL to `BIGINT`, which is out of scope for this PR. Hence every timestamp-bearing query projects `CAST(... AS REAL)` so the engine sees `Double`; the precision loss is sub-microsecond (well below the ms resolution the UI renders).
- We add `@prisma/adapter-better-sqlite3` (runtime) and keep `better-sqlite3` in `dependencies` because the adapter requires it as a runtime peer. `@types/better-sqlite3` lands in devDependencies because `better-sqlite3` ships no types and the adapter's `.d.ts` re-exports its `Options` type.
- `schema.prisma` carries a placeholder `url` on the datasource block. Prisma 6's schema validator still requires one at `prisma generate` time even though the adapter owns the runtime connection; Prisma 7 lifts this.

## Verification

- `yarn tsc --noEmit` clean
- `yarn build` clean (4 routes compile, no warnings)
- `yarn dev` + curl of `/`, `/sessions`, `/sessions/<real-id>`, `/users`, `/dashboard` — all 200, real session rows render, no server errors