### PR TITLE
Add session media timeline (NAN-649)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -98,6 +98,7 @@ export default defineConfig({
           items: [
             { slug: 'guides/tracing' },
             { slug: 'tracing-ui/spec', label: 'Tracing UI spec' },
+            { slug: 'tracing/session-media', label: 'Session media timeline' },
           ],
         },
       ],

--- a/docs/src/content/docs/tracing/session-media.md
+++ b/docs/src/content/docs/tracing/session-media.md
@@ -1,0 +1,75 @@
+---
+title: Session media timeline
+description: Session-level audio/video artifacts, MediaTimeline playback, and the capture gates involved in tracing UI media.
+---
+
+VoiceClaw can capture per-turn audio and video while a relay session is running, then write session-level artifacts at session finalize so the tracing UI can replay the call end-to-end.
+
+## Disk layout
+
+When `VOICECLAW_MEDIA_CAPTURE=enabled`, the relay writes under:
+
+```txt
+~/.voiceclaw/media/<sessionKey>/
+  user-<turnId>.pcm
+  user-<turnId>.pcm.json
+  assistant-<turnId>.pcm
+  assistant-<turnId>.pcm.json
+  video-<turnId>/0000.jpeg
+  video-<turnId>/timings.json
+  session/
+    user.wav
+    assistant.wav
+    peaks.json
+    thumbnails.json
+```
+
+The per-turn files are written as the call runs. The `session/` files are written when the relay finalizes the session, after all turns have been closed.
+
+## Session files
+
+`user.wav` is the stitched user microphone track. `assistant.wav` is the stitched model audio track. Both are mono PCM WAV files, usually at 24 kHz.
+
+`peaks.json` is a small waveform manifest:
+
+```ts
+{
+  user: number[]
+  assistant: number[]
+  userDurationMs: number
+  assistantDurationMs: number
+  sampleRate: number
+}
+```
+
+`thumbnails.json` is a bounded video manifest:
+
+```ts
+{
+  frames: [{ frameFile: string, timeMs: number }]
+}
+```
+
+`frameFile` is relative to `<sessionKey>`, so the tracing UI serves it with `GET /api/media/<sessionKey>/<frameFile>`.
+
+## Tracing UI consumption
+
+The collector indexes `media.session_*` attributes into `session_user_audio`, `session_assistant_audio`, `session_peaks`, and `session_thumbnails` rows. `MediaTimeline` reads those rows and drives:
+
+- two synchronized audio elements
+- a two-track waveform from `peaks.json`
+- a video canvas showing the nearest thumbnail frame
+- an iMovie-style thumbnail strip for click-and-drag scrubbing
+- transcript and turn markers on the same master time axis
+
+The Transcript tab uses the master playhead to highlight the active `voice-turn` row. Clicking a transcript row seeks the timeline to that turn start. The Turns tab uses the same full-session timeline and highlights the selected turn.
+
+## Capture gates
+
+`VOICECLAW_MEDIA_CAPTURE=enabled` controls local audio/video file capture in the relay.
+
+`OTEL_GENAI_CAPTURE_CONTENT` is separate. It controls whether OpenClaw emits raw tool arguments/results into tracing attributes. It does not enable audio capture, and disabling it does not stop `user.wav`, `assistant.wav`, `peaks.json`, or `thumbnails.json` from being written when relay media capture is enabled.
+
+## What to expect
+
+The current user track may be quieter than the assistant track because iOS captures post-processing mic audio. The media API normalizes user PCM for browser playback when wrapping per-turn PCM files, and the session timeline reads the finalized WAV files. The native mic-tap follow-up is tracked in NAN-652 so future captures can use an un-gated raw microphone path.

