### PR TITLE
Add Grok Voice Think Fast realtime model

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Platform: macOS](https://img.shields.io/badge/Platform-macOS-000000?logo=apple&logoColor=white)]()
 [![Platform: iOS](https://img.shields.io/badge/Platform-iOS-000000?logo=apple&logoColor=white)]()
 [![Gemini Live](https://img.shields.io/badge/Gemini-Live_API-4285F4?logo=google&logoColor=white)]()
-[![OpenAI Realtime](https://img.shields.io/badge/OpenAI-Realtime_API-412991?logo=openai&logoColor=white)]()
+[![Grok Voice](https://img.shields.io/badge/Grok-Voice_API-000000)]()
 [![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker&logoColor=white)](relay-server/Dockerfile)
 
 Open-source voice AI assistant. Talk to any AI model in real time from your phone or desktop.
@@ -72,7 +72,7 @@ yarn dev            # mobile + web + server together
 
 ## How it works: the `ask_brain` pattern
 
-Realtime voice models (Gemini Live, OpenAI Realtime) are great at natural conversation but can't use tools, access memory, or call external APIs on their own. VoiceClaw bridges this gap with a simple escalation pattern:
+Realtime voice models (Gemini Live, Grok Voice, OpenAI Realtime) are great at natural conversation but can't use tools, access memory, or call external APIs on their own. VoiceClaw bridges this gap with a simple escalation pattern:
 
 1. You speak to a **realtime voice model** that handles conversation naturally
 2. When the model needs capabilities it doesn't have, it calls the `ask_brain` tool
@@ -97,7 +97,7 @@ flowchart LR
   end
     Mobile -- WebSocket<br>audio+video --> Relay["🔗 Relay Server<br>(TypeScript / Node.js)<br><br>- Session mgmt<br>- Provider adapter<br>- Brain agent gateway<br>- Tracing (Langfuse / OTEL)"]
     Desktop -- WebSocket<br>audio + video --> Relay
-    Relay <-- Provider WebSocket<br>audio + video --> Provider["📢 Realtime AI Provider<br>(Gemini Live / OpenAI Realtime)<br><br>- Speech to Speech"]
+    Relay <-- Provider WebSocket<br>audio + video --> Provider["📢 Realtime AI Provider<br>(Gemini Live / Grok Voice / OpenAI Realtime)<br><br>- Speech to Speech"]
     Provider -- tool call: ask_brain --> Relay
     Relay <-- POST /v1/chat/completions<br>(SSE stream) --> Brain["🧠 Brain AI<br>(OpenAI-compatible agent)<br><br>- Web search<br>- Calendar / tasks<br>- Long-term memory"]
 
@@ -146,6 +146,7 @@ The relay server reads these environment variables from `relay-server/.env`:
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `GEMINI_API_KEY` | Yes (for Gemini provider) | Google Gemini API key for Live API |
+| `XAI_API_KEY` | Yes (for xAI provider) | xAI API key for Grok Voice API |
 | `OPENAI_API_KEY` | Yes (for OpenAI provider) | OpenAI API key for Realtime API |
 | `RELAY_API_KEY` | Recommended | API key clients must send to connect. Generate with `openssl rand -hex 24` |
 | `BRAIN_GATEWAY_AUTH_TOKEN` | Optional | Auth token for your brain agent endpoint |
@@ -155,7 +156,7 @@ The relay server reads these environment variables from `relay-server/.env`:
 | `LANGFUSE_SECRET_KEY` | Optional | Langfuse tracing secret key |
 | `LANGFUSE_BASE_URL` | Optional | Langfuse endpoint (default: `https://cloud.langfuse.com`) |
 
-You need at least one provider key (`OPENAI_API_KEY` or `GEMINI_API_KEY`) for the relay to be useful.
+You need at least one provider key (`GEMINI_API_KEY`, `XAI_API_KEY`, or `OPENAI_API_KEY`) for the relay to be useful.
 
 ## Project Structure
 

--- a/desktop/src/renderer/src/lib/use-realtime.ts
+++ b/desktop/src/renderer/src/lib/use-realtime.ts
@@ -200,7 +200,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
 
       ws.onopen = async () => {
         console.log('[useRealtime] WebSocket connected, sending session.config')
-        const provider = config.model?.startsWith('gemini-') ? 'gemini' : 'openai'
+        const provider = getProviderForRealtimeModel(config.model)
         ws.send(
           JSON.stringify({
             type: 'session.config',
@@ -313,4 +313,10 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
   }, [])
 
   return { start, stop, setMuted, sendFrame, getInputLevel, isConnected, isReconnecting, sessionId }
+}
+
+function getProviderForRealtimeModel(model?: string): 'gemini' | 'openai' | 'xai' {
+  if (model?.startsWith('gemini-')) return 'gemini'
+  if (model?.startsWith('grok-voice-')) return 'xai'
+  return 'openai'
 }

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -18,6 +18,11 @@ import {
   type Message,
 } from '../lib/db'
 
+const DEFAULT_REALTIME_MODEL = 'gemini-3.1-flash-live-preview'
+const REALTIME_MODELS = ['gemini-3.1-flash-live-preview', 'grok-voice-think-fast-1.0'] as const
+const GEMINI_VOICES = ['Puck', 'Charon', 'Kore', 'Fenrir', 'Aoede', 'Leda', 'Orus', 'Zephyr'] as const
+const XAI_VOICES = ['eve', 'ara', 'rex', 'sal', 'leo'] as const
+
 export function ChatPage() {
   const [messages, setMessages] = useState<Message[]>([])
   const [conversationId, setConversationId] = useState<number | null>(null)
@@ -31,6 +36,7 @@ export function ChatPage() {
   const [streamingRole, setStreamingRole] = useState<'user' | 'assistant'>('assistant')
   const [showLatency, setShowLatency] = useState(false)
   const [connectionError, setConnectionError] = useState('')
+  const [activeRealtimeModel, setActiveRealtimeModel] = useState('')
   const [showScreenPicker, setShowScreenPicker] = useState(false)
   const [isScreenSharing, setIsScreenSharing] = useState(false)
   const [screenSourceName, setScreenSourceName] = useState('')
@@ -178,14 +184,15 @@ export function ChatPage() {
     setConnectionError('')
     setIsConnecting(true)
     const serverUrl = (await getSetting('realtime_server_url')) || 'ws://localhost:8080/ws'
-    const voice = (await getSetting('realtime_voice')) || 'Zephyr'
-    const model = (await getSetting('realtime_model')) || 'gemini-3.1-flash-live-preview'
+    const model = normalizeRealtimeModel(await getSetting('realtime_model'))
+    const voice = normalizeRealtimeVoice(model, await getSetting('realtime_voice'))
     const apiKey = (await getSetting('realtime_api_key')) || ''
     const volume = parseFloat((await getSetting('realtime_volume')) || '1.0')
     const tracingEnabled = (await getSetting('tracing_enabled')) === 'true'
     const inputDeviceId = (await getSetting('input_device_id')) || undefined
     const outputDeviceId = (await getSetting('output_device_id')) || undefined
 
+    setActiveRealtimeModel(model)
     realtime.start({
       serverUrl,
       voice,
@@ -211,6 +218,7 @@ export function ChatPage() {
     setIsThinking(false)
     setStreamingText('')
     setIsMuted(false)
+    setActiveRealtimeModel('')
   }, [realtime])
 
   const toggleMute = useCallback(() => {
@@ -228,6 +236,7 @@ export function ChatPage() {
   }, [isCallActive, endCall])
 
   const startScreenShare = useCallback(async (source: ScreenSource) => {
+    if (activeRealtimeModel.startsWith('grok-voice-')) return
     setShowScreenPicker(false)
     const capture = new ScreenCapture()
     capture.setSourceName(source.name)
@@ -242,7 +251,7 @@ export function ChatPage() {
       console.error('[ChatPage] Screen capture failed:', err)
       screenCaptureRef.current = null
     }
-  }, [realtime])
+  }, [activeRealtimeModel, realtime])
 
   const stopScreenShare = useCallback(() => {
     screenCaptureRef.current?.stop()
@@ -257,6 +266,13 @@ export function ChatPage() {
       stopScreenShare()
     }
   }, [isCallActive, isScreenSharing, stopScreenShare])
+
+  const screenShareDisabled = isConnecting || (!isScreenSharing && activeRealtimeModel.startsWith('grok-voice-'))
+  const screenShareTitle = isScreenSharing
+    ? 'Stop screen sharing'
+    : activeRealtimeModel.startsWith('grok-voice-')
+      ? 'Screen sharing is only available with Gemini Live. Grok Voice does not support video input.'
+      : 'Share screen'
 
   // Keyboard shortcuts: Cmd+N (new), Cmd+M (mute), Cmd+E (end call)
   useEffect(() => {
@@ -390,15 +406,17 @@ export function ChatPage() {
             >
               {isMuted ? <MicOff size={20} /> : <Mic size={20} />}
             </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={isScreenSharing ? stopScreenShare : () => setShowScreenPicker(true)}
-              className={isScreenSharing ? 'text-green-500' : 'text-foreground'}
-              disabled={isConnecting}
-            >
-              {isScreenSharing ? <MonitorOff size={20} /> : <Monitor size={20} />}
-            </Button>
+            <span title={screenShareTitle} className="inline-flex">
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={isScreenSharing ? stopScreenShare : () => setShowScreenPicker(true)}
+                className={isScreenSharing ? 'text-green-500' : screenShareDisabled ? 'text-muted-foreground opacity-50' : 'text-foreground'}
+                disabled={screenShareDisabled}
+              >
+                {isScreenSharing ? <MonitorOff size={20} /> : <Monitor size={20} />}
+              </Button>
+            </span>
             <Button
               variant="destructive"
               size="icon"
@@ -440,4 +458,18 @@ function generateTitle(text: string): string {
   const lastSpace = truncated.lastIndexOf(' ')
   const title = lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated
   return title.trim() + '...'
+}
+
+function normalizeRealtimeModel(model: string | null): typeof REALTIME_MODELS[number] {
+  return (REALTIME_MODELS as readonly string[]).includes(model ?? '')
+    ? model as typeof REALTIME_MODELS[number]
+    : DEFAULT_REALTIME_MODEL
+}
+
+function normalizeRealtimeVoice(model: typeof REALTIME_MODELS[number], voice: string | null): string {
+  if (model.startsWith('grok-voice-')) {
+    return voice && (XAI_VOICES as readonly string[]).includes(voice) ? voice : 'eve'
+  }
+
+  return voice && (GEMINI_VOICES as readonly string[]).includes(voice) ? voice : 'Zephyr'
 }

--- a/desktop/src/renderer/src/pages/SettingsPage.tsx
+++ b/desktop/src/renderer/src/pages/SettingsPage.tsx
@@ -21,7 +21,17 @@ const GEMINI_VOICE_LABELS: Record<typeof GEMINI_VOICES[number], string> = {
   Zephyr: 'Zephyr (F)',
 }
 
-type RealtimeModel = 'gpt-realtime-mini' | 'gpt-realtime-1.5' | 'gemini-3.1-flash-live-preview'
+const XAI_VOICES = ['eve', 'ara', 'rex', 'sal', 'leo'] as const
+const XAI_VOICE_LABELS: Record<typeof XAI_VOICES[number], string> = {
+  eve: 'Eve (F)',
+  ara: 'Ara (F)',
+  rex: 'Rex (M)',
+  sal: 'Sal (N)',
+  leo: 'Leo (M)',
+}
+
+type RealtimeModel = 'gemini-3.1-flash-live-preview' | 'grok-voice-think-fast-1.0'
+const DEFAULT_REALTIME_MODEL: RealtimeModel = 'gemini-3.1-flash-live-preview'
 
 export function SettingsPage() {
   const { theme, setTheme } = useTheme()
@@ -58,9 +68,13 @@ export function SettingsPage() {
       const key = await getSetting('realtime_api_key')
       if (key) setApiKey(key)
       const m = await getSetting('realtime_model')
-      if (m === 'gpt-realtime-mini' || m === 'gpt-realtime-1.5' || m === 'gemini-3.1-flash-live-preview') setModel(m)
+      const loadedModel = normalizeRealtimeModel(m)
+      setModel(loadedModel)
+      if (m && m !== loadedModel) setSetting('realtime_model', loadedModel)
       const v = await getSetting('realtime_voice')
-      if (v) setVoice(v)
+      const loadedVoice = normalizeRealtimeVoice(loadedModel, v)
+      setVoice(loadedVoice)
+      if (v !== loadedVoice) setSetting('realtime_voice', loadedVoice)
       const vol = await getSetting('realtime_volume')
       if (vol) setVolume(parseFloat(vol))
       const inDev = await getSetting('input_device_id')
@@ -101,12 +115,14 @@ export function SettingsPage() {
     // Reset voice when switching providers
     const isGemini = v.startsWith('gemini-')
     const currentIsGemini = (GEMINI_VOICES as readonly string[]).includes(voice)
+    const isXAI = v.startsWith('grok-voice-')
+    const currentIsXAI = (XAI_VOICES as readonly string[]).includes(voice)
     if (isGemini && !currentIsGemini) {
       setVoice('Zephyr')
       save('realtime_voice', 'Zephyr')
-    } else if (!isGemini && currentIsGemini) {
-      setVoice('marin')
-      save('realtime_voice', 'marin')
+    } else if (isXAI && !currentIsXAI) {
+      setVoice('eve')
+      save('realtime_voice', 'eve')
     }
   }, [save, voice])
 
@@ -215,17 +231,14 @@ export function SettingsPage() {
         <Card className="p-4 space-y-4">
           <h3 className="text-sm font-semibold text-foreground">Model</h3>
           <div className="space-y-1.5">
-            {(['gemini-3.1-flash-live-preview', 'gpt-realtime-mini', 'gpt-realtime-1.5'] as const).map((m) => {
-              const isGemini = m.startsWith('gemini-')
-              const disabled = !isGemini
+            {(['gemini-3.1-flash-live-preview', 'grok-voice-think-fast-1.0'] as const).map((m) => {
               return (
                 <button
                   key={m}
-                  onClick={() => !disabled && updateModel(m)}
-                  disabled={disabled}
+                  onClick={() => updateModel(m)}
                   className={`w-full flex items-center gap-3 rounded-lg border px-3 py-2 text-left transition-colors
                     ${model === m ? 'border-primary bg-primary/10' : 'border-input'}
-                    ${disabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-accent cursor-pointer'}
+                    hover:bg-accent cursor-pointer
                   `}
                 >
                   <div className={`h-3.5 w-3.5 rounded-full border-2 flex items-center justify-center
@@ -234,13 +247,8 @@ export function SettingsPage() {
                     {model === m && <div className="h-1.5 w-1.5 rounded-full bg-primary" />}
                   </div>
                   <span className={`text-sm ${model === m ? 'font-medium text-foreground' : 'text-muted-foreground'}`}>
-                    {m === 'gemini-3.1-flash-live-preview' ? 'Gemini 3.1 Flash Live' : m === 'gpt-realtime-mini' ? 'GPT Realtime Mini' : 'GPT Realtime 1.5'}
+                    {m === 'gemini-3.1-flash-live-preview' ? 'Gemini 3.1 Flash Live' : 'Grok Voice Think Fast 1.0'}
                   </span>
-                  {disabled && (
-                    <span className="ml-auto text-[10px] font-medium text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
-                      Coming Soon
-                    </span>
-                  )}
                 </button>
               )
             })}
@@ -251,7 +259,7 @@ export function SettingsPage() {
         <Card className="p-4 space-y-4">
           <h3 className="text-sm font-semibold text-foreground">Voice</h3>
           <div className="grid grid-cols-2 gap-1.5">
-            {GEMINI_VOICES.map((v) => (
+            {(model.startsWith('gemini-') ? GEMINI_VOICES : XAI_VOICES).map((v) => (
               <button
                 key={v}
                 onClick={() => updateVoice(v)}
@@ -259,7 +267,9 @@ export function SettingsPage() {
                   ${voice === v ? 'border-primary bg-primary/10 font-medium text-foreground' : 'border-input text-muted-foreground hover:bg-accent'}
                 `}
               >
-                {GEMINI_VOICE_LABELS[v]}
+                {model.startsWith('gemini-')
+                  ? GEMINI_VOICE_LABELS[v as typeof GEMINI_VOICES[number]]
+                  : XAI_VOICE_LABELS[v as typeof XAI_VOICES[number]]}
               </button>
             ))}
           </div>
@@ -382,6 +392,22 @@ export function SettingsPage() {
       </div>
     </div>
   )
+}
+
+function isRealtimeModel(model: string | null): model is RealtimeModel {
+  return model === 'gemini-3.1-flash-live-preview' || model === 'grok-voice-think-fast-1.0'
+}
+
+function normalizeRealtimeModel(model: string | null): RealtimeModel {
+  return isRealtimeModel(model) ? model : DEFAULT_REALTIME_MODEL
+}
+
+function normalizeRealtimeVoice(model: RealtimeModel, voice: string | null): string {
+  if (model.startsWith('grok-voice-')) {
+    return voice && (XAI_VOICES as readonly string[]).includes(voice) ? voice : 'eve'
+  }
+
+  return voice && (GEMINI_VOICES as readonly string[]).includes(voice) ? voice : 'Zephyr'
 }
 
 // --- Helper Components ---

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -5,7 +5,7 @@ description: Detailed system design, audio flow, session lifecycle, brain agent,
 
 import { Aside } from '@astrojs/starlight/components'
 
-VoiceClaw is a three-tier system: clients (mobile/desktop) talk to a relay server over WebSocket, and the relay server talks to AI providers (Gemini Live, OpenAI Realtime) over their native WebSocket APIs.
+VoiceClaw is a three-tier system: clients (mobile/desktop) talk to a relay server over WebSocket, and the relay server talks to AI providers (Gemini Live, Grok Voice, OpenAI Realtime) over their native WebSocket APIs.
 
 ## System Overview
 
@@ -22,7 +22,7 @@ flowchart LR
   end
     Mobile -- WebSocket<br>audio+video --> Relay["🔗 Relay Server<br>(TypeScript / Node.js)<br><br>- Session mgmt<br>- Provider adapter<br>- Brain agent gateway<br>- Tracing (Langfuse / OTEL)"]
     Desktop -- WebSocket<br>audio + video --> Relay
-    Relay <-- Provider WebSocket<br>audio + video --> Provider["📢 Realtime AI Provider<br>(Gemini Live / OpenAI Realtime)<br><br>- Speech to Speech"]
+    Relay <-- Provider WebSocket<br>audio + video --> Provider["📢 Realtime AI Provider<br>(Gemini Live / Grok Voice / OpenAI Realtime)<br><br>- Speech to Speech"]
     Provider -- tool call: ask_brain --> Relay
     Relay <-- POST /v1/chat/completions<br>(SSE stream) --> Brain["🧠 Brain AI<br>(OpenAI-compatible agent)<br><br>- Web search<br>- Calendar / tasks<br>- Long-term memory"]
 
@@ -61,10 +61,10 @@ flowchart LR
 +--------+---------+
          |
          | Provider WebSocket
-         | (Gemini BidiGenerateContent / OpenAI Realtime)
+         | (Gemini BidiGenerateContent / Grok Voice / OpenAI Realtime)
          |
 +--------+---------+
-|   AI Provider    |   Gemini Live or OpenAI Realtime API
+|   AI Provider    |   Gemini Live, Grok Voice, or OpenAI Realtime API
 |                  |   Voice activity detection (VAD)
 |                  |   Speech-to-text + text-to-speech
 +------------------+
@@ -141,7 +141,7 @@ Mic -> PCM16 24kHz -> base64 -> audio.append -> [Relay] -> provider format -> [A
 
 ## Video / Screen Sharing Flow
 
-The desktop app can share screen content with the AI (Gemini only -- OpenAI Realtime does not support video input).
+The desktop app can share screen content with the AI (Gemini only -- Grok Voice and OpenAI Realtime do not support video input).
 
 1. User picks a screen source via Electron's `desktopCapturer`
 2. `ScreenCapture` grabs frames at **1 FPS**

--- a/docs/src/content/docs/guides/tracing.mdx
+++ b/docs/src/content/docs/guides/tracing.mdx
@@ -25,7 +25,7 @@ memory.save-transcript            [SPAN]          service: voiceclaw-relay   (en
     └── openclaw.llm              [GENERATION]    service: openclaw-gateway
 ```
 
-- **`voice-turn`** — lazily created on the first real content (user transcript, assistant delta, or tool call). Carries the assembled system prompt as the system message of the span's input, plus the user turn. Model (`gemini-3.1-flash-live-preview` / `gpt-5.4-realtime`), turnId, turnIndex, and `client.turnStartedAt` metadata live on the span.
+- **`voice-turn`** — lazily created on the first real content (user transcript, assistant delta, or tool call). Carries the assembled system prompt as the system message of the span's input, plus the user turn. Model (`gemini-3.1-flash-live-preview` / `grok-voice-think-fast-1.0` / `gpt-5.4-realtime`), turnId, turnIndex, and `client.turnStartedAt` metadata live on the span.
 - **`ask_brain`** — opened when the realtime model emits a tool call with `name=ask_brain`. Closed when the real brain response lands, not when the "searching" placeholder is sent. Duration reflects the actual brain call.
 - **`openclaw.chat_completions`** — the HTTP envelope span for the brain request. Input is the incoming messages array; output is the final response text.
 - **`openclaw.llm`** — the generation span for the actual LLM call. Input is a chat-format array starting with the **resolved** system prompt claude-cli saw (including MEMORY.md / IDENTITY.md / SOUL.md workspace bootstrap). Usage tokens + `gen_ai.request.model` attached.

--- a/docs/src/content/docs/relay-server.mdx
+++ b/docs/src/content/docs/relay-server.mdx
@@ -5,7 +5,7 @@ description: WebSocket protocol reference, configuration, brain agent, and suppo
 
 import { Tabs, TabItem, Aside, Steps } from '@astrojs/starlight/components'
 
-The relay server is a TypeScript / Node.js WebSocket server that sits between clients and AI providers. It translates the relay protocol into provider-specific formats (Gemini Live, OpenAI Realtime), handles server-side tool calls, manages session lifecycle, and provides observability via Langfuse.
+The relay server is a TypeScript / Node.js WebSocket server that sits between clients and AI providers. It translates the relay protocol into provider-specific formats (Gemini Live, Grok Voice, OpenAI Realtime), handles server-side tool calls, manages session lifecycle, and provides observability via Langfuse.
 
 ## Running
 
@@ -83,9 +83,9 @@ Must be the first message after connecting. Configures the session.
 ```
 
 Fields:
-- `provider` -- `"gemini"` or `"openai"`
-- `voice` -- voice name (Gemini: Puck, Charon, Kore, Fenrir, Aoede, Leda, Orus, Zephyr; OpenAI: any supported voice, default "marin")
-- `model` -- model identifier (default: `gemini-3.1-flash-live-preview` for Gemini, `gpt-realtime-mini` for OpenAI)
+- `provider` -- `"gemini"`, `"xai"`, or `"openai"`
+- `voice` -- voice name (Gemini: Puck, Charon, Kore, Fenrir, Aoede, Leda, Orus, Zephyr; xAI: eve, ara, rex, sal, leo; OpenAI: any supported voice, default "marin")
+- `model` -- model identifier (default: `gemini-3.1-flash-live-preview` for Gemini, `grok-voice-think-fast-1.0` for xAI, `gpt-realtime-mini` for OpenAI)
 - `brainAgent` -- `"enabled"` or `"none"`
 - `apiKey` -- must match `RELAY_API_KEY` if set on the server
 - `conversationHistory` -- prior messages to inject as context (for continuing conversations)
@@ -339,6 +339,15 @@ Common error codes:
 - Rotation: proactive on `goAway`, deferred if tool calls are in flight
 - Context window compression: enabled with sliding window (10k token trigger)
 - Voices: Puck, Charon, Kore, Fenrir, Aoede, Leda, Orus, Zephyr
+
+### xAI Grok Voice
+
+- Model: `grok-voice-think-fast-1.0` (default)
+- Audio: 24kHz PCM16 (native)
+- VAD: server-side
+- Video: not supported
+- Rotation: timer-based (default 50 minutes), transcript summary injected into new session
+- Voices: eve, ara, rex, sal, leo
 
 ### OpenAI Realtime
 

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -27,6 +27,10 @@ const MD_IMAGE_REGEX = /!\[([^\]]*)\]\(([^)]+)\)/g
 const URL_IMAGE_REGEX = /(?:^|\s)(https?:\/\/\S+\.(?:png|jpg|jpeg|gif|webp)(?:\?\S*)?)/gi
 const THINKING_MESSAGE_ID = -2
 const LISTENING_MESSAGE_ID = -3
+const DEFAULT_REALTIME_MODEL = 'gemini-3.1-flash-live-preview'
+const REALTIME_MODELS = ['gemini-3.1-flash-live-preview', 'grok-voice-think-fast-1.0'] as const
+const GEMINI_VOICES = ['Puck', 'Charon', 'Kore', 'Fenrir', 'Aoede', 'Leda', 'Orus', 'Zephyr'] as const
+const XAI_VOICES = ['eve', 'ara', 'rex', 'sal', 'leo'] as const
 
 const VOICE_SYSTEM_PROMPT = `\
 You are on a live voice call. Keep responses concise and conversational — short \
@@ -138,6 +142,7 @@ export default function ChatScreen() {
 
   // Refs for pipeline callbacks that need fresh closure values
   const loadMessagesRef = useRef<() => Promise<void>>(async () => {})
+  const startRealtimeCallRef = useRef<() => Promise<boolean>>(async () => false)
 
   const resetPipelineDebugState = useCallback(() => {
     setPipelineDebugState(INITIAL_PIPELINE_DEBUG_STATE)
@@ -365,7 +370,7 @@ export default function ChatScreen() {
       console.log('[Chat] Reconnecting Realtime session')
       setIsConnecting(true)
       try {
-        const success = await startRealtimeCall()
+        const success = await startRealtimeCallRef.current()
         if (!success) throw new Error('Realtime reconnect failed')
       } catch (e) {
         setIsConnecting(false)
@@ -401,7 +406,7 @@ export default function ChatScreen() {
       }
       throw e
     }
-  }, [startRealtimeCall])
+  }, [])
 
   const { state: reconnectState, trigger: triggerReconnect, cancel: cancelReconnect, retry: manualRetry } = useAutoReconnect({
     onReconnect: reconnectCall,
@@ -920,8 +925,8 @@ export default function ChatScreen() {
     if (!conversationId) return false
 
     const serverUrl = (await getSetting('realtime_server_url')) || 'ws://localhost:8080/ws'
-    const voice = (await getSetting('realtime_voice')) || 'Zephyr'
-    const model = (await getSetting('realtime_model')) || 'gemini-3.1-flash-live-preview'
+    const model = normalizeRealtimeModel(await getSetting('realtime_model'))
+    const voice = normalizeRealtimeVoice(model, await getSetting('realtime_voice'))
     const apiKey = await getSetting('realtime_api_key')
     const volumeStr = await getSetting('realtime_volume')
     const volume = volumeStr ? parseFloat(volumeStr) : 2.0
@@ -944,10 +949,12 @@ export default function ChatScreen() {
     }
 
     const isGemini = model.startsWith('gemini-')
+    const isXAI = model.startsWith('grok-voice-')
+    const realtimeProvider = isGemini ? 'gemini-realtime' : isXAI ? 'xai-realtime' : 'openai-realtime'
     activeProvidersRef.current = {
-      sttProvider: isGemini ? 'gemini-realtime' : 'openai-realtime',
-      llmProvider: isGemini ? 'gemini-realtime' : 'gpt-4o-mini-realtime',
-      ttsProvider: isGemini ? 'gemini-realtime' : 'openai-realtime',
+      sttProvider: realtimeProvider,
+      llmProvider: realtimeProvider,
+      ttsProvider: realtimeProvider,
     }
 
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
@@ -983,6 +990,7 @@ export default function ChatScreen() {
 
     return true
   }, [conversationId, loadMessages, realtime])
+  startRealtimeCallRef.current = startRealtimeCall
 
   const stopRealtimeCall = useCallback(() => {
     cancelReconnect()
@@ -1440,6 +1448,20 @@ function MessageBubble({ message }: { message: Message }) {
 }
 
 // --- Helper Functions ---
+
+function normalizeRealtimeModel(model: string | null): typeof REALTIME_MODELS[number] {
+  return (REALTIME_MODELS as readonly string[]).includes(model ?? '')
+    ? model as typeof REALTIME_MODELS[number]
+    : DEFAULT_REALTIME_MODEL
+}
+
+function normalizeRealtimeVoice(model: typeof REALTIME_MODELS[number], voice: string | null): string {
+  if (model.startsWith('grok-voice-')) {
+    return voice && (XAI_VOICES as readonly string[]).includes(voice) ? voice : 'eve'
+  }
+
+  return voice && (GEMINI_VOICES as readonly string[]).includes(voice) ? voice : 'Zephyr'
+}
 
 function parseContent(content: string): ContentPart[] {
   const parts: ContentPart[] = []

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -20,18 +20,14 @@ type STTProviderValue = 'apple' | 'deepgram'
 type TTSProviderValue = 'apple' | 'elevenlabs' | 'openai' | 'kokoro'
 
 const OPENAI_TTS_VOICES = ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'] as const
-const OPENAI_REALTIME_VOICES = ['alloy', 'ash', 'ballad', 'cedar', 'coral', 'echo', 'marin', 'sage', 'shimmer', 'verse'] as const
-const OPENAI_REALTIME_VOICE_LABELS: Record<typeof OPENAI_REALTIME_VOICES[number], string> = {
-  alloy: 'Alloy (F)',
-  ash: 'Ash (M)',
-  ballad: 'Ballad (M)',
-  cedar: 'Cedar (M)',
-  coral: 'Coral (F)',
-  echo: 'Echo (M)',
-  marin: 'Marin (F)',
-  sage: 'Sage (F)',
-  shimmer: 'Shimmer (F)',
-  verse: 'Verse (M)',
+
+const XAI_VOICES = ['eve', 'ara', 'rex', 'sal', 'leo'] as const
+const XAI_VOICE_LABELS: Record<typeof XAI_VOICES[number], string> = {
+  eve: 'Eve (F)',
+  ara: 'Ara (F)',
+  rex: 'Rex (M)',
+  sal: 'Sal (N)',
+  leo: 'Leo (M)',
 }
 
 const GEMINI_VOICES = ['Puck', 'Charon', 'Kore', 'Fenrir', 'Aoede', 'Leda', 'Orus', 'Zephyr'] as const
@@ -46,7 +42,8 @@ const GEMINI_VOICE_LABELS: Record<typeof GEMINI_VOICES[number], string> = {
   Zephyr: 'Zephyr (F)',
 }
 
-type RealtimeModel = 'gpt-realtime-mini' | 'gpt-realtime-1.5' | 'gemini-3.1-flash-live-preview'
+type RealtimeModel = 'gemini-3.1-flash-live-preview' | 'grok-voice-think-fast-1.0'
+const DEFAULT_REALTIME_MODEL: RealtimeModel = 'gemini-3.1-flash-live-preview'
 
 const STAGE_COLORS = {
   stt: '#3b82f6',  // blue-500
@@ -215,15 +212,17 @@ export default function SettingsScreen() {
       const rtUrl = await getSetting('realtime_server_url')
       if (rtUrl) setRealtimeServerUrl(rtUrl)
       const rtVoice = await getSetting('realtime_voice')
-      if (rtVoice) {
-        setRealtimeVoice(rtVoice)
-      }
       const rtKey = await getSetting('realtime_api_key')
       if (rtKey) setRealtimeApiKey(rtKey)
       const rtVol = await getSetting('realtime_volume')
       if (rtVol) setRealtimeVolume(parseFloat(rtVol))
       const rtModel = await getSetting('realtime_model')
-      if (rtModel === 'gpt-realtime-mini' || rtModel === 'gpt-realtime-1.5' || rtModel === 'gemini-3.1-flash-live-preview') setRealtimeModel(rtModel as RealtimeModel)
+      const loadedRealtimeModel = normalizeRealtimeModel(rtModel)
+      setRealtimeModel(loadedRealtimeModel)
+      if (rtModel && rtModel !== loadedRealtimeModel) await setSetting('realtime_model', loadedRealtimeModel)
+      const loadedRealtimeVoice = normalizeRealtimeVoice(loadedRealtimeModel, rtVoice)
+      setRealtimeVoice(loadedRealtimeVoice)
+      if (rtVoice !== loadedRealtimeVoice) await setSetting('realtime_voice', loadedRealtimeVoice)
       const stt = await getSetting('stt_provider')
       if (stt === 'apple' || stt === 'deepgram') setSttProvider(stt)
       const tts = await getSetting('tts_provider')
@@ -320,10 +319,12 @@ export default function SettingsScreen() {
     // Reset voice to a sensible default when switching providers
     const isGemini = v.startsWith('gemini-')
     const currentIsGemini = realtimeVoice.charAt(0) === realtimeVoice.charAt(0).toUpperCase() && GEMINI_VOICES.includes(realtimeVoice as typeof GEMINI_VOICES[number])
+    const isXAI = v.startsWith('grok-voice-')
+    const currentIsXAI = XAI_VOICES.includes(realtimeVoice as typeof XAI_VOICES[number])
     if (isGemini && !currentIsGemini) {
       updateRealtimeVoice('Zephyr')
-    } else if (!isGemini && currentIsGemini) {
-      updateRealtimeVoice('marin')
+    } else if (isXAI && !currentIsXAI) {
+      updateRealtimeVoice('eve')
     }
   }, [saveImmediate, realtimeVoice, updateRealtimeVoice])
 
@@ -498,8 +499,7 @@ export default function SettingsScreen() {
                 <OptionGroup
                   options={[
                     { label: 'Gemini 3.1 Flash Live', value: 'gemini-3.1-flash-live-preview' as const },
-                    { label: 'GPT Realtime Mini', value: 'gpt-realtime-mini' as const, disabled: true, badge: 'Coming Soon' },
-                    { label: 'GPT Realtime 1.5', value: 'gpt-realtime-1.5' as const, disabled: true, badge: 'Coming Soon' },
+                    { label: 'Grok Voice Think Fast 1.0', value: 'grok-voice-think-fast-1.0' as const },
                   ]}
                   value={realtimeModel}
                   onChange={updateRealtimeModel}
@@ -516,7 +516,7 @@ export default function SettingsScreen() {
                   />
                 ) : (
                   <OptionGroup
-                    options={OPENAI_REALTIME_VOICES.map((v) => ({ label: OPENAI_REALTIME_VOICE_LABELS[v], value: v }))}
+                    options={XAI_VOICES.map((v) => ({ label: XAI_VOICE_LABELS[v], value: v }))}
                     value={realtimeVoice}
                     onChange={updateRealtimeVoice}
                   />
@@ -761,6 +761,22 @@ export default function SettingsScreen() {
       </ScrollView>
     </KeyboardAvoidingView>
   )
+}
+
+function isRealtimeModel(model: string | null): model is RealtimeModel {
+  return model === 'gemini-3.1-flash-live-preview' || model === 'grok-voice-think-fast-1.0'
+}
+
+function normalizeRealtimeModel(model: string | null): RealtimeModel {
+  return isRealtimeModel(model) ? model : DEFAULT_REALTIME_MODEL
+}
+
+function normalizeRealtimeVoice(model: RealtimeModel, voice: string | null): string {
+  if (model.startsWith('grok-voice-')) {
+    return voice && (XAI_VOICES as readonly string[]).includes(voice) ? voice : 'eve'
+  }
+
+  return voice && (GEMINI_VOICES as readonly string[]).includes(voice) ? voice : 'Zephyr'
 }
 
 // --- Helper Components ---

--- a/mobile/lib/use-realtime.ts
+++ b/mobile/lib/use-realtime.ts
@@ -229,7 +229,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
 
     ws.onopen = () => {
       console.log('[useRealtime] WebSocket connected, sending session.config')
-      const provider = config.model?.startsWith('gemini-') ? 'gemini' : 'openai'
+      const provider = getProviderForRealtimeModel(config.model)
       ws.send(JSON.stringify({
         type: 'session.config',
         provider,
@@ -280,4 +280,10 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
   }, [])
 
   return { start, stop, setMuted, isConnected, sessionId }
+}
+
+function getProviderForRealtimeModel(model?: string): 'gemini' | 'openai' | 'xai' {
+  if (model?.startsWith('gemini-')) return 'gemini'
+  if (model?.startsWith('grok-voice-')) return 'xai'
+  return 'openai'
 }

--- a/relay-server/src/adapters/index.ts
+++ b/relay-server/src/adapters/index.ts
@@ -4,6 +4,7 @@ import type { ProviderAdapter } from "./types.js"
 import { EchoAdapter } from "./echo.js"
 import { OpenAIAdapter } from "./openai.js"
 import { GeminiAdapter } from "./gemini.js"
+import { XAIAdapter } from "./xai.js"
 
 export function createAdapter(provider: string): ProviderAdapter {
   switch (provider) {
@@ -13,6 +14,8 @@ export function createAdapter(provider: string): ProviderAdapter {
       return new OpenAIAdapter()
     case "gemini":
       return new GeminiAdapter()
+    case "xai":
+      return new XAIAdapter()
     default:
       throw new Error(`Unknown provider: ${provider}`)
   }

--- a/relay-server/src/adapters/openai.ts
+++ b/relay-server/src/adapters/openai.ts
@@ -9,11 +9,29 @@ import { log, error as logError } from "../log.js"
 
 const OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime"
 const DEFAULT_MODEL = "gpt-realtime-mini"
+const DEFAULT_VOICE = "marin"
+
+export interface OpenAICompatibleAdapterOptions {
+  providerName?: string
+  realtimeUrl?: string
+  apiKeyEnv?: string
+  defaultModel?: string
+  defaultVoice?: string
+  authHeaders?: Record<string, string>
+  sessionFormat?: "openai" | "xai"
+}
 
 const ROTATION_INTERVAL_MS = parseInt(process.env.ROTATION_INTERVAL_MS ?? String(50 * 60 * 1000), 10) // 50 min default
 const WATCHDOG_TIMEOUT_MS = 20_000 // 20 seconds with no audio out
 
 export class OpenAIAdapter implements ProviderAdapter {
+  private providerName: string
+  private realtimeUrl: string
+  private apiKeyEnv: string
+  private defaultModel: string
+  private defaultVoice: string
+  private authHeaders: Record<string, string>
+  private sessionFormat: "openai" | "xai"
   private upstream: WebSocket | null = null
   private sendToClient: SendToClient | null = null
   private config: SessionConfigEvent | null = null
@@ -36,6 +54,16 @@ export class OpenAIAdapter implements ProviderAdapter {
   private lastUpstreamAudioAtMs: number | null = null
   private firstAudioDeltaAtMs: number | null = null
   private turnWasInterrupted = false
+
+  constructor(options: OpenAICompatibleAdapterOptions = {}) {
+    this.providerName = options.providerName ?? "openai"
+    this.realtimeUrl = options.realtimeUrl ?? OPENAI_REALTIME_URL
+    this.apiKeyEnv = options.apiKeyEnv ?? "OPENAI_API_KEY"
+    this.defaultModel = options.defaultModel ?? DEFAULT_MODEL
+    this.defaultVoice = options.defaultVoice ?? DEFAULT_VOICE
+    this.authHeaders = options.authHeaders ?? { "OpenAI-Beta": "realtime=v1" }
+    this.sessionFormat = options.sessionFormat ?? "openai"
+  }
 
   async connect(config: SessionConfigEvent, sendToClient: SendToClient): Promise<void> {
     this.sendToClient = sendToClient
@@ -61,7 +89,7 @@ export class OpenAIAdapter implements ProviderAdapter {
   }
 
   injectContext(text: string) {
-    log(`[openai] Injecting context via conversation.item.create (${text.length} chars)`)
+    log(`[${this.providerName}] Injecting context via conversation.item.create (${text.length} chars)`)
     this.sendUpstream({
       type: "conversation.item.create",
       item: {
@@ -101,7 +129,7 @@ export class OpenAIAdapter implements ProviderAdapter {
       },
     })
     if (this.isResponseActive) {
-      log(`[openai] Tool result (${callId}) arrived mid-response, canceling current response before continuing`)
+      log(`[${this.providerName}] Tool result (${callId}) arrived mid-response, canceling current response before continuing`)
       this.pendingResponseCreate = true
       if (!this.pendingResponseCancel) {
         this.pendingResponseCancel = true
@@ -129,24 +157,24 @@ export class OpenAIAdapter implements ProviderAdapter {
   }
 
   private async openUpstream(config: SessionConfigEvent): Promise<void> {
-    const apiKey = process.env.OPENAI_API_KEY
-    if (!apiKey) throw new Error("OPENAI_API_KEY not set")
+    const apiKey = process.env[this.apiKeyEnv]
+    if (!apiKey) throw new Error(`${this.apiKeyEnv} not set`)
 
     this.resetResponseState()
 
-    const model = config.model || DEFAULT_MODEL
-    const url = `${OPENAI_REALTIME_URL}?model=${model}`
+    const model = config.model || this.defaultModel
+    const url = `${this.realtimeUrl}?model=${model}`
 
     return new Promise((resolve, reject) => {
       this.upstream = new WebSocket(url, {
         headers: {
           "Authorization": `Bearer ${apiKey}`,
-          "OpenAI-Beta": "realtime=v1",
+          ...this.authHeaders,
         },
       })
 
       this.upstream.on("open", () => {
-        log(`[openai] Upstream WebSocket connected (model=${model})`)
+        log(`[${this.providerName}] Upstream WebSocket connected (model=${model})`)
         this.configureSession(config)
         resolve()
       })
@@ -155,17 +183,17 @@ export class OpenAIAdapter implements ProviderAdapter {
         try {
           this.handleUpstreamEvent(JSON.parse(String(raw)))
         } catch (err) {
-          logError("[openai] Failed to parse upstream message:", err)
+          logError(`[${this.providerName}] Failed to parse upstream message:`, err)
         }
       })
 
       this.upstream.on("error", (err) => {
-        logError("[openai] Upstream error:", err.message)
+        logError(`[${this.providerName}] Upstream error:`, err.message)
         if (!this.isRotating) reject(err)
       })
 
       this.upstream.on("close", (code, reason) => {
-        log(`[openai] Upstream closed: ${code} ${String(reason)}`)
+        log(`[${this.providerName}] Upstream closed: ${code} ${String(reason)}`)
         if (!this.isRotating) {
           this.sendToClient?.({ type: "error", message: "upstream connection closed", code: 502 })
         }
@@ -195,25 +223,7 @@ export class OpenAIAdapter implements ProviderAdapter {
 
     this.sendUpstream({
       type: "session.update",
-      session: {
-        modalities: ["text", "audio"],
-        instructions,
-        voice: config.voice || "marin",
-        input_audio_format: "pcm16",
-        output_audio_format: "pcm16",
-        input_audio_transcription: {
-          model: "gpt-4o-mini-transcribe",
-        },
-        turn_detection: {
-          type: "server_vad",
-          threshold: 0.5,
-          prefix_padding_ms: 300,
-          silence_duration_ms: 800,
-        },
-        tools,
-        tool_choice: tools.length > 0 ? "auto" : "none",
-        temperature: 0.8,
-      },
+      session: this.buildSessionConfig(config, instructions, tools),
     })
   }
 
@@ -222,12 +232,12 @@ export class OpenAIAdapter implements ProviderAdapter {
     if (!this.config || this.isRotating) return
     this.isRotating = true
 
-    log("[openai] Starting session rotation...")
+    log(`[${this.providerName}] Starting session rotation...`)
     this.sendToClient?.({ type: "session.rotating" })
 
     // Summarize transcript for context injection
     const summary = this.summarizeTranscript()
-    log(`[openai] Transcript summary (${summary.length} chars): ${summary.substring(0, 100)}...`)
+    log(`[${this.providerName}] Transcript summary (${summary.length} chars): ${summary.substring(0, 100)}...`)
 
     // Close old upstream
     if (this.upstream && this.upstream.readyState !== WebSocket.CLOSED) {
@@ -241,9 +251,9 @@ export class OpenAIAdapter implements ProviderAdapter {
       this.transcript = [] // Clear transcript for new session
       this.startRotationTimer()
       this.sendToClient?.({ type: "session.rotated", sessionId: `rotated-${Date.now()}` })
-      log("[openai] Session rotation complete")
+      log(`[${this.providerName}] Session rotation complete`)
     } catch (err) {
-      logError("[openai] Rotation failed:", err)
+      logError(`[${this.providerName}] Rotation failed:`, err)
       this.sendToClient?.({ type: "error", message: "session rotation failed", code: 502 })
     } finally {
       this.isRotating = false
@@ -251,24 +261,24 @@ export class OpenAIAdapter implements ProviderAdapter {
   }
 
   private async openUpstreamWithSummary(config: SessionConfigEvent, summary: string): Promise<void> {
-    const apiKey = process.env.OPENAI_API_KEY
-    if (!apiKey) throw new Error("OPENAI_API_KEY not set")
+    const apiKey = process.env[this.apiKeyEnv]
+    if (!apiKey) throw new Error(`${this.apiKeyEnv} not set`)
 
     this.resetResponseState()
 
-    const model = config.model || DEFAULT_MODEL
-    const url = `${OPENAI_REALTIME_URL}?model=${model}`
+    const model = config.model || this.defaultModel
+    const url = `${this.realtimeUrl}?model=${model}`
 
     return new Promise((resolve, reject) => {
       this.upstream = new WebSocket(url, {
         headers: {
           "Authorization": `Bearer ${apiKey}`,
-          "OpenAI-Beta": "realtime=v1",
+          ...this.authHeaders,
         },
       })
 
       this.upstream.on("open", () => {
-        log("[openai] New upstream connected after rotation")
+        log(`[${this.providerName}] New upstream connected after rotation`)
         this.configureSession(config, summary)
         resolve()
       })
@@ -277,17 +287,17 @@ export class OpenAIAdapter implements ProviderAdapter {
         try {
           this.handleUpstreamEvent(JSON.parse(String(raw)))
         } catch (err) {
-          logError("[openai] Failed to parse upstream message:", err)
+          logError(`[${this.providerName}] Failed to parse upstream message:`, err)
         }
       })
 
       this.upstream.on("error", (err) => {
-        logError("[openai] New upstream error:", err.message)
+        logError(`[${this.providerName}] New upstream error:`, err.message)
         reject(err)
       })
 
       this.upstream.on("close", (code, reason) => {
-        log(`[openai] Upstream closed: ${code} ${String(reason)}`)
+        log(`[${this.providerName}] Upstream closed: ${code} ${String(reason)}`)
         if (!this.isRotating) {
           this.sendToClient?.({ type: "error", message: "upstream connection closed", code: 502 })
         }
@@ -315,7 +325,7 @@ export class OpenAIAdapter implements ProviderAdapter {
   private startRotationTimer() {
     this.clearRotationTimer()
     this.rotationTimer = setTimeout(() => {
-      log(`[openai] Rotation timer fired after ${ROTATION_INTERVAL_MS / 1000}s`)
+      log(`[${this.providerName}] Rotation timer fired after ${ROTATION_INTERVAL_MS / 1000}s`)
       this.rotate()
     }, ROTATION_INTERVAL_MS)
   }
@@ -356,14 +366,23 @@ export class OpenAIAdapter implements ProviderAdapter {
     switch (event.type) {
       // Session lifecycle
       case "session.created":
-        log(`[openai] Session created: ${event.session?.id}`)
+        log(`[${this.providerName}] Session created: ${event.session?.id}`)
         break
       case "session.updated":
-        log("[openai] Session updated")
+        log(`[${this.providerName}] Session updated`)
+        break
+      case "ping":
+      case "conversation.created":
+      case "conversation.item.added":
+      case "response.output_item.added":
+      case "response.output_item.done":
+      case "response.content_part.added":
+      case "response.content_part.done":
         break
 
       // Audio output
       case "response.audio.delta":
+      case "response.output_audio.delta":
         if (this.firstAudioDeltaAtMs == null) {
           this.firstAudioDeltaAtMs = Date.now()
         }
@@ -373,6 +392,7 @@ export class OpenAIAdapter implements ProviderAdapter {
 
       // Transcripts
       case "response.audio_transcript.delta":
+      case "response.output_audio_transcript.delta":
         if (this.firstTextDeltaAtMs == null) {
           this.firstTextDeltaAtMs = Date.now()
         }
@@ -383,6 +403,7 @@ export class OpenAIAdapter implements ProviderAdapter {
         })
         break
       case "response.audio_transcript.done":
+      case "response.output_audio_transcript.done":
         this.transcript.push({ role: "assistant", text: event.transcript })
         this.sendToClient?.({
           type: "transcript.done",
@@ -402,7 +423,9 @@ export class OpenAIAdapter implements ProviderAdapter {
 
       // User speech transcription (final)
       case "conversation.item.input_audio_transcription.completed":
-        this.transcript.push({ role: "user", text: event.transcript })
+        if (event.transcript) {
+          this.transcript.push({ role: "user", text: event.transcript })
+        }
         this.sendToClient?.({
           type: "transcript.done",
           text: event.transcript,
@@ -426,7 +449,7 @@ export class OpenAIAdapter implements ProviderAdapter {
 
       // Function calls
       case "response.function_call_arguments.done":
-        log(`[openai] Tool call: ${event.name} (${event.call_id})`)
+        log(`[${this.providerName}] Tool call: ${event.name} (${event.call_id})`)
         this.pendingToolCalls++
         this.pauseWatchdog()
         this.sendToClient?.({
@@ -468,7 +491,7 @@ export class OpenAIAdapter implements ProviderAdapter {
 
       // Errors
       case "error":
-        logError(`[openai] Error: ${event.error?.message ?? event}`)
+        logError(`[${this.providerName}] Error: ${event.error?.message ?? event}`)
         this.resetResponseState()
         this.sendToClient?.({
           type: "error",
@@ -491,8 +514,9 @@ export class OpenAIAdapter implements ProviderAdapter {
             event.type !== "response.text.delta" &&
             event.type !== "response.text.done" &&
             event.type !== "response.audio.done" &&
+            event.type !== "response.output_audio.done" &&
             event.type !== "response.function_call_arguments.delta") {
-          log(`[openai] Unhandled event: ${event.type}`)
+          log(`[${this.providerName}] Unhandled event: ${event.type}`)
         }
     }
   }
@@ -508,12 +532,12 @@ export class OpenAIAdapter implements ProviderAdapter {
 
   private handleWatchdogTimeout() {
     if (this.isResponseActive) {
-      log("[openai] Watchdog fired during active response, deferring")
+      log(`[${this.providerName}] Watchdog fired during active response, deferring`)
       this.resetWatchdog()
       return
     }
 
-    log("[openai] Watchdog: no audio for 20s, injecting prompt")
+    log(`[${this.providerName}] Watchdog: no audio for 20s, injecting prompt`)
     this.sendUpstream({
       type: "conversation.item.create",
       item: {
@@ -528,7 +552,7 @@ export class OpenAIAdapter implements ProviderAdapter {
   private requestResponse(reason: string) {
     if (this.isResponseActive) {
       this.pendingResponseCreate = true
-      log(`[openai] Skipping response.create (${reason}) because a response is already active`)
+      log(`[${this.providerName}] Skipping response.create (${reason}) because a response is already active`)
       return
     }
 
@@ -542,7 +566,7 @@ export class OpenAIAdapter implements ProviderAdapter {
   private flushPendingResponseCreate() {
     if (!this.pendingResponseCreate) return
 
-    log("[openai] Flushing queued response.create")
+    log(`[${this.providerName}] Flushing queued response.create`)
     this.pendingResponseCreate = false
     if (this.sendUpstream({ type: "response.create" })) {
       this.isResponseActive = true
@@ -623,6 +647,46 @@ export class OpenAIAdapter implements ProviderAdapter {
       firstOutputModality,
     })
     this.resetLatencyMarks()
+  }
+
+  private buildSessionConfig(
+    config: SessionConfigEvent,
+    instructions: string,
+    tools: ReturnType<typeof getTools>,
+  ): Record<string, unknown> {
+    const common = {
+      instructions,
+      voice: config.voice || this.defaultVoice,
+      turn_detection: {
+        type: "server_vad",
+        threshold: 0.5,
+        prefix_padding_ms: 300,
+        silence_duration_ms: 800,
+      },
+      tools,
+      tool_choice: tools.length > 0 ? "auto" : "none",
+    }
+
+    if (this.sessionFormat === "xai") {
+      return {
+        ...common,
+        audio: {
+          input: { format: { type: "audio/pcm", rate: 24000 } },
+          output: { format: { type: "audio/pcm", rate: 24000 } },
+        },
+      }
+    }
+
+    return {
+      ...common,
+      modalities: ["text", "audio"],
+      input_audio_format: "pcm16",
+      output_audio_format: "pcm16",
+      input_audio_transcription: {
+        model: "gpt-4o-mini-transcribe",
+      },
+      temperature: 0.8,
+    }
   }
 }
 

--- a/relay-server/src/adapters/xai.ts
+++ b/relay-server/src/adapters/xai.ts
@@ -1,0 +1,21 @@
+// xAI Grok Voice adapter — uses the OpenAI-compatible Realtime protocol with xAI event names
+
+import { OpenAIAdapter } from "./openai.js"
+
+const XAI_REALTIME_URL = "wss://api.x.ai/v1/realtime"
+const DEFAULT_MODEL = "grok-voice-think-fast-1.0"
+const DEFAULT_VOICE = "eve"
+
+export class XAIAdapter extends OpenAIAdapter {
+  constructor() {
+    super({
+      providerName: "xai",
+      realtimeUrl: XAI_REALTIME_URL,
+      apiKeyEnv: "XAI_API_KEY",
+      defaultModel: DEFAULT_MODEL,
+      defaultVoice: DEFAULT_VOICE,
+      authHeaders: {},
+      sessionFormat: "xai",
+    })
+  }
+}

--- a/relay-server/src/instructions.ts
+++ b/relay-server/src/instructions.ts
@@ -116,7 +116,7 @@ function loadAgentIdentity(provider: SessionConfigEvent["provider"]): string {
   const profile = loadAgentProfile()
   const soul = loadFile("SOUL.md")
 
-  if (provider === "openai") {
+  if (provider === "openai" || provider === "xai") {
     return buildOpenAIVoiceIdentity(profile, soul)
   }
 

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -334,7 +334,7 @@ export class RelaySession {
     this.config = config
     this.startedAt = Date.now()
     // Capture the assembled system prompt so every voice-turn span carries the
-    // full context Gemini / OpenAI Realtime was configured with. Uses the same
+    // full context Gemini / Grok Voice / OpenAI Realtime was configured with. Uses the same
     // buildInstructions the Gemini adapter feeds to the provider, so the trace
     // and the live session see the same string (minus anything the adapter
     // conditionally appends, e.g. tool schemas).

--- a/relay-server/src/test-page.ts
+++ b/relay-server/src/test-page.ts
@@ -51,33 +51,22 @@ export function getTestPageHTML(host: string): string {
     <label>Provider</label>
     <select id="provider">
       <option value="echo">Echo (loopback test)</option>
-      <option value="openai" selected>OpenAI Realtime</option>
       <option value="gemini">Gemini Live</option>
+      <option value="xai" selected>Grok Voice</option>
     </select>
   </div>
 
   <div class="section">
     <label>Model</label>
     <select id="model">
-      <option value="gpt-realtime-mini" data-provider="openai" selected>GPT Realtime Mini</option>
-      <option value="gpt-realtime-1.5" data-provider="openai">GPT Realtime 1.5</option>
       <option value="gemini-3.1-flash-live-preview" data-provider="gemini">Gemini 3.1 Flash Live</option>
+      <option value="grok-voice-think-fast-1.0" data-provider="xai" selected>Grok Voice Think Fast 1.0</option>
     </select>
   </div>
 
   <div class="section">
     <label>Voice</label>
     <select id="voice">
-      <option value="alloy" data-provider="openai">Alloy (N)</option>
-      <option value="ash" data-provider="openai">Ash (M)</option>
-      <option value="ballad" data-provider="openai">Ballad (M)</option>
-      <option value="coral" data-provider="openai">Coral (F)</option>
-      <option value="echo" data-provider="openai">Echo (M)</option>
-      <option value="sage" data-provider="openai">Sage (F)</option>
-      <option value="shimmer" data-provider="openai">Shimmer (F)</option>
-      <option value="verse" data-provider="openai">Verse (M)</option>
-      <option value="marin" data-provider="openai" selected>Marin (F)</option>
-      <option value="cedar" data-provider="openai">Cedar (M)</option>
       <option value="Puck" data-provider="gemini">Puck (M, upbeat)</option>
       <option value="Charon" data-provider="gemini">Charon (M, informative)</option>
       <option value="Fenrir" data-provider="gemini">Fenrir (M, excitable)</option>
@@ -86,6 +75,11 @@ export function getTestPageHTML(host: string): string {
       <option value="Aoede" data-provider="gemini">Aoede (F, breezy)</option>
       <option value="Leda" data-provider="gemini">Leda (F, youthful)</option>
       <option value="Zephyr" data-provider="gemini">Zephyr (F, bright)</option>
+      <option value="eve" data-provider="xai" selected>Eve (F, energetic)</option>
+      <option value="ara" data-provider="xai">Ara (F, warm)</option>
+      <option value="rex" data-provider="xai">Rex (M, confident)</option>
+      <option value="sal" data-provider="xai">Sal (N, smooth)</option>
+      <option value="leo" data-provider="xai">Leo (M, authoritative)</option>
     </select>
   </div>
 
@@ -117,13 +111,13 @@ export function getTestPageHTML(host: string): string {
     const modelSel = document.getElementById("model")
     const voiceSel = document.getElementById("voice")
 
-    const DEFAULT_MODEL = { openai: "gpt-realtime-mini", gemini: "gemini-3.1-flash-live-preview" }
-    const DEFAULT_VOICE = { openai: "marin", gemini: "Zephyr" }
+    const DEFAULT_MODEL = { gemini: "gemini-3.1-flash-live-preview", xai: "grok-voice-think-fast-1.0" }
+    const DEFAULT_VOICE = { gemini: "Zephyr", xai: "eve" }
 
     function syncForProvider() {
-      // Echo is a loopback with no upstream model/voice; treat it as openai for option visibility,
+      // Echo is a loopback with no upstream model/voice; treat it as xAI for option visibility,
       // since the echo adapter ignores both fields.
-      const provider = providerSel.value === "gemini" ? "gemini" : "openai"
+      const provider = providerSel.value === "gemini" ? "gemini" : "xai"
 
       let modelOk = false
       for (const opt of modelSel.options) {

--- a/relay-server/src/tracing/langfuse.ts
+++ b/relay-server/src/tracing/langfuse.ts
@@ -5,7 +5,7 @@
 //   Session = one relay WebSocket connection (sessionKey → Langfuse sessionId)
 //   Trace   = one voice turn (user utterance → assistant finished speaking)
 //   Observations (spans):
-//     - generation: model turn (Gemini Live / OpenAI Realtime); usage on close
+//     - generation: model turn (Gemini Live / Grok Voice / OpenAI Realtime); usage on close
 //     - agent/tool: brain tool calls
 //     - span: mobile-side timing reports (stt/llm/tts latency from the device)
 //

--- a/relay-server/src/tracing/turn-tracer.ts
+++ b/relay-server/src/tracing/turn-tracer.ts
@@ -32,7 +32,7 @@ export class TurnTracer {
   private model: string | null = null
   // Assembled system prompt that the realtime provider was configured with —
   // attached to every voice-turn span so the trace is self-contained and a
-  // reader can see exactly what instructions Gemini / OpenAI Realtime was
+  // reader can see exactly what instructions Gemini / Grok Voice / OpenAI Realtime was
   // running under without cross-referencing the relay code.
   private sessionInstructions: string | null = null
 
@@ -363,7 +363,7 @@ export class TurnTracer {
       return
     }
     // Compose the input as a chat conversation including the system prompt
-    // Gemini / OpenAI Realtime was configured with, so each trace is self-
+    // Gemini / Grok Voice / OpenAI Realtime was configured with, so each trace is self-
     // contained: a reader can see the full context the voice model ran under
     // without cross-referencing the relay code.
     const chatInput: Array<{ role: string; content: string }> = []

--- a/relay-server/src/types.ts
+++ b/relay-server/src/types.ts
@@ -14,7 +14,7 @@ export type ClientEvent =
 
 export interface SessionConfigEvent {
   type: "session.config"
-  provider: "openai" | "gemini"
+  provider: "openai" | "gemini" | "xai"
   voice: string
   model?: string
   brainAgent: "enabled" | "none"


### PR DESCRIPTION
## Summary
- Add an xAI Grok Voice adapter for `grok-voice-think-fast-1.0` using the realtime-compatible WebSocket protocol
- Route Grok models to the xAI provider and expose Gemini 3.1 Flash Live + Grok Voice Think Fast 1.0 as the two realtime app/test-page choices
- Document `XAI_API_KEY`, Grok voices, and supported relay provider details

## Test plan
- [x] `yarn workspace relay-server build`
- [x] `yarn workspace voiceclaw-mobile tsc --noEmit`
- [x] Live Grok Voice session with `XAI_API_KEY` configured

## Review notes
- Gemini CLI review was attempted, but Gemini returned capacity errors for both default `gemini-3-flash-preview` and `gemini-2.5-pro`, so no Gemini review result was available before posting.