### PR TITLE
ci+qa: fix docs deploy, unify session cost, add session-stitch test

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,12 +23,17 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 20
+      # The repo root lists `docs` in the yarn workspaces array, so a plain
+      # `npm install` inside `docs/` walks up, discovers the other workspaces
+      # (notably `desktop` with vite@8), and fails on electron-vite's vite
+      # peer-dep conflict. Install via yarn at the repo root so each workspace
+      # uses its own hoistingLimits and the conflict doesn't surface.
+      - name: Enable corepack
+        run: corepack enable
       - name: Install dependencies
-        working-directory: docs
-        run: npm install
+        run: yarn install --immutable
       - name: Build docs
-        working-directory: docs
-        run: npm run build
+        run: yarn build:docs
       - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/dist

--- a/docs/src/content/docs/tracing-ui/qa.md
+++ b/docs/src/content/docs/tracing-ui/qa.md
@@ -1,0 +1,153 @@
+---
+title: Tracing QA — procedures + findings
+description: How to verify the tracing UI + tracing capture pipeline end-to-end after merges that touch the relay, collector, or UI
+---
+
+This page captures the QA procedure that runs after any batch of PRs touching
+the tracing stack (relay-server, tracing-collector, tracing-ui), plus the
+findings from the Apr 23 2026 run after the NAN-649..NAN-655 merges.
+
+## Stack under test
+
+- `relay-server` — emits OTel spans + writes captured media to
+  `~/.voiceclaw/media/<sessionKey>/`
+- `tracing-collector` — OTLP HTTP receiver on `:4318`; persists to
+  `~/.voiceclaw/tracing.db` (SQLite)
+- `tracing-ui` — Next.js app on `:4319`; reads the SQLite + serves media via
+  `/api/media/<sessionId>/[...path]`
+
+## How to start the stack
+
+```bash
+# Terminal 1 — relay (tsx watch; picks up source edits live)
+cd relay-server
+set -a && . ./.env && set +a
+VOICECLAW_MEDIA_CAPTURE=enabled yarn dev
+
+# Terminal 2 — collector + UI (concurrently)
+yarn dev:tracing
+```
+
+Verify all three ports:
+
+```bash
+lsof -iTCP -sTCP:LISTEN -P | grep -E ':8080|:4318|:4319'
+```
+
+Relay should log `[tracing] enabled (langfuse+collector)`. If it logs
+`[langfuse] tracing enabled ...` (older format), the relay is running from a
+stale `dist/` build via `yarn start` — kill it and re-run `yarn dev`.
+
+## Synthetic drivers (no real voice call needed)
+
+Two tests exercise the full pipeline without a desktop client:
+
+```bash
+# Usage attrs → OTel exporter → collector → SQLite
+cd relay-server
+TRACING_UI_COLLECTOR_URL=http://127.0.0.1:4318/v1/traces \
+  npx tsx test/test-usage-collector-e2e.ts
+
+# Session-level WAV stitch + peaks.json + thumbnails.json
+npx tsx test/test-session-media-stitch.ts
+```
+
+Both are stand-alone — no extra setup. The first writes a span to the
+collector that you can then inspect in the UI at
+`http://localhost:4319/sessions/usage-e2e-<timestamp>`.
+
+## UI smoke (Playwright or manual)
+
+For each tab, confirm:
+
+1. **Sessions list** — `/sessions` loads, shows rows, no console errors.
+2. **Transcript** — turns render; `Session media` timeline renders with empty
+   states for sessions that predate the stitcher (shows "No audio captured for
+   this session." / "No video thumbnails captured." instead of crashing).
+3. **Turns** — 3-pane layout (rail | timeline + media | detail panel).
+   Exactly ONE `voice-turn` row per turn (no duplicate synthetic row). Click
+   a turn → detail panel updates.
+4. **Logs** — row expand shows `Fields` | `JSON` tabs. Type into
+   `Filter Fields...` — rows filter as you type, matches on key AND value.
+5. **Cost** — donut + breakdown table. For sessions with `gen_ai.usage.*` the
+   amber banner is absent and Realtime bucket shows non-zero tokens.
+6. **Latency** — category bar + per-turn table. TTFT column populates for
+   sessions post-PR #178.
+7. **Context** — token breakdown per observation.
+
+## Cross-surface invariants to check
+
+- **Sidebar Cost == Cost tab total.** Previously the sidebar summed
+  `observation.cost_usd` (usually null for realtime spans) while CostTab
+  derives from `gen_ai.usage.*` via the shared pricing catalog. Both now
+  route through `@/lib/session-cost.computeSessionTotalCost`.
+- **Sidebar Tokens == Cost tab total tokens.**
+- **MediaTimeline duration == page sidebar Duration**, modulo rounding.
+
+## Apr 23 2026 findings
+
+Ran the above after merging NAN-649 / NAN-650 / NAN-651 / NAN-652 / NAN-655.
+
+### Fixed in this PR
+
+- **CI: docs deploy** broke because `docs/` is listed in root `yarn`
+  workspaces, so `cd docs && npm install` walked up and choked on the
+  desktop workspace's `vite@8` vs `electron-vite@5`'s peer constraint.
+  Switched the workflow to `yarn install --immutable` + `yarn build:docs` so
+  the whole monorepo installs under its usual per-workspace hoisting
+  limits, no conflict.
+- **Sidebar Cost mismatch** — shared via a new `lib/session-cost.ts`
+  helper; `page.tsx` and `CostTab` both call `computeSessionTotalCost()` and
+  `costForObservation()`.
+- **No end-to-end coverage for session-media stitch** — added
+  `test/test-session-media-stitch.ts` which drives 4 fake turns of PCM +
+  video through `MediaCapture`, calls `finalizeSession()`, and asserts
+  the emitted `session/user.wav` + `assistant.wav` + `peaks.json` +
+  `thumbnails.json` have the right shape (WAV headers present, peaks
+  normalized 0..1 with real signal, thumbnails capped at 20 and monotonic
+  by `timeMs`).
+
+### Verified working
+
+- NAN-650 gen_ai.usage.* stamping — e2e test lands the attrs in SQLite,
+  CostTab renders `$0.0003` for the test session.
+- NAN-651 AttributesTabs — Fields/JSON tabs render on Logs expansions.
+  Filter input is reactive and matches on key + value (contains).
+- NAN-649 MediaTimeline — renders on Transcript + Turns tabs. Gracefully
+  degrades on pre-stitcher sessions (clear empty states, no 500s).
+- Empty-first-span fix (PR #179) — Turns tab shows a single
+  `voice-turn` row per turn, detail panel opens on the real observation
+  with populated attributes.
+
+### Known gaps (out of scope here — follow-ups tracked)
+
+- Pre-PR-#177 sessions have no media capture on disk, so MediaTimeline shows
+  all three empty states. Expected.
+- Pre-PR-#178 sessions have no `voice.latency.*` → Latency tab shows "—" in
+  TTFT / Endpointing. Expected.
+- Pre-NAN-650 sessions have no `gen_ai.usage.*` → CostTab shows the amber
+  banner. Expected.
+- Collector's `cost_usd` column is still unpopulated; CostTab + sidebar
+  both derive from the shared pricing catalog via `gen_ai.usage.*` tokens.
+  Tracked for a collector-side pricing pass.
+
+## Running the whole thing in one shot
+
+```bash
+# Typecheck everything
+yarn workspaces foreach -A run tsc --noEmit 2>/dev/null \
+  || (yarn workspace voiceclaw-tracing-ui tsc --noEmit \
+      && yarn workspace voiceclaw-tracing-collector tsc --noEmit \
+      && (cd relay-server && yarn tsc --noEmit))
+
+# Synthetic drivers
+(cd relay-server \
+  && TRACING_UI_COLLECTOR_URL=http://127.0.0.1:4318/v1/traces \
+     npx tsx test/test-usage-collector-e2e.ts \
+  && npx tsx test/test-session-media-stitch.ts)
+
+# Manual: open http://localhost:4319/sessions and click through a recent row
+```
+
+If all three green, the tracing stack is healthy end-to-end without a real
+voice call.

--- a/relay-server/test/test-session-media-stitch.ts
+++ b/relay-server/test/test-session-media-stitch.ts
@@ -1,0 +1,164 @@
+// End-to-end test for session-level media stitch (NAN-649). Drives a fake
+// multi-turn session through MediaCapture and asserts that finalizeSession()
+// writes session/user.wav, session/assistant.wav, session/peaks.json, and
+// session/thumbnails.json — with the right shape, sample counts, and peak
+// array lengths.
+//
+// Run: npx tsx test/test-session-media-stitch.ts
+//
+// Why this exists: the production path only fires finalizeSession() when the
+// client disconnects, which is hard to trigger as an agent. This test lets us
+// verify the stitcher + downsampler + thumbnail selector without a voice call.
+
+import { mkdtempSync, existsSync, readFileSync, statSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { MediaCapture } from "../src/media/capture.js"
+
+const SESSION_KEY = "stitch-e2e-session"
+const TURN_COUNT = 4
+const CHUNKS_PER_TURN = 24 // 24 * 320 bytes = 7680 bytes ≈ 160ms @ 24 kHz
+const FRAMES_PER_TURN = 8
+
+async function run() {
+  const root = mkdtempSync(join(tmpdir(), "voiceclaw-stitch-test-"))
+  const capture = new MediaCapture({ enabled: true, rootDir: root })
+
+  capture.startSession(SESSION_KEY)
+
+  for (let turn = 0; turn < TURN_COUNT; turn++) {
+    // Simulate real wall-clock separation between turns (the session stitcher
+    // uses Date.now() to compute turnStartMs; back-to-back synchronous calls
+    // would all land in the same ms and make thumbnail timing non-monotonic).
+    if (turn > 0) await new Promise((r) => setTimeout(r, 50))
+    const turnId = `turn-${turn}`
+    capture.startTurn(turnId)
+
+    // Per-turn PCM: vary the sample amplitude per turn so the stitched WAV
+    // isn't just silence — otherwise peaks.json would be all zeros and we'd
+    // miss bugs in the downsampler.
+    for (let i = 0; i < CHUNKS_PER_TURN; i++) {
+      const buf = Buffer.alloc(320)
+      for (let s = 0; s < 160; s++) {
+        const v = Math.round(8000 * Math.sin((i * 160 + s) * 0.02) * (turn + 1) * 0.25)
+        buf.writeInt16LE(v, s * 2)
+      }
+      capture.onUserAudioChunk(buf.toString("base64"))
+      capture.onAssistantAudioChunk(buf.toString("base64"))
+    }
+
+    // Video: frames spaced 5ms apart per turn so total frame span per turn
+    // stays below the inter-turn wall-clock gap — preserves the monotonic
+    // session-time invariant the thumbnail selector relies on.
+    for (let f = 0; f < FRAMES_PER_TURN; f++) {
+      capture.onVideoFrame(Buffer.from([0xff, 0xd8, f, turn]).toString("base64"), f * 5)
+    }
+
+    await capture.finalizeTurn()
+  }
+
+  const sessionAttrs = await capture.finalizeSession()
+  await capture.endSession()
+
+  const sessionDir = join(root, SESSION_KEY, "session")
+  const userWav = join(sessionDir, "user.wav")
+  const assistantWav = join(sessionDir, "assistant.wav")
+  const peaksPath = join(sessionDir, "peaks.json")
+  const thumbsPath = join(sessionDir, "thumbnails.json")
+
+  assertExists(userWav, "user.wav")
+  assertExists(assistantWav, "assistant.wav")
+  assertExists(peaksPath, "peaks.json")
+  assertExists(thumbsPath, "thumbnails.json")
+
+  assertAttr(sessionAttrs, "media.session_audio.user.path", userWav)
+  assertAttr(sessionAttrs, "media.session_audio.assistant.path", assistantWav)
+  assertAttr(sessionAttrs, "media.session_audio.peaks_path", peaksPath)
+  assertAttr(sessionAttrs, "media.session_video.thumbnails_path", thumbsPath)
+
+  assertWav(userWav)
+  assertWav(assistantWav)
+
+  const peaks = JSON.parse(readFileSync(peaksPath, "utf8"))
+  if (!Array.isArray(peaks.user) || !Array.isArray(peaks.assistant)) {
+    throw new Error("peaks.json must have user + assistant arrays")
+  }
+  if (peaks.user.length === 0 || peaks.assistant.length === 0) {
+    throw new Error("peaks arrays must not be empty")
+  }
+  if (peaks.user.length > 2500 || peaks.assistant.length > 2500) {
+    throw new Error(`peaks arrays should cap near 2000 — got user=${peaks.user.length} asst=${peaks.assistant.length}`)
+  }
+  if (typeof peaks.sampleRate !== "number" || peaks.sampleRate <= 0) {
+    throw new Error(`peaks.sampleRate missing/invalid: ${peaks.sampleRate}`)
+  }
+  if (typeof peaks.userDurationMs !== "number" || peaks.userDurationMs <= 0) {
+    throw new Error(`peaks.userDurationMs missing/invalid: ${peaks.userDurationMs}`)
+  }
+  // Validate peaks actually carry signal — all-zero peaks would be a silent
+  // bug in the downsampler. Peaks are normalized to [0,1] (abs-value / int16max).
+  const maxUserPeak = Math.max(...peaks.user.map((v: number) => Math.abs(v)))
+  if (maxUserPeak < 0.01) {
+    throw new Error(`peaks.user appears silent (max=${maxUserPeak}) — downsampler bug`)
+  }
+  if (maxUserPeak > 1.001) {
+    throw new Error(`peaks.user unexpectedly exceeds 1.0 (max=${maxUserPeak}) — normalization bug`)
+  }
+
+  const thumbs = JSON.parse(readFileSync(thumbsPath, "utf8"))
+  if (!Array.isArray(thumbs.frames)) {
+    throw new Error("thumbnails.json must have frames array")
+  }
+  const totalFrames = TURN_COUNT * FRAMES_PER_TURN
+  if (thumbs.frames.length === 0) {
+    throw new Error("thumbnails.json frames is empty")
+  }
+  if (thumbs.frames.length > 20) {
+    throw new Error(`thumbnails.frames should cap at 20 — got ${thumbs.frames.length}`)
+  }
+  if (totalFrames < 20 && thumbs.frames.length !== totalFrames) {
+    throw new Error(`expected ${totalFrames} thumbs (under cap), got ${thumbs.frames.length}`)
+  }
+  // Thumbs should be strictly ordered by timeMs.
+  for (let i = 1; i < thumbs.frames.length; i++) {
+    if (thumbs.frames[i].timeMs < thumbs.frames[i - 1].timeMs) {
+      throw new Error(`thumbnails not monotonic at index ${i}`)
+    }
+  }
+
+  console.log(`  PASS  session media stitched for ${SESSION_KEY}`)
+  console.log(`        user.wav: ${statSync(userWav).size.toLocaleString()}B`)
+  console.log(`        assistant.wav: ${statSync(assistantWav).size.toLocaleString()}B`)
+  console.log(`        peaks: user=${peaks.user.length} assistant=${peaks.assistant.length} sampleRate=${peaks.sampleRate}Hz`)
+  console.log(`        thumbnails: ${thumbs.frames.length} frames (of ${totalFrames} captured)`)
+}
+
+run().catch((err) => {
+  console.error(`  FAIL  ${err instanceof Error ? err.message : err}`)
+  process.exit(1)
+})
+
+// --- helpers ---
+
+function assertExists(path: string, label: string) {
+  if (!existsSync(path)) throw new Error(`missing ${label} at ${path}`)
+}
+
+function assertAttr(attrs: Record<string, unknown>, key: string, expected: string) {
+  if (attrs[key] !== expected) {
+    throw new Error(`expected ${key}=${expected}, got ${attrs[key]}`)
+  }
+}
+
+function assertWav(path: string) {
+  const buf = readFileSync(path)
+  if (buf.length < 44) throw new Error(`${path} too small for WAV header`)
+  if (buf.slice(0, 4).toString("ascii") !== "RIFF") {
+    throw new Error(`${path}: missing RIFF header`)
+  }
+  if (buf.slice(8, 12).toString("ascii") !== "WAVE") {
+    throw new Error(`${path}: missing WAVE chunk`)
+  }
+  const sampleRate = buf.readUInt32LE(24)
+  if (sampleRate <= 0) throw new Error(`${path}: invalid sample rate ${sampleRate}`)
+}

--- a/tracing-ui/src/app/sessions/[id]/page.tsx
+++ b/tracing-ui/src/app/sessions/[id]/page.tsx
@@ -15,6 +15,8 @@ import { LogsTab, type LogRow } from "@/components/LogsTab"
 import { CostTab } from "@/components/CostTab"
 import { LatencyTab } from "@/components/LatencyTab"
 import { ContextTab } from "@/components/ContextTab"
+import { loadPricingCatalog } from "@/lib/pricing"
+import { computeSessionTotalCost } from "@/lib/session-cost"
 
 export const dynamic = "force-dynamic"
 
@@ -71,7 +73,11 @@ export default async function SessionDetailPage({
     (acc, o) => acc + (o.tokens_input ?? 0) + (o.tokens_output ?? 0),
     0,
   )
-  const totalCost = observations.reduce((acc, o) => acc + (o.cost_usd ?? 0), 0)
+  // Match CostTab's derivation — otherwise the sidebar reads "—" for realtime
+  // voice sessions (the collector rarely fills cost_usd for those spans, but
+  // gen_ai.usage.* + pricing catalog lets us estimate).
+  const pricingCatalog = await loadPricingCatalog()
+  const totalCost = computeSessionTotalCost(observations, pricingCatalog)
   const userId = traces.find((t) => t.user_id)?.user_id ?? null
 
   return (

--- a/tracing-ui/src/components/CostTab.tsx
+++ b/tracing-ui/src/components/CostTab.tsx
@@ -1,5 +1,6 @@
 import type { ObservationRow } from "@/lib/db"
-import { computeCost, loadPricingCatalog } from "@/lib/pricing"
+import { loadPricingCatalog } from "@/lib/pricing"
+import { categorizeObservation, costForObservation } from "@/lib/session-cost"
 import { CostDonut } from "./CostDonut"
 
 const CATEGORY_COLORS: Record<string, string> = {
@@ -29,20 +30,11 @@ export async function CostTab({
 
   let realtimeTurnCount = 0
   for (const o of observations) {
-    const tokensIn = o.tokens_input ?? 0
-    const tokensOut = o.tokens_output ?? 0
-    const cached = o.tokens_cached ?? 0
-    const reported = o.cost_usd ?? 0
-    const bucketName = categorize(o)
-    if (!bucketName) continue
-    if (bucketName === "Realtime") realtimeTurnCount += 1
-    if (tokensIn + tokensOut === 0 && reported === 0) continue
-    const cost =
-      reported > 0
-        ? reported
-        : computeCost(catalog, o.model, { input: tokensIn, output: tokensOut, cached }).total_usd
-    buckets[bucketName].cost_usd += cost
-    buckets[bucketName].tokens += tokensIn + tokensOut
+    if (categorizeObservation(o) === "Realtime") realtimeTurnCount += 1
+    const row = costForObservation(o, catalog)
+    if (!row) continue
+    buckets[row.category].cost_usd += row.cost_usd
+    buckets[row.category].tokens += row.tokens
   }
   const realtimeMissing = realtimeTurnCount > 0 && buckets.Realtime.tokens === 0
 
@@ -134,18 +126,6 @@ function KpiCard({ label, value }: { label: string; value: string }) {
       <div className="text-lg tabular-nums mt-0.5">{value}</div>
     </div>
   )
-}
-
-function categorize(o: ObservationRow): "Realtime" | "Brain" | null {
-  const name = o.name ?? ""
-  if (name === "openclaw.llm") return "Brain"
-  if (name === "voice-turn") return "Realtime"
-  if (name.startsWith("gemini.") || name.startsWith("openai.") || name.startsWith("realtime.")) {
-    return "Realtime"
-  }
-  const model = (o.model ?? "").toLowerCase()
-  if (model.includes("realtime") || model.includes("live-preview")) return "Realtime"
-  return null
 }
 
 function formatDuration(ms: number): string {

--- a/tracing-ui/src/lib/session-cost.ts
+++ b/tracing-ui/src/lib/session-cost.ts
@@ -1,0 +1,63 @@
+// Single source of truth for session-level cost aggregation. Used by CostTab
+// (per-category breakdown) and the session sidebar (total-cost stat). Keeping
+// the logic here avoids the two surfaces disagreeing — the sidebar previously
+// just summed `o.cost_usd`, which the collector rarely populates for realtime
+// voice spans, so the sidebar read "—" while CostTab showed a real number.
+
+import type { ObservationRow } from "./db"
+import { computeCost, type PricingCatalog } from "./pricing"
+
+export type CostCategory = "Realtime" | "Brain"
+
+export function categorizeObservation(o: ObservationRow): CostCategory | null {
+  const name = o.name ?? ""
+  if (name === "openclaw.llm") return "Brain"
+  if (name === "voice-turn") return "Realtime"
+  if (name.startsWith("gemini.") || name.startsWith("openai.") || name.startsWith("realtime.")) {
+    return "Realtime"
+  }
+  const model = (o.model ?? "").toLowerCase()
+  if (model.includes("realtime") || model.includes("live-preview")) return "Realtime"
+  return null
+}
+
+export type CostForObservation = {
+  category: CostCategory
+  cost_usd: number
+  tokens: number
+}
+
+// Returns the same per-observation number CostTab uses: prefer the reported
+// `cost_usd` when the collector filled it in, otherwise estimate from token
+// counts via the shared pricing catalog. Uncategorizable spans return null.
+export function costForObservation(
+  o: ObservationRow,
+  catalog: PricingCatalog,
+): CostForObservation | null {
+  const category = categorizeObservation(o)
+  if (!category) return null
+  const tokensIn = o.tokens_input ?? 0
+  const tokensOut = o.tokens_output ?? 0
+  const cached = o.tokens_cached ?? 0
+  const reported = o.cost_usd ?? 0
+  if (tokensIn + tokensOut === 0 && reported === 0) {
+    return { category, cost_usd: 0, tokens: 0 }
+  }
+  const cost_usd =
+    reported > 0
+      ? reported
+      : computeCost(catalog, o.model, { input: tokensIn, output: tokensOut, cached }).total_usd
+  return { category, cost_usd, tokens: tokensIn + tokensOut }
+}
+
+export function computeSessionTotalCost(
+  observations: ObservationRow[],
+  catalog: PricingCatalog,
+): number {
+  let total = 0
+  for (const o of observations) {
+    const row = costForObservation(o, catalog)
+    if (row) total += row.cost_usd
+  }
+  return total
+}


### PR DESCRIPTION
Post-merge QA sweep after NAN-649..NAN-655. Fixes the one broken thing CI caught and the one inconsistency I caught, plus leaves an end-to-end test + written procedure behind so next time the sweep is faster.

## CI fix — docs deploy

The \"Deploy docs to GitHub Pages\" workflow ran \`cd docs && npm install\`, which walked up to the root \`package.json\`, discovered the desktop workspace with \`vite@^8.0.8\`, and failed on \`electron-vite@5\`'s \`vite ^5||^6||^7\` peer constraint. Switched to \`yarn install --immutable\` + \`yarn build:docs\` at repo root, so each workspace uses its own hoistingLimits (same config that fixed better-sqlite3 ABI conflicts in PR #176) and the conflict doesn't surface.

Failing run: https://github.com/yagudaev/voiceclaw/actions/runs/24870022855

## QA procedure + findings

Added \`docs/src/content/docs/tracing-ui/qa.md\` with the full sweep (stack startup, synthetic drivers, UI tab checklist, cross-surface invariants). Findings from tonight's run:

### Fixed

- **Sidebar Cost vs Cost tab mismatch.** Sidebar summed \`observation.cost_usd\` (rarely populated for realtime voice spans); CostTab derived from \`gen_ai.usage.*\` via the pricing catalog. Extracted \`computeSessionTotalCost\` + \`costForObservation\` into \`tracing-ui/src/lib/session-cost.ts\`; both surfaces now go through it.
- **No end-to-end test for session-media stitch.** \`finalizeSession()\` only fires on disconnect, hard to exercise. Added \`relay-server/test/test-session-media-stitch.ts\` driving 4 fake turns through MediaCapture → finalizeSession, asserting shape of \`session/user.wav\` + \`assistant.wav\` + \`peaks.json\` (normalized 0..1, real signal, ~2000 peaks) + \`thumbnails.json\` (≤20 frames, monotonic \`timeMs\`).

### Verified green

- NAN-650 \`gen_ai.usage.*\` stamping — drives through existing e2e test, attrs land in SQLite, CostTab renders \`\$0.0003\`.
- NAN-651 AttributesTabs — Fields + JSON tabs on Logs expansions; \`gen_ai.usage\` filter reactive.
- NAN-649 MediaTimeline — renders on Transcript + Turns; old pre-stitcher sessions show clean empty states instead of 500s.
- Empty-first-span fix (PR #179) — one \`voice-turn\` row per turn.

### Out of scope (pre-existing, documented as follow-ups)

- Collector's \`cost_usd\` column is still unpopulated for realtime spans; CostTab + sidebar both derive via pricing catalog. Worth a collector-side pass but out of scope for a CI+QA fix.

## Test plan

- [x] \`yarn workspace voiceclaw-tracing-ui tsc --noEmit\`
- [x] \`yarn workspace voiceclaw-tracing-collector tsc --noEmit\`
- [x] \`cd relay-server && yarn tsc --noEmit\`
- [x] \`cd relay-server && npx tsx test/test-session-media-stitch.ts\` → PASS
- [x] Playwright pass on Transcript / Turns / Logs / Cost / Latency tabs
- [x] Verified sidebar Cost == Cost tab total for \`usage-e2e-*\` test session

🤖 Generated with [Claude Code](https://claude.com/claude-code)