### PR TITLE
Add attribute Fields/JSON tabs (NAN-651)

### DIFF
--- a/tracing-ui/src/components/AttributesTabs.tsx
+++ b/tracing-ui/src/components/AttributesTabs.tsx
@@ -1,0 +1,213 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import type { ReactNode } from "react"
+
+export type AttributeRow = {
+  key: string
+  value: string
+}
+
+export function AttributesTabs({
+  attributes,
+  raw,
+  maxHeightClass = "max-h-80",
+}: {
+  attributes?: Record<string, unknown> | null
+  raw?: string | null
+  maxHeightClass?: string
+}) {
+  const [tab, setTab] = useState<"fields" | "json">("fields")
+  const [filter, setFilter] = useState("")
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+
+  const parsed = useMemo(() => attributes ?? parseRawAttributes(raw), [attributes, raw])
+  const rows = useMemo(() => flattenAttributes(parsed), [parsed])
+  const json = useMemo(() => formatRawJson(parsed, raw), [parsed, raw])
+  const normalizedFilter = filter.trim().toLowerCase()
+  const visibleRows = useMemo(() => {
+    if (!normalizedFilter) return rows
+    return rows.filter((row) => {
+      return (
+        row.key.toLowerCase().includes(normalizedFilter) ||
+        row.value.toLowerCase().includes(normalizedFilter)
+      )
+    })
+  }, [rows, normalizedFilter])
+
+  const toggleExpanded = (key: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  return (
+    <div className="rounded border border-zinc-800 bg-zinc-950/40">
+      <div className="flex items-center border-b border-zinc-800">
+        <TabButton active={tab === "fields"} onClick={() => setTab("fields")}>
+          Fields
+        </TabButton>
+        <TabButton active={tab === "json"} onClick={() => setTab("json")}>
+          JSON
+        </TabButton>
+      </div>
+
+      {tab === "fields" ? (
+        <div className="p-2">
+          <input
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filter Fields..."
+            className="mb-2 w-full rounded border border-zinc-800 bg-zinc-900 px-2 py-1 text-xs text-zinc-200 placeholder:text-zinc-600 outline-none focus:border-blue-500/70"
+          />
+
+          {rows.length === 0 ? (
+            <div className="px-2 py-6 text-center text-xs text-zinc-500">No attributes</div>
+          ) : visibleRows.length === 0 ? (
+            <div className="px-2 py-6 text-center text-xs text-zinc-500">No matching fields</div>
+          ) : (
+            <div className={`${maxHeightClass} overflow-auto rounded border border-zinc-900`}>
+              <table className="w-full text-left text-[11px]">
+                <thead className="sticky top-0 bg-zinc-900 text-zinc-500">
+                  <tr>
+                    <th className="w-[42%] px-2 py-1.5 font-medium">Key</th>
+                    <th className="px-2 py-1.5 font-medium">Value</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-900">
+                  {visibleRows.map((row) => {
+                    const isExpanded = expanded.has(row.key)
+                    const displayValue = isExpanded ? row.value : truncateValue(row.value)
+                    const canExpand = row.value.length > VALUE_PREVIEW_CHARS
+                    return (
+                      <tr key={row.key} className="align-top">
+                        <td className="px-2 py-1.5 font-mono text-zinc-300 break-all">
+                          {row.key}
+                        </td>
+                        <td className="px-2 py-1.5 font-mono text-zinc-400 break-all">
+                          {canExpand ? (
+                            <button
+                              type="button"
+                              onClick={() => toggleExpanded(row.key)}
+                              className="block w-full text-left hover:text-zinc-200"
+                            >
+                              {displayValue}
+                            </button>
+                          ) : (
+                            displayValue
+                          )}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      ) : (
+        <pre className={`${maxHeightClass} overflow-auto whitespace-pre-wrap break-words p-3 font-mono text-[11px] text-zinc-300`}>
+          {json}
+        </pre>
+      )}
+    </div>
+  )
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={[
+        "border-r border-zinc-800 px-3 py-1.5 text-xs",
+        active ? "bg-zinc-900 text-zinc-100" : "text-zinc-500 hover:text-zinc-300",
+      ].join(" ")}
+    >
+      {children}
+    </button>
+  )
+}
+
+const VALUE_PREVIEW_CHARS = 200
+
+export function flattenAttributes(
+  attrs: Record<string, unknown> | null | undefined,
+): AttributeRow[] {
+  if (!attrs || Object.keys(attrs).length === 0) return []
+  const rows: AttributeRow[] = []
+  for (const key of Object.keys(attrs).sort()) {
+    flattenValue(key, attrs[key], rows)
+  }
+  return rows
+}
+
+function flattenValue(path: string, value: unknown, rows: AttributeRow[]) {
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      rows.push({ key: path, value: "[]" })
+      return
+    }
+    value.forEach((entry, index) => flattenValue(`${path}[${index}]`, entry, rows))
+    return
+  }
+  if (isPlainObject(value)) {
+    const entries = Object.entries(value)
+    if (entries.length === 0) {
+      rows.push({ key: path, value: "{}" })
+      return
+    }
+    for (const [childKey, childValue] of entries) {
+      flattenValue(`${path}.${childKey}`, childValue, rows)
+    }
+    return
+  }
+  rows.push({ key: path, value: formatFieldValue(value) })
+}
+
+function parseRawAttributes(raw: string | null | undefined): Record<string, unknown> | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw)
+    return isPlainObject(parsed) ? parsed : { value: parsed }
+  } catch {
+    return { value: raw }
+  }
+}
+
+function formatRawJson(attrs: Record<string, unknown> | null, raw: string | null | undefined) {
+  if (attrs) return JSON.stringify(attrs, null, 2)
+  if (!raw) return "(no attributes)"
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2)
+  } catch {
+    return raw
+  }
+}
+
+function formatFieldValue(value: unknown): string {
+  if (value === null) return "null"
+  if (value === undefined) return "undefined"
+  if (typeof value === "string") return value
+  return JSON.stringify(value)
+}
+
+function truncateValue(value: string): string {
+  if (value.length <= VALUE_PREVIEW_CHARS) return value
+  return `${value.slice(0, VALUE_PREVIEW_CHARS).trimEnd()}...`
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}

