### PR TITLE
fix(tracing-collector): store OTel ns timestamps as BigInt (precision loss at ingest)

### DIFF
--- a/relay-server/test/test-collector-precision.ts
+++ b/relay-server/test/test-collector-precision.ts
@@ -1,0 +1,113 @@
+// Runtime precision test for the tracing-collector BigInt fix.
+//
+// Emits a span with a known ns-resolution start time, ships it via OTLP-HTTP
+// to a collector on localhost:4320 with a test DB, then reads back from the
+// same SQLite file to confirm no digits were lost at ingest.
+//
+// This is a throwaway smoke-test for PR #<bigint-precision>. Run with the
+// collector already listening on 4320 and pointing at
+// VOICECLAW_TRACING_DB=/tmp/voiceclaw-tracing-test.db:
+//
+//   cd relay-server && npx tsx test/test-collector-precision.ts
+//
+// Remove after the PR lands — this file exists only to prove the fix.
+
+import { NodeSDK } from "@opentelemetry/sdk-node"
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http"
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base"
+import { trace, SpanKind } from "@opentelemetry/api"
+import Database from "better-sqlite3"
+
+const COLLECTOR_URL = process.env.COLLECTOR_URL ?? "http://127.0.0.1:4320/v1/traces"
+const DB_PATH = process.env.TEST_DB ?? "/tmp/voiceclaw-tracing-test.db"
+
+async function main() {
+  const sdk = new NodeSDK({
+    serviceName: "precision-test",
+    spanProcessors: [new BatchSpanProcessor(new OTLPTraceExporter({ url: COLLECTOR_URL }))],
+  })
+  sdk.start()
+
+  const tracer = trace.getTracer("precision-test")
+
+  // Start a span "now" and hold it briefly. Nothing special about the value —
+  // the point is that current ns-since-epoch (~1.75e18 in 2026) is already
+  // two orders of magnitude past Number.MAX_SAFE_INTEGER (2^53 − 1 ≈ 9.007e15).
+  const span = tracer.startSpan("precision-probe", { kind: SpanKind.INTERNAL })
+  const traceId = span.spanContext().traceId
+  const spanId = span.spanContext().spanId
+  const emitNsApprox = BigInt(Date.now()) * 1_000_000n
+  await new Promise((r) => setTimeout(r, 5))
+  span.end()
+
+  await sdk.shutdown()
+
+  // BatchSpanProcessor is async; give the exporter + HTTP round-trip a moment
+  // to reach SQLite.
+  await new Promise((r) => setTimeout(r, 500))
+
+  const db = new Database(DB_PATH, { readonly: true })
+  // Read back as BigInt so we compare at full int64 precision. The collector
+  // stores int64 natively; a default Number read on the UI side would round.
+  const row = db
+    .prepare("SELECT start_time_ns, end_time_ns FROM traces WHERE trace_id = ?")
+    .safeIntegers(true)
+    .get(traceId) as { start_time_ns: bigint; end_time_ns: bigint | null } | undefined
+  const obs = db
+    .prepare(
+      "SELECT start_time_ns, end_time_ns, duration_ms FROM observations WHERE span_id = ?",
+    )
+    .safeIntegers(true)
+    .get(spanId) as
+    | { start_time_ns: bigint; end_time_ns: bigint | null; duration_ms: bigint | null }
+    | undefined
+  db.close()
+
+  if (!row || !obs) {
+    throw new Error(`no row found for trace=${traceId} span=${spanId}`)
+  }
+
+  console.log("trace_id         =", traceId)
+  console.log("span_id          =", spanId)
+  console.log("emit (approx ns) =", emitNsApprox.toString())
+  console.log("db.traces.start  =", row.start_time_ns.toString())
+  console.log("db.traces.end    =", row.end_time_ns?.toString() ?? "null")
+  console.log("db.obs.start     =", obs.start_time_ns.toString())
+  console.log("db.obs.end       =", obs.end_time_ns?.toString() ?? "null")
+  console.log("db.obs.duration  =", obs.duration_ms?.toString() ?? "null", "ms")
+
+  // Sanity: within a few ms of our reference.
+  const deltaMs = Number((row.start_time_ns - emitNsApprox) / 1_000_000n)
+  if (Math.abs(deltaMs) > 100) {
+    throw new Error(`start_time_ns drifted ${deltaMs}ms from expected — bad`)
+  }
+  console.log(`delta from emit-time reference: ${deltaMs}ms (OK)`)
+
+  // Demonstrate that the raw bigint carries digits a Number round-trip loses.
+  // OTel's clock source often rounds start times to whole ms, so start may be
+  // a coincidentally lossless round-trip. End times are essentially always
+  // sub-ms and expose the loss clearly.
+  const showLoss = (label: string, v: bigint | null) => {
+    if (v == null) return
+    const asNumber = Number(v)
+    const roundTripped = BigInt(asNumber)
+    if (v === roundTripped) {
+      console.log(`${label}: lossless Number round-trip (value ends in many zeros — common for start times)`)
+    } else {
+      console.log(`${label}: Number round-trip would SHIFT by ${v - roundTripped}ns`)
+      console.log(`  stored (bigint):  ${v.toString()}`)
+      console.log(`  via Number:       ${asNumber}`)
+      console.log(`  back to bigint:   ${roundTripped.toString()}`)
+    }
+  }
+  showLoss("traces.start_time_ns", row.start_time_ns)
+  showLoss("traces.end_time_ns  ", row.end_time_ns)
+  showLoss("obs.end_time_ns     ", obs.end_time_ns)
+
+  console.log("\nPASS — collector stored the full-precision int64 ns timestamp")
+}
+
+main().catch((err) => {
+  console.error("TEST FAILED:", err)
+  process.exit(1)
+})

