### PR TITLE
Add capture-only mic recording path (NAN-652)

### DIFF
--- a/mobile/lib/use-realtime.ts
+++ b/mobile/lib/use-realtime.ts
@@ -105,7 +105,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
 
   // Listen for audio from native module and forward to WebSocket
   useEffect(() => {
-    const subscription = ExpoRealtimeAudioModule.addListener(
+    const gatedSubscription = ExpoRealtimeAudioModule.addListener(
       'onAudioCaptured',
       (event: { data: string }) => {
         if (mutedRef.current) return
@@ -117,7 +117,22 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
         }
       },
     )
-    return () => subscription.remove()
+    const rawCaptureSubscription = ExpoRealtimeAudioModule.addListener(
+      'onAudioCapturedRaw',
+      (event: { data: string }) => {
+        if (mutedRef.current) return
+        if (wsRef.current?.readyState === WebSocket.OPEN) {
+          wsRef.current.send(JSON.stringify({
+            type: 'audio.append_capture_only',
+            data: event.data,
+          }))
+        }
+      },
+    )
+    return () => {
+      gatedSubscription.remove()
+      rawCaptureSubscription.remove()
+    }
   }, [])
 
   const handleMessage = useCallback((event: MessageEvent) => {

--- a/mobile/modules/expo-realtime-audio/ios/ExpoRealtimeAudioModule.swift
+++ b/mobile/modules/expo-realtime-audio/ios/ExpoRealtimeAudioModule.swift
@@ -7,12 +7,15 @@ public class ExpoRealtimeAudioModule: Module {
     public func definition() -> ModuleDefinition {
         Name("ExpoRealtimeAudio")
 
-        Events("onAudioCaptured", "onError", "onLog", "onRmsMetrics")
+        Events("onAudioCaptured", "onAudioCapturedRaw", "onError", "onLog", "onRmsMetrics")
 
         OnCreate {
             self.audioManager = RealtimeAudioManager(
                 onAudioCaptured: { [weak self] base64Audio in
                     self?.sendEvent("onAudioCaptured", ["data": base64Audio])
+                },
+                onAudioCapturedRaw: { [weak self] base64Audio in
+                    self?.sendEvent("onAudioCapturedRaw", ["data": base64Audio])
                 },
                 onError: { [weak self] message in
                     self?.sendEvent("onError", ["message": message])

--- a/mobile/modules/expo-realtime-audio/ios/RealtimeAudioManager.swift
+++ b/mobile/modules/expo-realtime-audio/ios/RealtimeAudioManager.swift
@@ -31,6 +31,7 @@ class RealtimeAudioManager {
     private var softwareGain: Float = 1.0
 
     private let onAudioCaptured: (String) -> Void
+    private let onAudioCapturedRaw: (String) -> Void
     private let onError: (String) -> Void
     private let onLog: (String) -> Void
     private let onRmsMetrics: (Float, Bool, Bool, Float, String) -> Void
@@ -40,11 +41,13 @@ class RealtimeAudioManager {
 
     init(
         onAudioCaptured: @escaping (String) -> Void,
+        onAudioCapturedRaw: @escaping (String) -> Void,
         onError: @escaping (String) -> Void,
         onLog: @escaping (String) -> Void,
         onRmsMetrics: @escaping (Float, Bool, Bool, Float, String) -> Void
     ) {
         self.onAudioCaptured = onAudioCaptured
+        self.onAudioCapturedRaw = onAudioCapturedRaw
         self.onError = onError
         self.onLog = onLog
         self.onRmsMetrics = onRmsMetrics
@@ -102,6 +105,8 @@ class RealtimeAudioManager {
         // Buffer for accumulating downsampled audio
         var accumulatedSamples: [Int16] = []
         accumulatedSamples.reserveCapacity(samplesPerChunk * 2)
+        var rawCaptureSamples: [Int16] = []
+        rawCaptureSamples.reserveCapacity(samplesPerChunk * 2)
 
         var tapCallCount = 0
         var gatedCount = 0
@@ -140,29 +145,34 @@ class RealtimeAudioManager {
                 }
                 // Send silence to keep the audio stream alive
                 self.onAudioCaptured(silenceBase64)
+                appendDownsampledPcm16(
+                    channelData: channelData,
+                    frameCount: frameCount,
+                    downsampleRatio: downsampleRatio,
+                    samplesPerChunk: samplesPerChunk,
+                    into: &rawCaptureSamples,
+                    onChunk: self.onAudioCapturedRaw
+                )
                 return
             }
 
             // Downsample to 24kHz and convert to Int16
-            var i: Double = 0
-            while Int(i) < frameCount {
-                let idx = Int(i)
-                let sample = channelData[idx]
-                let clamped = max(-1.0, min(1.0, sample))
-                let int16Val = Int16(clamped * 32767.0)
-                accumulatedSamples.append(int16Val)
-
-                if accumulatedSamples.count >= samplesPerChunk {
-                    let data = accumulatedSamples.withUnsafeBufferPointer { ptr in
-                        Data(buffer: ptr)
-                    }
-                    let base64 = data.base64EncodedString()
-                    self.onAudioCaptured(base64)
-                    accumulatedSamples.removeAll(keepingCapacity: true)
-                }
-
-                i += downsampleRatio
-            }
+            appendDownsampledPcm16(
+                channelData: channelData,
+                frameCount: frameCount,
+                downsampleRatio: downsampleRatio,
+                samplesPerChunk: samplesPerChunk,
+                into: &accumulatedSamples,
+                onChunk: self.onAudioCaptured
+            )
+            appendDownsampledPcm16(
+                channelData: channelData,
+                frameCount: frameCount,
+                downsampleRatio: downsampleRatio,
+                samplesPerChunk: samplesPerChunk,
+                into: &rawCaptureSamples,
+                onChunk: self.onAudioCapturedRaw
+            )
         }
 
         // Handle audio session interruptions
@@ -275,5 +285,33 @@ class RealtimeAudioManager {
 
     func setDebugMetricsEnabled(_ enabled: Bool) {
         debugMetricsEnabled = enabled
+    }
+}
+
+private func appendDownsampledPcm16(
+    channelData: UnsafePointer<Float>,
+    frameCount: Int,
+    downsampleRatio: Double,
+    samplesPerChunk: Int,
+    into accumulatedSamples: inout [Int16],
+    onChunk: (String) -> Void
+) {
+    var i: Double = 0
+    while Int(i) < frameCount {
+        let idx = Int(i)
+        let sample = channelData[idx]
+        let clamped = max(-1.0, min(1.0, sample))
+        let int16Val = Int16(clamped * 32767.0)
+        accumulatedSamples.append(int16Val)
+
+        if accumulatedSamples.count >= samplesPerChunk {
+            let data = accumulatedSamples.withUnsafeBufferPointer { ptr in
+                Data(buffer: ptr)
+            }
+            onChunk(data.base64EncodedString())
+            accumulatedSamples.removeAll(keepingCapacity: true)
+        }
+
+        i += downsampleRatio
     }
 }

--- a/mobile/modules/expo-realtime-audio/src/ExpoRealtimeAudio.types.ts
+++ b/mobile/modules/expo-realtime-audio/src/ExpoRealtimeAudio.types.ts
@@ -20,6 +20,7 @@ export type AudioLogEvent = {
 
 export type ExpoRealtimeAudioModuleEvents = {
   onAudioCaptured: (event: AudioCapturedEvent) => void
+  onAudioCapturedRaw: (event: AudioCapturedEvent) => void
   onError: (event: AudioErrorEvent) => void
   onLog: (event: AudioLogEvent) => void
   onRmsMetrics: (event: RmsMetricsEvent) => void

--- a/relay-server/src/media/capture.ts
+++ b/relay-server/src/media/capture.ts
@@ -6,6 +6,8 @@
 //
 //   user-<turnId>.pcm            mono PCM16 little-endian
 //   user-<turnId>.pcm.json       { "sampleRate": 24000, "channels": 1 }
+//   user-capture-<turnId>.pcm    ungated user mic recording, when client supports it
+//   user-capture-<turnId>.pcm.json
 //   assistant-<turnId>.pcm
 //   assistant-<turnId>.pcm.json
 //   video-<turnId>/0000.jpeg     (one JPEG per frame)
@@ -118,6 +120,14 @@ export class MediaCapture {
     t.userBytes += buf.byteLength
   }
 
+  onUserAudioChunkCaptureOnly(base64Pcm: string): void {
+    const t = this.currentTurn
+    if (!t || !t.userCaptureStream) return
+    const buf = Buffer.from(base64Pcm, "base64")
+    t.userCaptureStream.write(buf)
+    t.userCaptureBytes += buf.byteLength
+  }
+
   onAssistantAudioChunk(base64Pcm: string): void {
     const t = this.currentTurn
     if (!t || !t.assistantStream) return
@@ -166,19 +176,39 @@ export class MediaCapture {
       "media.turn_id": t.turnId,
     }
 
-    if (t.userStream) {
-      await closeStream(t.userStream)
-      const durationMs = estimatePcmDurationMs(t.userBytes, this.config.userSampleRate, 1)
+    if (t.userStream) await closeStream(t.userStream)
+    if (t.userCaptureStream) await closeStream(t.userCaptureStream)
+
+    const preferredUserPath = t.userCaptureBytes > 0 ? t.userCapturePcmPath : t.userPcmPath
+    const preferredUserBytes = t.userCaptureBytes > 0 ? t.userCaptureBytes : t.userBytes
+
+    if (preferredUserBytes > 0) {
+      const durationMs = estimatePcmDurationMs(preferredUserBytes, this.config.userSampleRate, 1)
+      await writeSidecar(preferredUserPath + ".json", {
+        sampleRate: this.config.userSampleRate,
+        channels: 1,
+      })
+      attrs["media.user_audio.path"] = preferredUserPath
+      attrs["media.user_audio.duration_ms"] = durationMs
+      attrs["media.user_audio.sample_rate"] = this.config.userSampleRate
+      attrs["media.user_audio.codec"] = "pcm_s16le"
+      attrs["media.user_audio.bytes"] = preferredUserBytes
+      attrs["media.user_audio.provider"] = "local"
+      if (t.userCaptureBytes > 0) {
+        attrs["media.user_audio.capture_path"] = t.userCapturePcmPath
+        attrs["media.user_audio.capture_bytes"] = t.userCaptureBytes
+        if (t.userBytes > 0) {
+          attrs["media.user_audio.gated_path"] = t.userPcmPath
+          attrs["media.user_audio.gated_bytes"] = t.userBytes
+        }
+      }
+    }
+
+    if (t.userBytes > 0 && preferredUserPath !== t.userPcmPath) {
       await writeSidecar(t.userPcmPath + ".json", {
         sampleRate: this.config.userSampleRate,
         channels: 1,
       })
-      attrs["media.user_audio.path"] = t.userPcmPath
-      attrs["media.user_audio.duration_ms"] = durationMs
-      attrs["media.user_audio.sample_rate"] = this.config.userSampleRate
-      attrs["media.user_audio.codec"] = "pcm_s16le"
-      attrs["media.user_audio.bytes"] = t.userBytes
-      attrs["media.user_audio.provider"] = "local"
     }
 
     if (t.assistantStream) {
@@ -219,8 +249,8 @@ export class MediaCapture {
     // in-memory footprint stays O(1) regardless of session length.
     this.completedTurns.push({
       turnId: t.turnId,
-      userPcmPath: t.userStream ? t.userPcmPath : null,
-      userBytes: t.userBytes,
+      userPcmPath: preferredUserBytes > 0 ? preferredUserPath : null,
+      userBytes: preferredUserBytes,
       assistantPcmPath: t.assistantStream ? t.assistantPcmPath : null,
       assistantBytes: t.assistantBytes,
       videoDir: t.videoDir && t.videoFrames.length > 0 ? t.videoDir : null,
@@ -352,6 +382,9 @@ type TurnState = {
   userPcmPath: string
   userStream: WriteStream | null
   userBytes: number
+  userCapturePcmPath: string
+  userCaptureStream: WriteStream | null
+  userCaptureBytes: number
   assistantPcmPath: string
   assistantStream: WriteStream | null
   assistantBytes: number
@@ -378,9 +411,11 @@ function openTurn(
   _cfg: Required<Omit<MediaCaptureConfig, "enabled">> & { enabled: boolean },
 ): TurnState {
   const userPath = join(sessionDir, `user-${turnId}.pcm`)
+  const userCapturePath = join(sessionDir, `user-capture-${turnId}.pcm`)
   const assistantPath = join(sessionDir, `assistant-${turnId}.pcm`)
   const videoDir = join(sessionDir, `video-${turnId}`)
   const userStream = openStreamOrNull(userPath, "user")
+  const userCaptureStream = openStreamOrNull(userCapturePath, "user-capture")
   const assistantStream = openStreamOrNull(assistantPath, "assistant")
   // Video dir is created lazily on first frame to avoid scattering empty
   // `video-<turnId>/` dirs for audio-only turns.
@@ -391,6 +426,9 @@ function openTurn(
     userPcmPath: userPath,
     userStream,
     userBytes: 0,
+    userCapturePcmPath: userCapturePath,
+    userCaptureStream,
+    userCaptureBytes: 0,
     assistantPcmPath: assistantPath,
     assistantStream,
     assistantBytes: 0,

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -266,6 +266,11 @@ export class RelaySession {
         this.media.onUserAudioChunk(event.data)
         this.adapter?.sendAudio(event.data)
         break
+      case "audio.append_capture_only":
+        // Raw mic capture for recordings only. Do not forward upstream; Gemini
+        // should keep receiving the echo-gated stream via audio.append.
+        this.media.onUserAudioChunkCaptureOnly(event.data)
+        break
       case "audio.commit":
         this.adapter?.commitAudio()
         break

--- a/relay-server/src/types.ts
+++ b/relay-server/src/types.ts
@@ -4,6 +4,7 @@
 export type ClientEvent =
   | SessionConfigEvent
   | AudioAppendEvent
+  | AudioAppendCaptureOnlyEvent
   | AudioCommitEvent
   | FrameAppendEvent
   | ResponseCreateEvent
@@ -36,6 +37,11 @@ export interface SessionConfigEvent {
 export interface AudioAppendEvent {
   type: "audio.append"
   data: string // base64 PCM16
+}
+
+export interface AudioAppendCaptureOnlyEvent {
+  type: "audio.append_capture_only"
+  data: string // base64 PCM16, local recording only; never forwarded upstream
 }
 
 export interface AudioCommitEvent {

--- a/relay-server/test/test-media-capture.ts
+++ b/relay-server/test/test-media-capture.ts
@@ -23,6 +23,10 @@ async function run() {
     capture.onUserAudioChunk(chunk.toString("base64"))
     capture.onAssistantAudioChunk(chunk.toString("base64"))
   }
+  const rawChunk = Buffer.alloc(640)
+  for (let i = 0; i < 10; i++) {
+    capture.onUserAudioChunkCaptureOnly(rawChunk.toString("base64"))
+  }
 
   // Two video frames (1-byte payload is fine for this test — JPEG validation
   // isn't part of the capture contract; the relay writes raw JPEG bytes as-is).
@@ -32,11 +36,18 @@ async function run() {
   const attrs = await capture.finalizeTurn()
 
   const expectedUserPath = join(root, "unit-session", "user-turn-001.pcm")
+  const expectedUserCapturePath = join(root, "unit-session", "user-capture-turn-001.pcm")
   const expectedAssistantPath = join(root, "unit-session", "assistant-turn-001.pcm")
   const expectedVideoDir = join(root, "unit-session", "video-turn-001")
 
-  if (attrs["media.user_audio.path"] !== expectedUserPath) {
+  if (attrs["media.user_audio.path"] !== expectedUserCapturePath) {
     throw new Error(`user path mismatch: ${attrs["media.user_audio.path"]}`)
+  }
+  if (attrs["media.user_audio.gated_path"] !== expectedUserPath) {
+    throw new Error(`gated user path mismatch: ${attrs["media.user_audio.gated_path"]}`)
+  }
+  if (attrs["media.user_audio.capture_path"] !== expectedUserCapturePath) {
+    throw new Error(`capture user path mismatch: ${attrs["media.user_audio.capture_path"]}`)
   }
   if (attrs["media.assistant_audio.path"] !== expectedAssistantPath) {
     throw new Error(`assistant path mismatch: ${attrs["media.assistant_audio.path"]}`)
@@ -48,13 +59,19 @@ async function run() {
     throw new Error(`expected provider=local, got ${attrs["media.user_audio.provider"]}`)
   }
   if (!existsSync(expectedUserPath)) throw new Error("user pcm file missing")
+  if (!existsSync(expectedUserCapturePath)) throw new Error("user capture pcm file missing")
   if (!existsSync(expectedUserPath + ".json")) throw new Error("user sidecar missing")
+  if (!existsSync(expectedUserCapturePath + ".json")) throw new Error("user capture sidecar missing")
   if (!existsSync(expectedAssistantPath)) throw new Error("assistant pcm file missing")
 
   // Verify the user PCM got 50 * 320 bytes.
   const userBytes = readFileSync(expectedUserPath).byteLength
   if (userBytes !== 50 * 320) {
     throw new Error(`expected 16000 bytes in user.pcm, got ${userBytes}`)
+  }
+  const userCaptureBytes = readFileSync(expectedUserCapturePath).byteLength
+  if (userCaptureBytes !== 10 * 640) {
+    throw new Error(`expected 6400 bytes in user-capture.pcm, got ${userCaptureBytes}`)
   }
 
   // Timing JSON for video frames.
@@ -72,17 +89,34 @@ async function run() {
   // Second turn through the same session — must not clobber turn-001 files.
   capture.startTurn("turn-002")
   capture.onUserAudioChunk(chunk.toString("base64"))
+  capture.onUserAudioChunkCaptureOnly(rawChunk.toString("base64"))
   const attrs2 = await capture.finalizeTurn()
-  if (attrs2["media.user_audio.path"] === expectedUserPath) {
-    throw new Error("turn-002 reused turn-001's path")
+  if (attrs2["media.user_audio.path"] === expectedUserCapturePath) {
+    throw new Error("turn-002 reused turn-001's capture path")
   }
   if (!existsSync(expectedUserPath)) {
     throw new Error("turn-001 user.pcm deleted by turn-002")
   }
+  if (!existsSync(expectedUserCapturePath)) {
+    throw new Error("turn-001 user-capture.pcm deleted by turn-002")
+  }
 
   console.log("  PASS  second turn writes to distinct files")
 
-  capture.endSession()
+  const sessionAttrs = await capture.finalizeSession()
+  const sessionUserWav = sessionAttrs["media.session_audio.user.path"]
+  if (typeof sessionUserWav !== "string") {
+    throw new Error(`missing session user wav path: ${JSON.stringify(sessionAttrs)}`)
+  }
+  const sessionUserBytes = readFileSync(sessionUserWav).byteLength
+  const expectedSessionUserBytes = 44 + 10 * 640 + 640
+  if (sessionUserBytes !== expectedSessionUserBytes) {
+    throw new Error(`expected session user wav to use capture bytes (${expectedSessionUserBytes}), got ${sessionUserBytes}`)
+  }
+
+  console.log("  PASS  session user wav prefers capture-only PCM")
+
+  await capture.endSession()
 
   // Disabled mode should be a no-op.
   const noop = new MediaCapture({ enabled: false, rootDir: root })

--- a/tracing-ui/src/app/api/media/[sessionId]/[...path]/route.ts
+++ b/tracing-ui/src/app/api/media/[sessionId]/[...path]/route.ts
@@ -10,7 +10,7 @@
 
 import { promises as fs } from "node:fs"
 import { homedir } from "node:os"
-import { join, resolve, extname, basename } from "node:path"
+import { join, resolve, extname, basename, dirname } from "node:path"
 import { NextResponse } from "next/server"
 
 export const dynamic = "force-dynamic"
@@ -21,13 +21,10 @@ const MEDIA_ROOT = process.env.VOICECLAW_MEDIA_DIR
 // PCM sidecar sample rate keys we accept, in order of preference.
 const SAMPLE_RATE_KEYS = ["sampleRate", "sample_rate_hz", "sample_rate"]
 
-// User audio is captured post-AEC on the iOS client and echo-gated to match
-// what Gemini received (silence frames when the speaker is playing back).
-// Result: the raw user PCM is ~30 dB quieter on average than the assistant.
-// We auto-normalize user-* files at WAV wrap time so browser playback is
-// audible. The on-disk PCM is never mutated — only the streamed copy.
-// Proper fix (capture a separate un-gated mic tap in the iOS native module)
-// tracked as a follow-up; this is the zero-risk viewer-side patch.
+// Older user-* files were captured post-AEC and echo-gated to match what
+// Gemini received, which made recordings too quiet or silence-stuffed. Newer
+// clients also write user-capture-* files before the echo gate; prefer those
+// when present and keep normalization only for the older gated fallback.
 const USER_AUDIO_TARGET_PEAK_I16 = 29000 // ~-1 dB from int16 max (32767)
 const USER_AUDIO_MAX_GAIN = 8 // cap amplification — silent files stay silent
 
@@ -46,19 +43,22 @@ export async function GET(
     return new NextResponse("forbidden", { status: 403 })
   }
 
+  const readTarget = await preferCapturePcm(target)
+
   let bytes: Buffer
   try {
-    bytes = await fs.readFile(target)
+    bytes = await fs.readFile(readTarget)
   } catch {
     return new NextResponse("not found", { status: 404 })
   }
 
-  const ext = extname(target).toLowerCase()
+  const ext = extname(readTarget).toLowerCase()
 
   if (ext === ".pcm") {
-    const sampleRate = await readSampleRate(target)
-    const isUserAudio = basename(target).startsWith("user-")
-    const pcmForWav = isUserAudio ? normalizePcmGain(bytes) : bytes
+    const sampleRate = await readSampleRate(readTarget)
+    const name = basename(readTarget)
+    const isGatedUserAudio = name.startsWith("user-") && !name.startsWith("user-capture-")
+    const pcmForWav = isGatedUserAudio ? normalizePcmGain(bytes) : bytes
     const wav = pcmToWav(pcmForWav, sampleRate, 1)
     return new NextResponse(wav as unknown as BodyInit, {
       status: 200,
@@ -100,25 +100,39 @@ async function readSampleRate(pcmPath: string): Promise<number> {
   return 24000
 }
 
+async function preferCapturePcm(target: string): Promise<string> {
+  const name = basename(target)
+  if (extname(name).toLowerCase() !== ".pcm") return target
+  if (!name.startsWith("user-") || name.startsWith("user-capture-")) return target
+
+  const captureTarget = join(dirname(target), `user-capture-${name.slice("user-".length)}`)
+  try {
+    const stat = await fs.stat(captureTarget)
+    return stat.size > 0 ? captureTarget : target
+  } catch {
+    return target
+  }
+}
+
 function pcmToWav(pcm: Buffer, sampleRate: number, channels: number): Buffer {
   const byteRate = sampleRate * channels * 2
   const blockAlign = channels * 2
   const dataSize = pcm.length
   const buf = Buffer.alloc(44 + dataSize)
   let off = 0
-  buf.write("RIFF", off); off += 4
-  buf.writeUInt32LE(36 + dataSize, off); off += 4
-  buf.write("WAVE", off); off += 4
-  buf.write("fmt ", off); off += 4
-  buf.writeUInt32LE(16, off); off += 4
-  buf.writeUInt16LE(1, off); off += 2
-  buf.writeUInt16LE(channels, off); off += 2
-  buf.writeUInt32LE(sampleRate, off); off += 4
-  buf.writeUInt32LE(byteRate, off); off += 4
-  buf.writeUInt16LE(blockAlign, off); off += 2
-  buf.writeUInt16LE(16, off); off += 2
-  buf.write("data", off); off += 4
-  buf.writeUInt32LE(dataSize, off); off += 4
+  off = writeAscii(buf, off, "RIFF")
+  off = writeUInt32(buf, off, 36 + dataSize)
+  off = writeAscii(buf, off, "WAVE")
+  off = writeAscii(buf, off, "fmt ")
+  off = writeUInt32(buf, off, 16)
+  off = writeUInt16(buf, off, 1)
+  off = writeUInt16(buf, off, channels)
+  off = writeUInt32(buf, off, sampleRate)
+  off = writeUInt32(buf, off, byteRate)
+  off = writeUInt16(buf, off, blockAlign)
+  off = writeUInt16(buf, off, 16)
+  off = writeAscii(buf, off, "data")
+  off = writeUInt32(buf, off, dataSize)
   pcm.copy(buf, off)
   return buf
 }
@@ -163,4 +177,19 @@ function guessContentType(ext: string): string {
     case ".mp4": return "video/mp4"
     default: return "application/octet-stream"
   }
+}
+
+function writeAscii(buf: Buffer, off: number, value: string): number {
+  buf.write(value, off)
+  return off + value.length
+}
+
+function writeUInt16(buf: Buffer, off: number, value: number): number {
+  buf.writeUInt16LE(value, off)
+  return off + 2
+}
+
+function writeUInt32(buf: Buffer, off: number, value: number): number {
+  buf.writeUInt32LE(value, off)
+  return off + 4
 }


### PR DESCRIPTION
## Summary
- Add native iOS raw capture events and forward them as `audio.append_capture_only` without changing the gated model audio feed
- Write `user-capture-<turnId>.pcm` in the relay, prefer it for user recordings/session WAVs, and retain gated path metadata for debugging
- Prefer capture-only PCM in the tracing UI media route and keep gain normalization only for older gated user files

## Test plan
- [x] yarn workspace relay-server exec tsx test/test-media-capture.ts
- [x] yarn workspace relay-server build
- [x] yarn workspace voiceclaw-tracing-ui build
- [x] xcrun swiftc -typecheck -sdk $(xcrun --sdk iphoneos --show-sdk-path) -target arm64-apple-ios18.0 mobile/modules/expo-realtime-audio/ios/RealtimeAudioManager.swift
- [x] Ran tracing-ui dev server with a route fixture and verified `/api/media/.../user-turn-1.pcm` serves `user-capture-*` PCM without normalization
- [ ] APP_VARIANT=development yarn workspace voiceclaw-mobile exec expo run:ios --no-install -d 00008101-000D69900150001E (blocked: Xcode is missing the iOS 26.4 platform required by the connected iPhone)
- [ ] yarn workspace voiceclaw-mobile exec tsc --noEmit (blocked by pre-existing `mobile/app/(tabs)/index.tsx` startRealtimeCall used-before-declaration errors)