--- a/tracing-ui/src/components/LogsTab.tsx
+++ b/tracing-ui/src/components/LogsTab.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Fragment, useMemo, useState } from "react"
+import { AttributesTabs } from "./AttributesTabs"
 
 export type LogRow = {
   span_id: string
@@ -124,9 +125,7 @@ export function LogsTab({ rows }: { rows: LogRow[] }) {
                   <tr className="border-t border-zinc-900 bg-zinc-950">
                     <td></td>
                     <td colSpan={7} className="px-3 py-3">
-                      <pre className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded bg-zinc-900/50 border border-zinc-800 p-3 font-mono text-[11px] text-zinc-300">
-                        {prettyJson(r.attributes_json)}
-                      </pre>
+                      <AttributesTabs raw={r.attributes_json} maxHeightClass="max-h-96" />
                     </td>
                   </tr>
                 )}
@@ -206,13 +205,4 @@ function SortHeader({
 
 function uniqueSorted(arr: string[]): string[] {
   return Array.from(new Set(arr.filter(Boolean))).sort()
-}
-
-function prettyJson(raw: string | null): string {
-  if (!raw) return "(no attributes)"
-  try {
-    return JSON.stringify(JSON.parse(raw), null, 2)
-  } catch {
-    return raw
-  }
 }

--- a/tracing-ui/src/components/TurnsTab.tsx
+++ b/tracing-ui/src/components/TurnsTab.tsx
@@ -12,6 +12,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import type { MediaRow, ObservationRow, TraceWithObservations } from "@/lib/db"
+import { AttributesTabs } from "./AttributesTabs"
 
 export type TurnsTabProps = {
   sessionId: string
@@ -333,9 +334,7 @@ function DetailPanel({ step }: { step: ObservationRow | null }) {
 
         <div className="space-y-1">
           <div className="text-[10px] uppercase tracking-wide text-zinc-500">All attributes</div>
-          <pre className="rounded border border-zinc-800 bg-zinc-900/50 p-2 font-mono text-[10px] text-zinc-300 max-h-80 overflow-auto whitespace-pre-wrap break-words">
-            {JSON.stringify(attrs, null, 2)}
-          </pre>
+          <AttributesTabs attributes={attrs} />
         </div>
       </div>
     </aside>

--- a/tracing-ui/test/test-attributes-tabs.ts
+++ b/tracing-ui/test/test-attributes-tabs.ts
@@ -1,0 +1,51 @@
+// Unit-ish test for the pure attribute flattening helper used by AttributesTabs.
+//
+// Run: npx tsx test/test-attributes-tabs.ts
+
+import { flattenAttributes } from "../src/components/AttributesTabs.js"
+
+function run() {
+  const rows = flattenAttributes({
+    gen_ai: {
+      usage: {
+        input_tokens: 12,
+        output_tokens: 3,
+      },
+    },
+    media: {
+      user_audio: {
+        path: "/tmp/user.pcm",
+      },
+    },
+    events: [
+      { name: "first", timeMs: 10 },
+      { name: "second", timeMs: 20 },
+    ],
+    emptyArray: [],
+    emptyObject: {},
+  })
+
+  expectRow(rows, "gen_ai.usage.input_tokens", "12")
+  expectRow(rows, "gen_ai.usage.output_tokens", "3")
+  expectRow(rows, "media.user_audio.path", "/tmp/user.pcm")
+  expectRow(rows, "events[0].name", "first")
+  expectRow(rows, "events[1].timeMs", "20")
+  expectRow(rows, "emptyArray", "[]")
+  expectRow(rows, "emptyObject", "{}")
+
+  if (flattenAttributes({}).length !== 0) {
+    throw new Error("expected empty attrs to flatten to no rows")
+  }
+
+  console.log("  PASS  attributes flatten to dot paths with array indexes")
+}
+
+run()
+
+function expectRow(rows: { key: string; value: string }[], key: string, value: string) {
+  const row = rows.find((entry) => entry.key === key)
+  if (!row) throw new Error(`missing row ${key}`)
+  if (row.value !== value) {
+    throw new Error(`row ${key}: expected ${JSON.stringify(value)}, got ${JSON.stringify(row.value)}`)
+  }
+}


### PR DESCRIPTION
## Summary
- Add a shared `AttributesTabs` component with Fields/JSON views, dot-path flattening, filtering, and expandable long values
- Replace raw attribute JSON blocks in Turns detail and Logs expanded rows
- Add focused coverage for nested object/array flattening

## Test plan
- [x] `yarn workspace voiceclaw-tracing-ui typecheck`
- [x] `yarn workspace voiceclaw-tracing-ui build`
- [x] `yarn workspace relay-server exec tsx ../tracing-ui/test/test-attributes-tabs.ts`
- [x] Ran tracing UI dev server and verified `/sessions` plus a session logs page returned 200