### PR TITLE
fix(monorepo): isolate better-sqlite3 per workspace to end ABI ping-pong

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -7,7 +7,10 @@
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "typecheck": "tsc --noEmit",
-    "postinstall": "electron-rebuild -f -w better-sqlite3"
+    "postinstall": "electron-rebuild -f -w better-sqlite3 --module-dir ."
+  },
+  "installConfig": {
+    "hoistingLimits": "workspaces"
   },
   "dependencies": {
     "better-sqlite3": "^12.9.0",
@@ -29,8 +32,5 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "vite": "^8.0.8"
-  },
-  "installConfig": {
-    "hoistingLimits": "workspaces"
   }
 }

--- a/tracing-collector/package.json
+++ b/tracing-collector/package.json
@@ -9,6 +9,9 @@
     "build": "tsc",
     "start": "node dist/index.js"
   },
+  "installConfig": {
+    "hoistingLimits": "workspaces"
+  },
   "dependencies": {
     "@opentelemetry/otlp-transformer": "^0.215.0",
     "better-sqlite3": "^12.0.0"

--- a/tracing-ui/package.json
+++ b/tracing-ui/package.json
@@ -9,6 +9,9 @@
     "start": "next start --port 4319",
     "typecheck": "tsc --noEmit"
   },
+  "installConfig": {
+    "hoistingLimits": "workspaces"
+  },
   "dependencies": {
     "better-sqlite3": "^12.0.0",
     "chart.js": "^4.4.7",


### PR DESCRIPTION
## Why

The monorepo mixes two runtimes — Node (for \`tracing-collector\` and \`tracing-ui\`, ABI 141 under Node v25) and Electron (for \`desktop\`, ABI 145 under Electron 41). Both workspaces declare \`better-sqlite3\`, and until this PR Yarn hoisted a single copy to root. Running either stack's rebuild poisoned the other:

- \`electron-rebuild\` from \`desktop/\` walks the whole workspace dep tree and rebuilds the root's copy to ABI 145 → collector + tracing-ui crash with \`NODE_MODULE_VERSION\` mismatch on next start.
- \`yarn install\` / \`prebuild-install\` in a Node workspace flips root back to ABI 141 → desktop crashes next time it launches.

Whichever stack you ran last won. We hit this twice today while testing.

## Fix

- Set \`installConfig.hoistingLimits: \"workspaces\"\` on the three workspaces that use \`better-sqlite3\`. Each keeps its own copy in its own \`node_modules\`; root has none, so there is nothing for cross-rebuilds to clobber.
- Scope desktop's \`postinstall\` with \`--module-dir .\` so even if electron-rebuild's tree walk expands later, it stays inside \`desktop/\`.

## What this means for the dev loop

- One \`yarn install\` sets up all three correctly. Desktop's postinstall compiles for Electron; the Node workspaces get \`better-sqlite3\`'s shipped Node-ABI prebuild.
- Switching between \`yarn dev:desktop\` and \`yarn dev:tracing\` no longer requires manual rebuilds.
- Slightly more disk (three copies of \`better_sqlite3.node\`, ~2 MB each). Worth it.

<details><summary>Test plan</summary>

- [x] Clean install from scratch — each workspace has its own \`better-sqlite3\`, root has none.
- [x] \`require(\"better-sqlite3\")\` under Node from \`tracing-collector/\` → ABI 141, opens in-memory DB, \`pragma journal_mode\` returns.
- [x] \`require(\"better-sqlite3\")\` under Node from \`tracing-ui/\` → ABI 141, same.
- [x] \`require(\"better-sqlite3\")\` under Node from \`desktop/\` → \`ERR_DLOPEN_FAILED\` (Electron-rebuilt, as intended).
- [x] \`yarn postinstall\` in \`desktop/\` (i.e. re-running electron-rebuild) → desktop's copy rebuilt, Node workspace copies untouched, root still absent.
- [ ] Full desktop boot — reviewer to verify in their own env.
- [ ] \`yarn dev:tracing\` + \`yarn dev:desktop\` simultaneously — reviewer to verify both work after a single \`yarn install\`.

</details>

<details><summary>Implementation notes</summary>

- Yarn Berry's \`installConfig.hoistingLimits: \"workspaces\"\` is the documented per-workspace nohoist mechanism (replaces the Yarn 1 \`nohoist\` array). Value \`\"workspaces\"\` means \"do not hoist beyond this workspace's own \`node_modules\`\".
- Alternative considered: a single \`predev\` hook that rebuilds the shared root copy for the correct runtime on each \`yarn dev:*\` invocation. Rejected — brittle, slow, and still leaves you one stray \`yarn install\` away from a wrong ABI.
- Alternative considered: move \`better-sqlite3\` out of the Node workspaces and replace it with \`sqlite\` (pure JS) or a native client-server SQLite. Too large a change for an infra fix; each workspace's existing usage is small and correct.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)