--- a/tracing-ui/src/app/sessions/[id]/page.tsx
+++ b/tracing-ui/src/app/sessions/[id]/page.tsx
@@ -167,7 +167,15 @@ function TabContent({
 }) {
   switch (tab) {
     case "transcript":
-      return <TranscriptTab turns={voiceTurns} sessionStartNs={startNs} />
+      return (
+        <TranscriptTab
+          sessionId={sessionId}
+          turns={voiceTurns}
+          media={media}
+          sessionStartNs={startNs}
+          durationMs={totalMs}
+        />
+      )
     case "turns":
       // TurnsTab uses useSearchParams — wrap in Suspense per Next.js 15 rules.
       return (

--- a/tracing-ui/src/components/MediaTimeline.tsx
+++ b/tracing-ui/src/components/MediaTimeline.tsx
@@ -1,0 +1,307 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { MediaRow, TraceWithObservations, VoiceTurn } from "@/lib/db"
+import { ThumbnailStrip, type ThumbnailFrame, nearestFrameIndex } from "./ThumbnailStrip"
+import { WaveformView } from "./WaveformView"
+import { getSessionMediaUrls, mediaPathUrl } from "./media-paths"
+
+export type MediaTimelineProps = {
+  sessionId: string
+  media: MediaRow[]
+  durationMs: number
+  turns?: VoiceTurn[] | TraceWithObservations[]
+  sessionStartNs?: number
+  highlightedTraceId?: string | null
+  seekRequest?: { timeMs: number; nonce: number }
+  onTimeChange?: (timeMs: number) => void
+}
+
+export function MediaTimeline({
+  sessionId,
+  media,
+  durationMs,
+  turns = [],
+  sessionStartNs,
+  highlightedTraceId,
+  seekRequest,
+  onTimeChange,
+}: MediaTimelineProps) {
+  const userAudioRef = useRef<HTMLAudioElement>(null)
+  const assistantAudioRef = useRef<HTMLAudioElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [currentTimeMs, setCurrentTimeMs] = useState(0)
+  const [playing, setPlaying] = useState(false)
+  const [rate, setRate] = useState(1)
+  const [frames, setFrames] = useState<ThumbnailFrame[]>([])
+  const urls = useMemo(() => getSessionMediaUrls(sessionId, media), [media, sessionId])
+  const totalMs = Math.max(1, durationMs || inferDurationMs(media))
+  const hasSessionUser = media.some((m) => m.kind === "session_user_audio")
+  const hasSessionAssistant = media.some((m) => m.kind === "session_assistant_audio")
+  const primaryRef = hasSessionUser || !hasSessionAssistant ? userAudioRef : assistantAudioRef
+
+  useEffect(() => {
+    const user = userAudioRef.current
+    const assistant = assistantAudioRef.current
+    if (user) user.playbackRate = rate
+    if (assistant) assistant.playbackRate = rate
+  }, [rate])
+
+  useEffect(() => {
+    drawNearestFrame(canvasRef.current, urls.sessionDir, frames, currentTimeMs)
+  }, [currentTimeMs, frames, urls.sessionDir])
+
+  const seek = useCallback(
+    (timeMs: number) => {
+      const nextMs = clamp(timeMs, 0, totalMs)
+      setCurrentTimeMs(nextMs)
+      syncAudioTime(userAudioRef.current, nextMs)
+      syncAudioTime(assistantAudioRef.current, nextMs)
+    },
+    [totalMs],
+  )
+
+  useEffect(() => {
+    if (seekRequest) seek(seekRequest.timeMs)
+  }, [seek, seekRequest])
+
+  useEffect(() => {
+    onTimeChange?.(currentTimeMs)
+  }, [currentTimeMs, onTimeChange])
+
+  const togglePlay = useCallback(async () => {
+    const user = userAudioRef.current
+    const assistant = assistantAudioRef.current
+    if (playing) {
+      user?.pause()
+      assistant?.pause()
+      setPlaying(false)
+      return
+    }
+    syncAudioTime(user, currentTimeMs)
+    syncAudioTime(assistant, currentTimeMs)
+    const results = await Promise.all([playAudio(user), playAudio(assistant)])
+    if (results.some(Boolean)) {
+      setPlaying(true)
+    } else {
+      setPlaying(false)
+    }
+  }, [currentTimeMs, playing])
+
+  const onPrimaryTimeUpdate = useCallback(() => {
+    const primary = primaryRef.current
+    if (!primary) return
+    const nextMs = primary.currentTime * 1000
+    setCurrentTimeMs(nextMs)
+    correctDrift(userAudioRef.current, nextMs)
+    correctDrift(assistantAudioRef.current, nextMs)
+    if (nextMs >= totalMs - 50) setPlaying(false)
+  }, [primaryRef, totalMs])
+
+  const markers = useMemo(
+    () => buildTurnMarkers(turns, sessionStartNs, totalMs),
+    [sessionStartNs, totalMs, turns],
+  )
+
+  return (
+    <div className="border-b border-zinc-800 bg-zinc-950/70 p-5">
+      <div className="mx-auto max-w-5xl space-y-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <div className="text-[10px] uppercase tracking-wide text-zinc-500">
+              Session media
+            </div>
+            <div className="text-sm text-zinc-100">Captured audio/video</div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={togglePlay}
+              className="rounded border border-zinc-700 px-3 py-1 text-xs text-zinc-100 hover:bg-zinc-900"
+            >
+              {playing ? "Pause" : "Play"}
+            </button>
+            <div className="font-mono text-xs tabular-nums text-zinc-400">
+              {formatTime(currentTimeMs)} / {formatTime(totalMs)}
+            </div>
+            <select
+              value={rate}
+              onChange={(e) => setRate(Number(e.target.value))}
+              className="rounded border border-zinc-700 bg-zinc-950 px-2 py-1 text-xs text-zinc-200"
+            >
+              {[0.5, 1, 1.25, 1.5, 2].map((value) => (
+                <option key={value} value={value}>
+                  {value}x
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <canvas ref={canvasRef} className="h-64 w-full rounded border border-zinc-800 bg-black" />
+
+        <WaveformView
+          peaksUrl={urls.peaksUrl}
+          currentTimeMs={currentTimeMs}
+          durationMs={totalMs}
+          onSeek={seek}
+        />
+
+        <ThumbnailStrip
+          thumbnailsUrl={urls.thumbnailsUrl}
+          sessionDir={urls.sessionDir}
+          currentTimeMs={currentTimeMs}
+          durationMs={totalMs}
+          onSeek={seek}
+          onFrames={setFrames}
+        />
+
+        {markers.length > 0 && (
+          <div className="relative h-3 rounded bg-zinc-900">
+            {markers.map((marker) => (
+              <button
+                key={marker.id}
+                type="button"
+                onClick={() => seek(marker.startMs)}
+                className={[
+                  "absolute top-0 h-3 min-w-1 rounded-sm",
+                  marker.id === highlightedTraceId ? "bg-blue-300" : "bg-zinc-500 hover:bg-zinc-300",
+                ].join(" ")}
+                style={{
+                  left: `${marker.leftPct}%`,
+                  width: `${marker.widthPct}%`,
+                }}
+                title={marker.label}
+              />
+            ))}
+          </div>
+        )}
+
+        <audio
+          ref={userAudioRef}
+          src={urls.userAudioUrl ?? undefined}
+          preload="metadata"
+          onTimeUpdate={primaryRef === userAudioRef ? onPrimaryTimeUpdate : undefined}
+          onEnded={() => setPlaying(false)}
+        />
+        <audio
+          ref={assistantAudioRef}
+          src={urls.assistantAudioUrl ?? undefined}
+          preload="metadata"
+          onTimeUpdate={primaryRef === assistantAudioRef ? onPrimaryTimeUpdate : undefined}
+          onEnded={() => setPlaying(false)}
+        />
+      </div>
+    </div>
+  )
+}
+
+function buildTurnMarkers(
+  turns: Array<VoiceTurn | TraceWithObservations>,
+  sessionStartNs: number | undefined,
+  totalMs: number,
+): { id: string; label: string; startMs: number; leftPct: number; widthPct: number }[] {
+  if (sessionStartNs == null) return []
+  return turns.map((turn, index) => {
+    const startMs = Math.max(0, Math.round((Number(turn.start_time_ns) - sessionStartNs) / 1e6))
+    const endMs =
+      turn.end_time_ns != null
+        ? Math.max(startMs, Math.round((Number(turn.end_time_ns) - sessionStartNs) / 1e6))
+        : startMs + 250
+    return {
+      id: turn.trace_id,
+      label: `Turn ${index + 1}`,
+      startMs,
+      leftPct: clamp((startMs / totalMs) * 100, 0, 100),
+      widthPct: Math.max(0.5, clamp(((endMs - startMs) / totalMs) * 100, 0.5, 100)),
+    }
+  })
+}
+
+function drawNearestFrame(
+  canvas: HTMLCanvasElement | null,
+  sessionDir: string,
+  frames: ThumbnailFrame[],
+  currentTimeMs: number,
+) {
+  if (!canvas) return
+  const ctx = canvas.getContext("2d")
+  if (!ctx) return
+  const idx = nearestFrameIndex(frames, currentTimeMs)
+  if (idx < 0) {
+    const rect = canvas.getBoundingClientRect()
+    const scale = window.devicePixelRatio || 1
+    canvas.width = Math.max(1, Math.floor(rect.width * scale))
+    canvas.height = Math.max(1, Math.floor(rect.height * scale))
+    ctx.fillStyle = "#000000"
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
+    ctx.fillStyle = "#71717a"
+    ctx.font = `${12 * scale}px system-ui, sans-serif`
+    ctx.fillText("No video captured", 14 * scale, 24 * scale)
+    return
+  }
+  const frame = frames[idx]
+  const img = new Image()
+  img.onload = () => {
+    const rect = canvas.getBoundingClientRect()
+    const scale = window.devicePixelRatio || 1
+    canvas.width = Math.max(1, Math.floor(rect.width * scale))
+    canvas.height = Math.max(1, Math.floor(rect.height * scale))
+    ctx.fillStyle = "#000000"
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
+    const fitted = fitRect(img.naturalWidth, img.naturalHeight, canvas.width, canvas.height)
+    ctx.drawImage(img, fitted.x, fitted.y, fitted.width, fitted.height)
+  }
+  img.src = mediaPathUrl(sessionDir, frame.frameFile)
+}
+
+function fitRect(srcWidth: number, srcHeight: number, destWidth: number, destHeight: number) {
+  const scale = Math.min(destWidth / Math.max(1, srcWidth), destHeight / Math.max(1, srcHeight))
+  const width = srcWidth * scale
+  const height = srcHeight * scale
+  return {
+    x: (destWidth - width) / 2,
+    y: (destHeight - height) / 2,
+    width,
+    height,
+  }
+}
+
+function syncAudioTime(audio: HTMLAudioElement | null, timeMs: number) {
+  if (!audio) return
+  audio.currentTime = timeMs / 1000
+}
+
+async function playAudio(audio: HTMLAudioElement | null): Promise<boolean> {
+  if (!audio || !audio.src) return false
+  try {
+    await audio.play()
+    return true
+  } catch {
+    return false
+  }
+}
+
+function correctDrift(audio: HTMLAudioElement | null, targetMs: number) {
+  if (!audio || audio.paused) return
+  const driftMs = Math.abs(audio.currentTime * 1000 - targetMs)
+  if (driftMs > 50) syncAudioTime(audio, targetMs)
+}
+
+function inferDurationMs(media: MediaRow[]): number {
+  const durations = media
+    .filter((m) => m.kind === "session_user_audio" || m.kind === "session_assistant_audio")
+    .map((m) => m.duration_ms ?? 0)
+  return Math.max(1, ...durations)
+}
+
+function formatTime(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}

--- a/tracing-ui/src/components/ThumbnailStrip.tsx
+++ b/tracing-ui/src/components/ThumbnailStrip.tsx
@@ -1,0 +1,146 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { mediaPathUrl } from "./media-paths"
+
+export type ThumbnailFrame = {
+  frameFile: string
+  timeMs: number
+}
+
+export type ThumbnailsJson = {
+  frames: ThumbnailFrame[]
+}
+
+export type ThumbnailStripProps = {
+  thumbnailsUrl: string
+  sessionDir: string
+  currentTimeMs: number
+  durationMs: number
+  onSeek: (timeMs: number) => void
+  onFrames?: (frames: ThumbnailFrame[]) => void
+}
+
+export function ThumbnailStrip({
+  thumbnailsUrl,
+  sessionDir,
+  currentTimeMs,
+  durationMs,
+  onSeek,
+  onFrames,
+}: ThumbnailStripProps) {
+  const stripRef = useRef<HTMLDivElement>(null)
+  const [frames, setFrames] = useState<ThumbnailFrame[]>([])
+  const [missing, setMissing] = useState(false)
+  const activeIndex = useMemo(
+    () => nearestFrameIndex(frames, currentTimeMs),
+    [frames, currentTimeMs],
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    setMissing(false)
+    fetch(thumbnailsUrl)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json) => {
+        if (cancelled) return
+        const nextFrames = isThumbnailsJson(json) ? json.frames.slice(0, 20) : []
+        setFrames(nextFrames)
+        setMissing(nextFrames.length === 0)
+        onFrames?.(nextFrames)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setMissing(true)
+        onFrames?.([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [onFrames, thumbnailsUrl])
+
+  const seekFromClientX = useCallback(
+    (clientX: number) => {
+      const el = stripRef.current
+      if (!el) return
+      const rect = el.getBoundingClientRect()
+      const ratio = rect.width > 0 ? (clientX - rect.left) / rect.width : 0
+      onSeek(clamp(ratio, 0, 1) * durationMs)
+    },
+    [durationMs, onSeek],
+  )
+
+  if (missing) {
+    return (
+      <div className="rounded border border-zinc-800 bg-zinc-950 px-3 py-4 text-center text-xs text-zinc-500">
+        No video thumbnails captured.
+      </div>
+    )
+  }
+
+  return (
+    <div
+      ref={stripRef}
+      className="grid h-20 cursor-ew-resize grid-flow-col auto-cols-fr overflow-hidden rounded border border-zinc-800 bg-zinc-950"
+      onClick={(e) => seekFromClientX(e.clientX)}
+      onPointerDown={(e) => {
+        e.currentTarget.setPointerCapture(e.pointerId)
+        seekFromClientX(e.clientX)
+      }}
+      onPointerMove={(e) => {
+        if (e.buttons === 1) seekFromClientX(e.clientX)
+      }}
+    >
+      {frames.map((frame, index) => (
+        <div
+          key={`${frame.frameFile}-${frame.timeMs}`}
+          className={[
+            "relative min-w-0 border-r border-zinc-950 last:border-r-0",
+            activeIndex === index ? "ring-2 ring-inset ring-blue-400" : "",
+          ].join(" ")}
+        >
+          <img
+            src={mediaPathUrl(sessionDir, frame.frameFile)}
+            alt=""
+            className="h-full w-full object-cover"
+            draggable={false}
+          />
+          <div className="absolute bottom-1 left-1 rounded bg-black/70 px-1 font-mono text-[10px] text-zinc-200">
+            {formatTime(frame.timeMs)}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function nearestFrameIndex(frames: ThumbnailFrame[], currentTimeMs: number): number {
+  if (frames.length === 0) return -1
+  let bestIndex = 0
+  let bestDelta = Number.POSITIVE_INFINITY
+  for (let i = 0; i < frames.length; i++) {
+    const delta = Math.abs(frames[i].timeMs - currentTimeMs)
+    if (delta < bestDelta) {
+      bestIndex = i
+      bestDelta = delta
+    }
+  }
+  return bestIndex
+}
+
+function isThumbnailsJson(value: unknown): value is ThumbnailsJson {
+  if (!value || typeof value !== "object") return false
+  const frames = (value as ThumbnailsJson).frames
+  return Array.isArray(frames)
+}
+
+function formatTime(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}

--- a/tracing-ui/src/components/TranscriptTab.tsx
+++ b/tracing-ui/src/components/TranscriptTab.tsx
@@ -1,12 +1,29 @@
-import type { VoiceTurn } from "@/lib/db"
+"use client"
+
+import { useMemo, useState } from "react"
+import type { MediaRow, VoiceTurn } from "@/lib/db"
+import { MediaTimeline } from "./MediaTimeline"
 
 export function TranscriptTab({
+  sessionId,
   turns,
+  media,
   sessionStartNs,
+  durationMs,
 }: {
+  sessionId: string
   turns: VoiceTurn[]
+  media: MediaRow[]
   sessionStartNs: number
+  durationMs: number
 }) {
+  const [currentTimeMs, setCurrentTimeMs] = useState(0)
+  const [seekRequest, setSeekRequest] = useState({ timeMs: 0, nonce: 0 })
+  const activeTraceId = useMemo(
+    () => activeTurnTraceId(turns, sessionStartNs, currentTimeMs),
+    [currentTimeMs, sessionStartNs, turns],
+  )
+
   if (turns.length === 0) {
     return (
       <div className="px-6 py-8 text-sm text-zinc-400">
@@ -17,10 +34,35 @@ export function TranscriptTab({
   }
 
   return (
-    <div className="px-6 py-6 space-y-8 max-w-3xl">
-      {turns.map((turn, idx) => (
-        <TurnBlock key={turn.span_id} turn={turn} index={idx + 1} sessionStartNs={sessionStartNs} />
-      ))}
+    <div>
+      <MediaTimeline
+        sessionId={sessionId}
+        media={media}
+        durationMs={durationMs}
+        turns={turns}
+        sessionStartNs={sessionStartNs}
+        highlightedTraceId={activeTraceId}
+        seekRequest={seekRequest}
+        onTimeChange={setCurrentTimeMs}
+      />
+      <div className="px-6 py-6 space-y-4 max-w-3xl">
+        {turns.map((turn, idx) => {
+          const relMs = turnStartMs(turn, sessionStartNs)
+          return (
+            <TurnBlock
+              key={turn.span_id}
+              turn={turn}
+              index={idx + 1}
+              sessionStartNs={sessionStartNs}
+              active={turn.trace_id === activeTraceId}
+              onSeek={() => {
+                setCurrentTimeMs(relMs)
+                setSeekRequest((prev) => ({ timeMs: relMs, nonce: prev.nonce + 1 }))
+              }}
+            />
+          )
+        })}
+      </div>
     </div>
   )
 }
@@ -29,18 +71,35 @@ function TurnBlock({
   turn,
   index,
   sessionStartNs,
+  active,
+  onSeek,
 }: {
   turn: VoiceTurn
   index: number
   sessionStartNs: number
+  active: boolean
+  onSeek: () => void
 }) {
-  const relMs = Math.max(0, Math.round((turn.start_time_ns - sessionStartNs) / 1e6))
+  const relMs = turnStartMs(turn, sessionStartNs)
   const sys = turn.input_messages.find((m) => m.role === "system")
   const userMsgs = turn.input_messages.filter((m) => m.role === "user")
   const userText = userMsgs.map((m) => m.content).join("\n\n")
 
   return (
-    <div className="space-y-3">
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onSeek}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") onSeek()
+      }}
+      className={[
+        "block w-full cursor-pointer rounded border p-3 text-left transition-colors",
+        active
+          ? "border-blue-500/60 bg-blue-500/10"
+          : "border-transparent hover:border-zinc-800 hover:bg-zinc-950/60",
+      ].join(" ")}
+    >
       <div className="flex items-center gap-3 text-xs text-zinc-500">
         <span className="rounded bg-zinc-900 px-2 py-0.5 text-zinc-400">Turn {index}</span>
         <span className="font-mono tabular-nums">+{formatOffset(relMs)}</span>
@@ -70,7 +129,10 @@ function SystemBubble({ text }: { text: string }) {
   // Collapsible <details> keeps the system prompt out of the way but one click
   // away. Dark-mode-friendly styling to match the rest of the app.
   return (
-    <details className="rounded border border-zinc-800 bg-zinc-950/50 text-xs">
+    <details
+      className="rounded border border-zinc-800 bg-zinc-950/50 text-xs"
+      onClick={(e) => e.stopPropagation()}
+    >
       <summary className="cursor-pointer select-none px-3 py-2 text-zinc-400 hover:text-zinc-200">
         System prompt{" "}
         <span className="text-zinc-600 tabular-nums">({text.length.toLocaleString()} chars)</span>
@@ -110,4 +172,23 @@ function formatOffset(ms: number): string {
   const m = Math.floor(s / 60)
   const rem = Math.round(s - m * 60)
   return `${m}m${rem.toString().padStart(2, "0")}s`
+}
+
+function activeTurnTraceId(
+  turns: VoiceTurn[],
+  sessionStartNs: number,
+  currentTimeMs: number,
+): string | null {
+  if (turns.length === 0) return null
+  let active = turns[0]
+  for (const turn of turns) {
+    const startMs = turnStartMs(turn, sessionStartNs)
+    if (startMs <= currentTimeMs) active = turn
+    else break
+  }
+  return active.trace_id
+}
+
+function turnStartMs(turn: VoiceTurn, sessionStartNs: number): number {
+  return Math.max(0, Math.round((turn.start_time_ns - sessionStartNs) / 1e6))
 }

--- a/tracing-ui/src/components/TurnsTab.tsx
+++ b/tracing-ui/src/components/TurnsTab.tsx
@@ -9,10 +9,11 @@
 // particular step. Client-side router updates keep the rest of the page
 // interactive without full reloads.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useMemo } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import type { MediaRow, ObservationRow, TraceWithObservations } from "@/lib/db"
 import { AttributesTabs } from "./AttributesTabs"
+import { MediaTimeline } from "./MediaTimeline"
 
 export type TurnsTabProps = {
   sessionId: string
@@ -59,13 +60,10 @@ export function TurnsTab({ sessionId, traces, media, sessionStartNs }: TurnsTabP
     [router, search, sessionId],
   )
 
-  // Media for the active turn. Filter by trace_id so we only load what we need
-  // into the audio player — a session with 30 turns shouldn't load 30 audio
-  // files upfront.
-  const activeMedia = useMemo(
-    () => (activeTrace ? media.filter((m) => m.trace_id === activeTrace.trace_id) : []),
-    [media, activeTrace],
-  )
+  const sessionTotalMs = useMemo(() => {
+    const endNs = Math.max(...traces.map((t) => Number(t.end_time_ns ?? t.start_time_ns)))
+    return Math.max(0, Math.round((endNs - sessionStartNs) / 1e6))
+  }, [sessionStartNs, traces])
 
   if (traces.length === 0) {
     return (
@@ -85,8 +83,11 @@ export function TurnsTab({ sessionId, traces, media, sessionStartNs }: TurnsTabP
       />
       <TimelinePanel
         trace={activeTrace}
-        media={activeMedia}
+        traces={traces}
+        media={media}
         sessionId={sessionId}
+        sessionStartNs={sessionStartNs}
+        sessionTotalMs={sessionTotalMs}
         activeStepSpanId={activeStep?.span_id ?? null}
         onSelectStep={(spanId) => setSelection(activeTraceId, spanId)}
       />
@@ -155,14 +156,20 @@ function TurnRail({
 
 function TimelinePanel({
   trace,
+  traces,
   media,
   sessionId,
+  sessionStartNs,
+  sessionTotalMs,
   activeStepSpanId,
   onSelectStep,
 }: {
   trace: TraceWithObservations | null
+  traces: TraceWithObservations[]
   media: MediaRow[]
   sessionId: string
+  sessionStartNs: number
+  sessionTotalMs: number
   activeStepSpanId: string | null
   onSelectStep: (spanId: string) => void
 }) {
@@ -177,7 +184,14 @@ function TimelinePanel({
 
   return (
     <div className="overflow-y-auto">
-      <MediaPlayer media={media} sessionId={sessionId} turnTotalMs={turnTotalMs} />
+      <MediaTimeline
+        sessionId={sessionId}
+        media={media}
+        durationMs={sessionTotalMs}
+        turns={traces}
+        sessionStartNs={sessionStartNs}
+        highlightedTraceId={trace.trace_id}
+      />
 
       <div className="px-5 py-4 space-y-2">
         <div className="flex items-center justify-between text-xs text-zinc-500">
@@ -366,197 +380,6 @@ function Section({ title, value }: { title: string; value: unknown }) {
   )
 }
 
-// --- media player (user + assistant audio + optional video) ---
-
-function MediaPlayer({
-  media,
-  sessionId,
-  turnTotalMs,
-}: {
-  media: MediaRow[]
-  sessionId: string
-  turnTotalMs: number
-}) {
-  const user = media.find((m) => m.kind === "user_audio" || m.kind === "user")
-  const assistant = media.find(
-    (m) => m.kind === "assistant_audio" || m.kind === "assistant",
-  )
-  const video = media.find((m) => m.kind === "video")
-
-  if (!user && !assistant && !video) {
-    return (
-      <div className="border-b border-zinc-800 px-5 py-4 text-xs text-zinc-500">
-        No captured media for this turn. (The relay writes PCM + JPEG files when
-        capture is enabled; older sessions have none.)
-      </div>
-    )
-  }
-
-  return (
-    <div className="border-b border-zinc-800 p-5 space-y-3">
-      <div className="flex items-center justify-between text-[10px] uppercase tracking-wide text-zinc-500">
-        <span>Turn media</span>
-        <span className="tabular-nums text-zinc-400">{turnTotalMs.toLocaleString()}ms</span>
-      </div>
-      {user && <AudioTrack row={user} sessionId={sessionId} label="User" accent="user" />}
-      {assistant && (
-        <AudioTrack row={assistant} sessionId={sessionId} label="Assistant" accent="assistant" />
-      )}
-      {video && <VideoPlayer row={video} sessionId={sessionId} />}
-    </div>
-  )
-}
-
-function AudioTrack({
-  row,
-  sessionId,
-  label,
-  accent,
-}: {
-  row: MediaRow
-  sessionId: string
-  label: string
-  accent: "user" | "assistant"
-}) {
-  if (!row.file_path) return null
-  const url = mediaUrlFromFilePath(row.file_path)
-  if (!url) return null
-  return (
-    <div className="rounded border border-zinc-800 p-3 space-y-2">
-      <div className="flex items-center justify-between text-[11px]">
-        <span
-          className={[
-            "rounded px-2 py-0.5 text-[10px] uppercase tracking-wide",
-            accent === "user"
-              ? "bg-blue-600/20 text-blue-200 border border-blue-500/30"
-              : "bg-emerald-600/20 text-emerald-200 border border-emerald-500/30",
-          ].join(" ")}
-        >
-          {label}
-        </span>
-        <span className="text-zinc-500 tabular-nums">
-          {row.duration_ms != null ? `${row.duration_ms}ms` : "—"}
-          {row.sample_rate_hz != null && ` · ${row.sample_rate_hz}Hz`}
-          {row.codec && ` · ${row.codec}`}
-        </span>
-      </div>
-      {/* Browser <audio> handles WAV natively — the API endpoint re-wraps PCM16 on the fly. */}
-      <audio
-        controls
-        src={url}
-        className="w-full h-8 [&::-webkit-media-controls-panel]:bg-zinc-900"
-        preload="metadata"
-      />
-    </div>
-  )
-}
-
-function VideoPlayer({ row, sessionId }: { row: MediaRow; sessionId: string }) {
-  const canvasRef = useRef<HTMLCanvasElement>(null)
-  const [timings, setTimings] = useState<{ frames: { offset_ms: number; file: string }[] } | null>(
-    null,
-  )
-  const [playing, setPlaying] = useState(false)
-  const [frameIdx, setFrameIdx] = useState(0)
-  // Intrinsic aspect of the first loaded frame — used to size the canvas so
-  // wide screens/portraits don't get stretched to fill the container.
-  const [aspect, setAspect] = useState<number | null>(null)
-  const mediaPrefix = mediaDirUrlFromFilePath(row.file_path ?? "")
-
-  useEffect(() => {
-    if (!mediaPrefix) return
-    fetch(`${mediaPrefix}/timings.json`)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((j) => setTimings(j))
-      .catch(() => setTimings(null))
-  }, [mediaPrefix])
-
-  useEffect(() => {
-    if (!playing || !timings) return
-    const frames = timings.frames
-    if (frameIdx >= frames.length - 1) {
-      setPlaying(false)
-      return
-    }
-    const cur = frames[frameIdx].offset_ms
-    const next = frames[frameIdx + 1].offset_ms
-    const delay = Math.max(10, next - cur)
-    const handle = setTimeout(() => setFrameIdx((i) => i + 1), delay)
-    return () => clearTimeout(handle)
-  }, [playing, frameIdx, timings])
-
-  useEffect(() => {
-    if (!timings || !mediaPrefix) return
-    const frame = timings.frames[frameIdx]
-    if (!frame) return
-    const url = `${mediaPrefix}/${encodeURIComponent(frame.file)}`
-    const img = new Image()
-    img.onload = () => {
-      const canvas = canvasRef.current
-      if (!canvas) return
-      canvas.width = img.naturalWidth
-      canvas.height = img.naturalHeight
-      const ctx = canvas.getContext("2d")
-      ctx?.drawImage(img, 0, 0)
-      if (img.naturalWidth > 0 && img.naturalHeight > 0) {
-        setAspect(img.naturalWidth / img.naturalHeight)
-      }
-    }
-    img.src = url
-  }, [timings, frameIdx, mediaPrefix])
-
-  if (!mediaPrefix) return null
-  if (!timings) {
-    return (
-      <div className="rounded border border-zinc-800 p-3 text-[11px] text-zinc-500">
-        Loading video frames…
-      </div>
-    )
-  }
-  const frameCount = timings.frames.length
-  return (
-    <div className="rounded border border-zinc-800 p-3 space-y-2">
-      <div className="flex items-center justify-between text-[11px]">
-        <span className="rounded px-2 py-0.5 text-[10px] uppercase tracking-wide bg-purple-600/20 text-purple-200 border border-purple-500/30">
-          Video
-        </span>
-        <span className="text-zinc-500 tabular-nums">
-          {frameCount} frame{frameCount === 1 ? "" : "s"}
-          {row.duration_ms != null && ` · ${row.duration_ms}ms`}
-        </span>
-      </div>
-      <canvas
-        ref={canvasRef}
-        className="w-full rounded bg-black"
-        style={aspect ? { aspectRatio: aspect, height: "auto" } : { maxHeight: "16rem" }}
-      />
-      <div className="flex items-center gap-2 text-[11px]">
-        <button
-          type="button"
-          onClick={() => {
-            if (frameIdx >= frameCount - 1) setFrameIdx(0)
-            setPlaying((p) => !p)
-          }}
-          className="rounded border border-zinc-700 px-2 py-0.5 text-zinc-200 hover:bg-zinc-900"
-        >
-          {playing ? "Pause" : "Play"}
-        </button>
-        <input
-          type="range"
-          min={0}
-          max={Math.max(0, frameCount - 1)}
-          value={frameIdx}
-          onChange={(e) => setFrameIdx(Number(e.target.value))}
-          className="flex-1"
-        />
-        <span className="tabular-nums text-zinc-500">
-          {frameIdx + 1}/{frameCount}
-        </span>
-      </div>
-    </div>
-  )
-}
-
 // --- helpers (private) ---
 
 type SpanNode = ObservationRow & { depth: number; children: SpanNode[] }
@@ -587,40 +410,6 @@ function buildSpanTree(trace: TraceWithObservations): SpanNode[] {
   }
   for (const r of roots) walk(r)
   return flat
-}
-
-function extractBasename(path: string): string | null {
-  if (!path) return null
-  const parts = path.split("/")
-  return parts[parts.length - 1] || null
-}
-
-// Derive a media URL from a stored absolute path like
-//   /Users/<user>/.voiceclaw/media/<sessionDir>/user-<turnId>.pcm
-// We mount the API route at /api/media/[sessionId]/[...path], where the
-// route resolves under MEDIA_ROOT/<sessionId>/... on disk. The UI doesn't
-// know MEDIA_ROOT, so we take the LAST two path segments — the on-disk
-// session dir + file basename — which already match the layout the relay
-// wrote. Works even when sessionKey is hashed because we read the hashed
-// dir name straight out of the stored file_path.
-function mediaUrlFromFilePath(filePath: string): string | null {
-  if (!filePath) return null
-  const parts = filePath.split("/").filter(Boolean)
-  if (parts.length < 2) return null
-  const file = parts[parts.length - 1]
-  const dir = parts[parts.length - 2]
-  return `/api/media/${encodeURIComponent(dir)}/${encodeURIComponent(file)}`
-}
-
-// For media that is itself a directory (e.g. video-<turnId>/) returns the
-// URL prefix under which its frame files + timings.json live.
-function mediaDirUrlFromFilePath(filePath: string): string | null {
-  if (!filePath) return null
-  const parts = filePath.split("/").filter(Boolean)
-  if (parts.length < 2) return null
-  const dirName = parts[parts.length - 1]
-  const sessionDir = parts[parts.length - 2]
-  return `/api/media/${encodeURIComponent(sessionDir)}/${encodeURIComponent(dirName)}`
 }
 
 function parseAttrs(raw: string | null): Record<string, unknown> {

--- a/tracing-ui/src/components/WaveformView.tsx
+++ b/tracing-ui/src/components/WaveformView.tsx
@@ -1,0 +1,219 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+export type PeaksJson = {
+  user: number[]
+  assistant: number[]
+  userDurationMs: number
+  assistantDurationMs: number
+  sampleRate: number
+}
+
+export type WaveformViewProps = {
+  peaksUrl: string
+  currentTimeMs: number
+  durationMs: number
+  onSeek: (timeMs: number) => void
+}
+
+export function WaveformView({
+  peaksUrl,
+  currentTimeMs,
+  durationMs,
+  onSeek,
+}: WaveformViewProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [peaks, setPeaks] = useState<PeaksJson | null>(null)
+  const [missing, setMissing] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    setMissing(false)
+    fetch(peaksUrl)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json) => {
+        if (cancelled) return
+        if (isPeaksJson(json)) setPeaks(json)
+        else setMissing(true)
+      })
+      .catch(() => {
+        if (!cancelled) setMissing(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [peaksUrl])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas || !peaks) return
+    drawWaveform(canvas, peaks, currentTimeMs, durationMs)
+  }, [peaks, currentTimeMs, durationMs])
+
+  const handlePointer = useCallback(
+    (clientX: number) => {
+      const canvas = canvasRef.current
+      if (!canvas) return
+      const rect = canvas.getBoundingClientRect()
+      const ratio = rect.width > 0 ? (clientX - rect.left) / rect.width : 0
+      onSeek(clamp(ratio, 0, 1) * durationMs)
+    },
+    [durationMs, onSeek],
+  )
+
+  if (missing) {
+    return (
+      <div className="rounded border border-zinc-800 bg-zinc-950 px-3 py-6 text-center text-xs text-zinc-500">
+        No audio captured for this session.
+      </div>
+    )
+  }
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="h-36 w-full cursor-pointer rounded border border-zinc-800 bg-zinc-950"
+      onClick={(e) => handlePointer(e.clientX)}
+      onPointerDown={(e) => {
+        e.currentTarget.setPointerCapture(e.pointerId)
+        handlePointer(e.clientX)
+      }}
+      onPointerMove={(e) => {
+        if (e.buttons === 1) handlePointer(e.clientX)
+      }}
+    />
+  )
+}
+
+export function mapPeakToTrackY(peak: number, baselineY: number, halfHeight: number): number {
+  return baselineY - normalizePeak(peak) * halfHeight
+}
+
+function drawWaveform(
+  canvas: HTMLCanvasElement,
+  peaks: PeaksJson,
+  currentTimeMs: number,
+  durationMs: number,
+) {
+  const rect = canvas.getBoundingClientRect()
+  const scale = window.devicePixelRatio || 1
+  const width = Math.max(1, Math.floor(rect.width * scale))
+  const height = Math.max(1, Math.floor(rect.height * scale))
+  if (canvas.width !== width || canvas.height !== height) {
+    canvas.width = width
+    canvas.height = height
+  }
+
+  const ctx = canvas.getContext("2d")
+  if (!ctx) return
+  ctx.clearRect(0, 0, width, height)
+  ctx.fillStyle = "#09090b"
+  ctx.fillRect(0, 0, width, height)
+
+  const paddingX = 10 * scale
+  const trackHeight = (height - 32 * scale) / 2
+  const assistantBase = 20 * scale + trackHeight / 2
+  const userBase = 22 * scale + trackHeight + trackHeight / 2
+  const halfHeight = Math.max(4 * scale, trackHeight * 0.42)
+
+  drawTicks(ctx, width, height, paddingX, durationMs, scale)
+  drawTrack(ctx, peaks.assistant, paddingX, width - paddingX, assistantBase, halfHeight, "#34d399")
+  drawTrack(ctx, peaks.user, paddingX, width - paddingX, userBase, halfHeight, "#60a5fa")
+  drawTrackLabel(ctx, "Assistant", paddingX, assistantBase - halfHeight - 3 * scale, "#a7f3d0", scale)
+  drawTrackLabel(ctx, "User", paddingX, userBase - halfHeight - 3 * scale, "#bfdbfe", scale)
+
+  const playheadX = paddingX + clamp(currentTimeMs / Math.max(1, durationMs), 0, 1) * (width - paddingX * 2)
+  ctx.strokeStyle = "#f4f4f5"
+  ctx.lineWidth = 1 * scale
+  ctx.beginPath()
+  ctx.moveTo(playheadX, 0)
+  ctx.lineTo(playheadX, height)
+  ctx.stroke()
+}
+
+function drawTrack(
+  ctx: CanvasRenderingContext2D,
+  values: number[],
+  left: number,
+  right: number,
+  baseline: number,
+  halfHeight: number,
+  color: string,
+) {
+  ctx.strokeStyle = color
+  ctx.lineWidth = Math.max(1, (right - left) / Math.max(1, values.length) * 0.72)
+  const count = values.length
+  if (count === 0) {
+    ctx.globalAlpha = 0.35
+    ctx.beginPath()
+    ctx.moveTo(left, baseline)
+    ctx.lineTo(right, baseline)
+    ctx.stroke()
+    ctx.globalAlpha = 1
+    return
+  }
+  for (let i = 0; i < count; i++) {
+    const x = left + (i / Math.max(1, count - 1)) * (right - left)
+    const top = mapPeakToTrackY(values[i], baseline, halfHeight)
+    const bottom = baseline + (baseline - top)
+    ctx.beginPath()
+    ctx.moveTo(x, top)
+    ctx.lineTo(x, bottom)
+    ctx.stroke()
+  }
+}
+
+function drawTicks(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  paddingX: number,
+  durationMs: number,
+  scale: number,
+) {
+  const intervalMs = 10_000
+  const count = Math.floor(durationMs / intervalMs)
+  ctx.strokeStyle = "#27272a"
+  ctx.fillStyle = "#71717a"
+  ctx.lineWidth = 1 * scale
+  ctx.font = `${10 * scale}px ui-monospace, SFMono-Regular, Menlo, monospace`
+  for (let i = 0; i <= count; i++) {
+    const time = i * intervalMs
+    const x = paddingX + (time / Math.max(1, durationMs)) * (width - paddingX * 2)
+    ctx.beginPath()
+    ctx.moveTo(x, 0)
+    ctx.lineTo(x, height)
+    ctx.stroke()
+    ctx.fillText(`${time / 1000}s`, x + 4 * scale, height - 7 * scale)
+  }
+}
+
+function drawTrackLabel(
+  ctx: CanvasRenderingContext2D,
+  label: string,
+  x: number,
+  y: number,
+  color: string,
+  scale: number,
+) {
+  ctx.fillStyle = color
+  ctx.font = `${10 * scale}px ui-monospace, SFMono-Regular, Menlo, monospace`
+  ctx.fillText(label, x, y)
+}
+
+function isPeaksJson(value: unknown): value is PeaksJson {
+  if (!value || typeof value !== "object") return false
+  const candidate = value as PeaksJson
+  return Array.isArray(candidate.user) && Array.isArray(candidate.assistant)
+}
+
+function normalizePeak(peak: number): number {
+  if (!Number.isFinite(peak) || peak <= 0) return 0
+  const normalized = peak > 1 ? peak / 32767 : peak
+  return clamp(normalized, 0, 1)
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}

--- a/tracing-ui/src/components/media-paths.ts
+++ b/tracing-ui/src/components/media-paths.ts
@@ -1,0 +1,75 @@
+import type { MediaRow } from "@/lib/db"
+
+export type SessionMediaUrls = {
+  sessionDir: string
+  userAudioUrl: string | null
+  assistantAudioUrl: string | null
+  peaksUrl: string
+  thumbnailsUrl: string
+}
+
+export function getSessionMediaUrls(sessionId: string, media: MediaRow[]): SessionMediaUrls {
+  const userAudio = media.find((m) => m.kind === "session_user_audio")
+  const assistantAudio = media.find((m) => m.kind === "session_assistant_audio")
+  const peaks = media.find((m) => m.kind === "session_peaks")
+  const thumbnails = media.find((m) => m.kind === "session_thumbnails")
+  const sessionDir =
+    sessionDirFromFilePath(peaks?.file_path)
+    ?? sessionDirFromFilePath(thumbnails?.file_path)
+    ?? sessionDirFromFilePath(userAudio?.file_path)
+    ?? sessionDirFromFilePath(assistantAudio?.file_path)
+    ?? sessionId
+
+  return {
+    sessionDir,
+    userAudioUrl:
+      mediaUrlFromFilePath(userAudio?.file_path ?? null)
+      ?? mediaPathUrl(sessionDir, ["session", "user.wav"]),
+    assistantAudioUrl:
+      mediaUrlFromFilePath(assistantAudio?.file_path ?? null)
+      ?? mediaPathUrl(sessionDir, ["session", "assistant.wav"]),
+    peaksUrl:
+      mediaUrlFromFilePath(peaks?.file_path ?? null)
+      ?? mediaPathUrl(sessionDir, ["session", "peaks.json"]),
+    thumbnailsUrl:
+      mediaUrlFromFilePath(thumbnails?.file_path ?? null)
+      ?? mediaPathUrl(sessionDir, ["session", "thumbnails.json"]),
+  }
+}
+
+export function mediaUrlFromFilePath(filePath: string | null): string | null {
+  if (!filePath) return null
+  const parts = filePath.split("/").filter(Boolean)
+  if (parts.length < 2) return null
+  const sessionDir = sessionDirFromFilePath(filePath)
+  if (!sessionDir) return null
+  const sessionIdx = parts.lastIndexOf(sessionDir)
+  if (sessionIdx < 0 || sessionIdx >= parts.length - 1) return null
+  return mediaPathUrl(sessionDir, parts.slice(sessionIdx + 1))
+}
+
+export function mediaDirUrlFromFilePath(filePath: string | null): string | null {
+  if (!filePath) return null
+  const parts = filePath.split("/").filter(Boolean)
+  if (parts.length < 2) return null
+  const dirName = parts[parts.length - 1]
+  const sessionDir = parts[parts.length - 2]
+  return mediaPathUrl(sessionDir, [dirName])
+}
+
+export function mediaPathUrl(sessionDir: string, path: string | string[]): string {
+  const parts = Array.isArray(path) ? path : path.split("/")
+  return `/api/media/${encodeURIComponent(sessionDir)}/${parts
+    .filter(Boolean)
+    .map((part) => encodeURIComponent(part))
+    .join("/")}`
+}
+
+function sessionDirFromFilePath(filePath: string | null | undefined): string | null {
+  if (!filePath) return null
+  const parts = filePath.split("/").filter(Boolean)
+  const sessionIdx = parts.lastIndexOf("session")
+  if (sessionIdx > 0) return parts[sessionIdx - 1]
+  if (parts.length >= 2) return parts[parts.length - 2]
+  return null
+}

--- a/tracing-ui/test/test-media-timeline-helpers.ts
+++ b/tracing-ui/test/test-media-timeline-helpers.ts
@@ -1,0 +1,43 @@
+// Unit-ish tests for pure MediaTimeline helpers.
+//
+// Run: npx tsx test/test-media-timeline-helpers.ts
+
+import { nearestFrameIndex } from "../src/components/ThumbnailStrip.js"
+import { mapPeakToTrackY } from "../src/components/WaveformView.js"
+import { mediaUrlFromFilePath } from "../src/components/media-paths.js"
+
+function run() {
+  assertEqual(mapPeakToTrackY(0, 50, 20), 50, "zero peak stays on baseline")
+  assertEqual(mapPeakToTrackY(0.5, 50, 20), 40, "normalized peak maps to half height")
+  assertEqual(mapPeakToTrackY(32767, 50, 20), 30, "int16 peak maps to full height")
+
+  const frames = [
+    { frameFile: "video-a/0000.jpeg", timeMs: 0 },
+    { frameFile: "video-b/0000.jpeg", timeMs: 900 },
+    { frameFile: "video-c/0000.jpeg", timeMs: 2000 },
+  ]
+  assertEqual(nearestFrameIndex(frames, 100), 0, "nearest first frame")
+  assertEqual(nearestFrameIndex(frames, 1200), 1, "nearest middle frame")
+  assertEqual(nearestFrameIndex(frames, 1900), 2, "nearest last frame")
+  assertEqual(nearestFrameIndex([], 500), -1, "empty frame list")
+  assertEqual(
+    mediaUrlFromFilePath("/tmp/media/session-a/session/user.wav"),
+    "/api/media/session-a/session/user.wav",
+    "session-level media keeps session subdir in URL",
+  )
+  assertEqual(
+    mediaUrlFromFilePath("/tmp/media/session-a/user-turn-1.pcm"),
+    "/api/media/session-a/user-turn-1.pcm",
+    "per-turn media maps to session root",
+  )
+
+  console.log("  PASS  media timeline helpers map peaks and nearest thumbnails")
+}
+
+run()
+
+function assertEqual(actual: unknown, expected: unknown, label: string) {
+  if (actual !== expected) {
+    throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+  }
+}


### PR DESCRIPTION
## Summary
- Add the shared MediaTimeline with synced session audio, waveform canvas, video canvas, thumbnail scrubbing, and turn markers
- Wire the Transcript and Turns tabs to the session-level media timeline with active-turn highlighting and transcript-row seeking
- Add session media docs and pure helper coverage for waveform scaling, thumbnail selection, and media URL mapping

## Test plan
- [x] yarn workspace voiceclaw-tracing-ui typecheck
- [x] yarn workspace voiceclaw-tracing-ui build
- [x] yarn workspace voiceclaw-docs build
- [x] yarn workspace relay-server exec tsx ../tracing-ui/test/test-media-timeline-helpers.ts
- [x] yarn workspace relay-server exec tsx ../tracing-ui/test/test-attributes-tabs.ts
- [x] Ran tracing-ui dev server against an isolated SQLite/media fixture and verified transcript/turn pages plus peaks, WAV, thumbnails, and JPEG media routes with curl