--- a/tracing-collector/src/db.ts
+++ b/tracing-collector/src/db.ts
@@ -22,13 +22,20 @@ export function openDb(path: string = process.env.VOICECLAW_TRACING_DB ?? DEFAUL
   return db
 }
 
+// OTel timestamps are nanoseconds since epoch (~1.8e18 in 2026) — past the
+// 2^53 safe-integer ceiling of JS Number. We carry them as bigint end-to-end
+// in the writer so SQLite receives the exact int64 value. Callers that need a
+// JS number for display should convert AT THE DISPLAY BOUNDARY (typically by
+// dividing to ms first: `Number(ns / 1_000_000n)`). Converting ns to Number
+// earlier silently truncates — Number(1_745_000_000_000_000_000n) loses the
+// low digits before it ever reaches SQLite.
 export type TraceRow = {
   trace_id: string
   session_id: string | null
   user_id: string | null
   name: string | null
-  start_time_ns: number
-  end_time_ns: number | null
+  start_time_ns: bigint
+  end_time_ns: bigint | null
   input_json: string | null
   output_json: string | null
   metadata_json: string | null
@@ -43,8 +50,8 @@ export type ObservationRow = {
   kind: string | null
   observation_type: string | null
   service_name: string | null
-  start_time_ns: number
-  end_time_ns: number | null
+  start_time_ns: bigint
+  end_time_ns: bigint | null
   duration_ms: number | null
   status_code: string | null
   status_message: string | null

--- a/tracing-collector/src/otlp.ts
+++ b/tracing-collector/src/otlp.ts
@@ -71,9 +71,15 @@ export async function ingest(buf: Buffer, contentType: string | undefined) {
         const spanId = toHex(span.spanId)
         const parentSpanId = span.parentSpanId ? toHex(span.parentSpanId) : null
         const startNs = toNs(span.startTimeUnixNano)
-        const endNs = toNs(span.endTimeUnixNano) ?? null
+        const endNs = toNs(span.endTimeUnixNano)
+        // OTel ns timestamps are ~1.8e18 — past Number.MAX_SAFE_INTEGER (2^53 − 1
+        // ≈ 9e15). Subtract at bigint precision, THEN divide to ms, THEN cast to
+        // Number. Casting ns-scale bigints to Number first (`Number(endNs-startNs)`)
+        // would silently truncate the low digits and distort durations.
         const durationMs =
-          startNs != null && endNs != null ? Math.max(0, Math.round((Number(endNs - startNs)) / 1_000_000)) : null
+          startNs != null && endNs != null
+            ? Math.max(0, Number((endNs - startNs) / 1_000_000n))
+            : null
 
         // Promote usage/cost attrs into columns for fast aggregation.
         const tokensInput =
@@ -97,7 +103,7 @@ export async function ingest(buf: Buffer, contentType: string | undefined) {
           kind: span.kind != null ? String(span.kind) : null,
           observation_type: stringAttr(attrs, "langfuse.observation.type"),
           service_name: serviceName,
-          start_time_ns: startNs ?? 0,
+          start_time_ns: startNs ?? 0n,
           end_time_ns: endNs,
           duration_ms: durationMs,
           status_code: span.status?.code != null ? String(span.status.code) : null,
@@ -135,11 +141,8 @@ export async function ingest(buf: Buffer, contentType: string | undefined) {
             (prev?.session_id ?? sessionIdFromResource ?? stringAttr(attrs, "session.id")) ?? null,
           user_id: (prev?.user_id ?? userIdFromResource ?? stringAttr(attrs, "user.id")) ?? null,
           name: prev?.name ?? (isRoot ? span.name ?? null : null),
-          start_time_ns: Math.min(prev?.start_time_ns ?? startNs ?? 0, startNs ?? Number.MAX_SAFE_INTEGER),
-          end_time_ns:
-            prev?.end_time_ns != null && endNs != null
-              ? Math.max(prev.end_time_ns, endNs)
-              : (endNs ?? prev?.end_time_ns ?? null),
+          start_time_ns: minBigInt(prev?.start_time_ns, startNs) ?? 0n,
+          end_time_ns: maxBigInt(prev?.end_time_ns, endNs),
           input_json:
             prev?.input_json ??
             (isRoot ? stringAttr(attrs, "langfuse.observation.input") ?? null : null),
@@ -200,12 +203,40 @@ function toHex(val: string | Uint8Array | undefined): string {
   return Buffer.from(val).toString("hex")
 }
 
-function toNs(val: string | number | bigint | undefined): number | null {
+// OTel wire format delivers ns timestamps as bigint (protobuf uint64 via
+// otlp-transformer), decimal strings (JSON OTLP), or number (when the sender
+// rounded). We normalize to bigint so the downstream pipeline never touches
+// a lossy Number representation. Why bigint: ns values in 2026 are ~1.75e18,
+// far past Number.MAX_SAFE_INTEGER (2^53 − 1 ≈ 9.007e15). `Number(bigint)`
+// silently truncates low bits — it does not throw, it does not warn, it just
+// rounds to the nearest representable double. Two spans 500ns apart become
+// indistinguishable, and that data loss is permanent at ingest.
+function toNs(val: string | number | bigint | undefined): bigint | null {
   if (val == null) return null
-  if (typeof val === "number") return val
-  if (typeof val === "bigint") return Number(val)
-  const n = Number(val)
-  return Number.isFinite(n) ? n : null
+  if (typeof val === "bigint") return val
+  if (typeof val === "number") {
+    if (!Number.isFinite(val)) return null
+    // A sender that delivers ns as a Number has already lost precision on its
+    // side; we preserve what we got rather than inventing digits.
+    return BigInt(Math.trunc(val))
+  }
+  try {
+    return BigInt(val)
+  } catch {
+    return null
+  }
+}
+
+function minBigInt(a: bigint | null | undefined, b: bigint | null | undefined): bigint | null {
+  if (a == null) return b ?? null
+  if (b == null) return a
+  return a < b ? a : b
+}
+
+function maxBigInt(a: bigint | null | undefined, b: bigint | null | undefined): bigint | null {
+  if (a == null) return b ?? null
+  if (b == null) return a
+  return a > b ? a : b
 }
 
 function stringAttr(attrs: Record<string, unknown>, key: string): string | null {


### PR DESCRIPTION
## Why

OTel ns timestamps (~1.8e18 in 2026) are ~200x past `Number.MAX_SAFE_INTEGER` (2^53 − 1 ≈ 9.007e15). The old `toNs` in `tracing-collector/src/otlp.ts` called `Number(bigint)`, which silently rounds low bits to the nearest representable double. The value SQLite persisted was **already fuzzy** — spans 100ns apart could land on the same rounded value, and that data loss was permanent at ingest. The UI never noticed because it only displays ms.

Flagged by an independent Gemini review of #174.

<details><summary>Why this was silently broken — the learn section</summary>

**The 2^53 wall.** JavaScript's `number` is a 64-bit IEEE-754 double. Integers stay exact up to `2^53 − 1` (~9.007e15). Above that, only even numbers are representable at 2^54, then multiples of 4 at 2^55, and so on. A nanosecond timestamp in 2026 is ~1.75e18 — 128x past the wall. At that magnitude the spacing between representable doubles is ~256, so the last ~3 decimal digits are lossy.

**`Number(bigint)` does not throw.** It uses the same round-to-nearest-even rule as any double conversion. There is no warning. There is no hint. It looks identical to code paths where the value happens to be < 2^53. The symptom is that sub-µs ordering vanishes, but only for timestamps you never look at at that precision — i.e., it's invisible until a reviewer thinks to check.

Concrete example from the smoke test (`relay-server/test/test-collector-precision.ts`):
- Stored in SQLite (int64, exact): `1776969403794790542`
- Via `Number(...)`: `1776969403794790700`
- `BigInt(Number(...))` round-trip: `1776969403794790656`
- Shift: **+114ns** just from the ns → Number → ns round-trip. Before this fix, **the +114ns value was what got written to SQLite.**

**`better-sqlite3`'s default is asymmetric.** Binding a BigInt works natively — sqlite is an int64 engine internally, the binding path is lossless. Reading an INTEGER column returns a JS Number by default — lossy at int64 scale. To read BigInt back, call `.safeIntegers(true)` on the statement (or `db.defaultSafeIntegers(true)` globally). The writer in this fix relies on the lossless binding path and does **not** enable safeIntegers — there's no read-back on the write side.

**Why the UI is unchanged.** The reader's queries use `MIN(start_time_ns)`, `MAX(end_time_ns)`, etc., and SQLite does that arithmetic internally at int64 precision. The final aggregated value comes back to JS as a Number, which is lossy — but the UI only divides to ms for display, and ms-scale precision is well under 2^53 for any realistic span. Losing the ns suffix at the read boundary is acceptable; losing it at the **write** boundary was destroying data.

**Why `Math.min`/`Math.max` had to go.** The old trace-merge path called `Math.min(prev?.start_time_ns, startNs)` — but `Math.min` on a BigInt throws (`TypeError: Cannot convert a BigInt value to a number`). Replaced with explicit `minBigInt`/`maxBigInt` helpers. The sentinel `Number.MAX_SAFE_INTEGER` that the old code used as a "no previous value" marker is also gone — ironic, since that sentinel is exactly the precision ceiling the bug was crossing.
</details>

<details><summary>Test plan</summary>

- [x] `npx tsc --noEmit` in `tracing-collector/` — clean
- [x] `npx tsc --noEmit` in `tracing-ui/` — clean (reader contract unchanged; Numbers still returned to UI code)
- [x] Ran new smoke test `relay-server/test/test-collector-precision.ts` against a local collector pointed at `/tmp/voiceclaw-tracing-test.db` — PASS. Direct SQLite readback (`safeIntegers(true)`) shows the stored `end_time_ns` = `1776969403794790542`, which a Number round-trip would shift to `1776969403794790656` (+114ns drift).
- [x] `sqlite3 /tmp/voiceclaw-tracing-test.db "SELECT typeof(start_time_ns) FROM traces"` → `integer` (INT64; SQLite's `typeof` doesn't distinguish int32 vs int64).
- [x] `relay-server/test/test-brain-traceparent.ts` still passes (unrelated but confirms no regression in the tracing plumbing upstream of the collector).
- [ ] Deferred: boot `yarn dev:tracing-ui` and visit `/sessions` end-to-end. SQL aggregates work from direct queries; the UI's typecheck is clean; skipped as low-risk given the reader's contract didn't change.

</details>

<details><summary>Implementation notes</summary>

- **Migration story:** none needed. Old rows in `~/.voiceclaw/tracing.db` are already fuzzy; they stay that way. New rows written after this fix are precise. No schema change — SQLite INTEGER storage already holds int64 regardless of what the JS side called it.
- **Writer does NOT enable `safeIntegers(true)`.** `better-sqlite3` accepts BigInt bindings losslessly regardless of that flag (confirmed via context7 + the smoke test). Enabling safeIntegers globally would force the reader's aggregation queries to return BigInt, which would cascade through the UI. Keeping the default and binding BigInt is the minimal surface change.
- **Reader unchanged.** `tracing-ui/src/lib/db.ts` still types `start_time_ns: number`. When the UI reads an int64 it becomes a rounded Number, which is fine for ms-scale display and keeps the UI code simple. If we ever need ns precision downstream we can flip `safeIntegers` per-statement in the reader.
- **Helper placement:** `minBigInt`/`maxBigInt` live at the bottom of `otlp.ts` per project convention (public interface at top, helpers at bottom). No semicolons added.
- **Throwaway test file:** `relay-server/test/test-collector-precision.ts` is a standalone smoke test — drop it if preferred; it's not in any runner. I left it because it's the only thing that proves the fix end-to-end.
</details>