### PR TITLE
Stamp usage OTel attrs on voice turns (NAN-650)

### DIFF
--- a/relay-server/src/tracing/turn-tracer.ts
+++ b/relay-server/src/tracing/turn-tracer.ts
@@ -329,6 +329,8 @@ export class TurnTracer {
     if (usage.inputAudioTokens != null) usageDetails.input_audio = usage.inputAudioTokens
     if (usage.outputAudioTokens != null) usageDetails.output_audio = usage.outputAudioTokens
     target.update({ usageDetails })
+    const otelUsage = usageToOtelAttrs(usage)
+    if (Object.keys(otelUsage).length > 0) target.otelSpan.setAttributes(otelUsage)
   }
 
   // Stamp media-capture attrs on the voice-turn span for `turnId`. Written as
@@ -460,4 +462,18 @@ function safeParse(s: string): unknown {
 
 function isNonNegativeFinite(v: number | undefined): v is number {
   return typeof v === "number" && Number.isFinite(v) && v >= 0
+}
+
+export function usageToOtelAttrs(usage: {
+  promptTokens?: number
+  completionTokens?: number
+  inputAudioTokens?: number
+  outputAudioTokens?: number
+}): Record<string, number> {
+  const attrs: Record<string, number> = {}
+  if (usage.promptTokens != null) attrs["gen_ai.usage.input_tokens"] = usage.promptTokens
+  if (usage.completionTokens != null) attrs["gen_ai.usage.output_tokens"] = usage.completionTokens
+  if (usage.inputAudioTokens != null) attrs["gen_ai.usage.input_audio_tokens"] = usage.inputAudioTokens
+  if (usage.outputAudioTokens != null) attrs["gen_ai.usage.output_audio_tokens"] = usage.outputAudioTokens
+  return attrs
 }

--- a/relay-server/test/test-usage-collector-e2e.ts
+++ b/relay-server/test/test-usage-collector-e2e.ts
@@ -1,0 +1,33 @@
+// End-to-end check for relay-emitted usage attrs:
+// TurnTracer -> OTel exporter -> running tracing-collector -> SQLite.
+//
+// Run with a collector already listening:
+// TRACING_UI_COLLECTOR_URL=http://127.0.0.1:4318/v1/traces npx tsx test/test-usage-collector-e2e.ts
+
+const collectorUrl = process.env.TRACING_UI_COLLECTOR_URL
+if (!collectorUrl) {
+  throw new Error("TRACING_UI_COLLECTOR_URL must point at a running tracing-collector")
+}
+
+const sessionKey = `usage-e2e-${Date.now()}`
+
+const { initLangfuse, shutdownLangfuse } = await import("../src/tracing/langfuse.js")
+const { TurnTracer } = await import("../src/tracing/turn-tracer.js")
+
+initLangfuse()
+
+const tracer = new TurnTracer()
+tracer.startSession(sessionKey, "usage-e2e-user", "gpt-realtime-mini", "test instructions")
+tracer.startTurn()
+tracer.appendUserText("hello")
+tracer.appendAssistantText("hi")
+tracer.attachUsage({
+  promptTokens: 11,
+  completionTokens: 7,
+  inputAudioTokens: 13,
+  outputAudioTokens: 17,
+})
+tracer.endSession()
+await shutdownLangfuse()
+
+console.log(`  PASS  exported usage voice-turn for session ${sessionKey}`)

--- a/relay-server/test/test-usage-otel-attrs.ts
+++ b/relay-server/test/test-usage-otel-attrs.ts
@@ -1,0 +1,36 @@
+// Unit test for voice-turn usage OTel attribute mapping.
+//
+// Run: npx tsx test/test-usage-otel-attrs.ts
+
+import { usageToOtelAttrs } from "../src/tracing/turn-tracer.js"
+
+function run() {
+  const attrs = usageToOtelAttrs({
+    promptTokens: 123,
+    completionTokens: 45,
+    inputAudioTokens: 67,
+    outputAudioTokens: 89,
+  })
+
+  expectEqual("input tokens", attrs["gen_ai.usage.input_tokens"], 123)
+  expectEqual("output tokens", attrs["gen_ai.usage.output_tokens"], 45)
+  expectEqual("input audio tokens", attrs["gen_ai.usage.input_audio_tokens"], 67)
+  expectEqual("output audio tokens", attrs["gen_ai.usage.output_audio_tokens"], 89)
+
+  const partial = usageToOtelAttrs({ inputAudioTokens: 10 })
+  expectEqual("partial key count", Object.keys(partial).length, 1)
+  expectEqual("partial input audio tokens", partial["gen_ai.usage.input_audio_tokens"], 10)
+
+  const empty = usageToOtelAttrs({})
+  expectEqual("empty key count", Object.keys(empty).length, 0)
+
+  console.log("  PASS  usage metrics map to vendor-neutral OTel attrs")
+}
+
+run()
+
+function expectEqual(label: string, actual: unknown, expected: unknown) {
+  if (actual !== expected) {
+    throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+  }
+}


### PR DESCRIPTION
## Summary
- Stamp vendor-neutral `gen_ai.usage.*` OTel attributes on voice-turn spans after updating Langfuse usageDetails
- Add focused unit coverage for usage mapping plus a relay-to-collector e2e export check

## Test plan
- [x] `yarn workspace relay-server build`
- [x] `yarn workspace relay-server exec tsx test/test-usage-otel-attrs.ts`
- [x] `yarn workspace voiceclaw-tracing-collector build`
- [x] Start tracing collector with isolated DB on `127.0.0.1:54318`
- [x] Start relay on `127.0.0.1:58080` and verify `/health`
- [x] `TRACING_UI_COLLECTOR_URL=http://127.0.0.1:54318/v1/traces yarn workspace relay-server exec tsx test/test-usage-collector-e2e.ts`
- [x] `sqlite3 /tmp/.../tracing.db` confirmed latest `voice-turn` attrs: `11|7|13|17`
- [x] Gemini review: LGTM