### PR TITLE
Add real-time brain mode

### DIFF
--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -35,7 +35,7 @@ export function registerIpcHandlers() {
           (SELECT content FROM messages WHERE conversation_id = c.id ORDER BY created_at ASC LIMIT 1) as preview,
           (SELECT COUNT(*) FROM messages WHERE conversation_id = c.id) as message_count
         FROM conversations c
-        ORDER BY c.updated_at DESC`,
+        ORDER BY c.updated_at DESC`
       )
       .all()
   })
@@ -57,7 +57,7 @@ export function registerIpcHandlers() {
     db.prepare('UPDATE conversations SET title = ?, updated_at = ? WHERE id = ?').run(
       title,
       Date.now(),
-      id,
+      id
     )
   })
 
@@ -76,14 +76,14 @@ export function registerIpcHandlers() {
       conversationId: number,
       role: string,
       content: string,
-      latency?: { sttLatencyMs?: number, llmLatencyMs?: number, ttsLatencyMs?: number },
-      providers?: { sttProvider?: string, llmProvider?: string, ttsProvider?: string },
+      latency?: { sttLatencyMs?: number; llmLatencyMs?: number; ttsLatencyMs?: number },
+      providers?: { sttProvider?: string; llmProvider?: string; ttsProvider?: string }
     ) => {
       const db = getDb()
       const now = Date.now()
       const result = db
         .prepare(
-          'INSERT INTO messages (conversation_id, role, content, created_at, stt_latency_ms, llm_latency_ms, tts_latency_ms, stt_provider, llm_provider, tts_provider) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+          'INSERT INTO messages (conversation_id, role, content, created_at, stt_latency_ms, llm_latency_ms, tts_latency_ms, stt_provider, llm_provider, tts_provider) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
         )
         .run(
           conversationId,
@@ -95,7 +95,7 @@ export function registerIpcHandlers() {
           latency?.ttsLatencyMs ?? null,
           providers?.sttProvider ?? null,
           providers?.llmProvider ?? null,
-          providers?.ttsProvider ?? null,
+          providers?.ttsProvider ?? null
         )
       db.prepare('UPDATE conversations SET updated_at = ? WHERE id = ?').run(now, conversationId)
       return {
@@ -111,7 +111,7 @@ export function registerIpcHandlers() {
         llm_provider: providers?.llmProvider ?? null,
         tts_provider: providers?.ttsProvider ?? null,
       }
-    },
+    }
   )
 
   ipcMain.handle('db:getMessages', (_e, conversationId: number) => {
@@ -133,13 +133,13 @@ export function registerIpcHandlers() {
   ipcMain.handle('db:setSetting', (_e, key: string, value: string) => {
     const db = getDb()
     db.prepare(
-      'INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?',
+      'INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?'
     ).run(key, value, value)
   })
 
   ipcMain.handle('db:getAllSettings', () => {
     const db = getDb()
-    const rows = db.prepare('SELECT * FROM settings').all() as { key: string, value: string }[]
+    const rows = db.prepare('SELECT * FROM settings').all() as { key: string; value: string }[]
     return Object.fromEntries(rows.map((r) => [r.key, r.value]))
   })
 
@@ -172,8 +172,7 @@ function toHealthUrl(url: string): string | null {
     if (parsed.protocol === 'ws:') parsed.protocol = 'http:'
     else if (parsed.protocol === 'wss:') parsed.protocol = 'https:'
     else return null
-    // Strip /ws path and append /health
-    parsed.pathname = parsed.pathname.replace(/\/ws\/?$/, '')
+    parsed.pathname = parsed.pathname.replace(/\/(?:ws|voiceclaw\/realtime)\/?$/, '')
     parsed.pathname = parsed.pathname.replace(/\/$/, '') + '/health'
     return parsed.toString()
   } catch {

--- a/desktop/src/renderer/src/lib/realtime-settings.ts
+++ b/desktop/src/renderer/src/lib/realtime-settings.ts
@@ -1,0 +1,38 @@
+export type RealtimeConnectionMode = 'relay' | 'realtime-brain'
+
+export const RELAY_DEFAULT_SERVER_URL = 'ws://localhost:8080/ws'
+export const REALTIME_BRAIN_DEFAULT_SERVER_URL = 'ws://localhost:19789/voiceclaw/realtime'
+export const LEGACY_REALTIME_SERVER_URL_SETTING = 'realtime_server_url'
+export const REALTIME_CONNECTION_MODE_SETTING = 'realtime_connection_mode'
+
+const SERVER_URL_SETTING_BY_MODE: Record<RealtimeConnectionMode, string> = {
+  relay: 'realtime_server_url_relay',
+  'realtime-brain': 'realtime_server_url_realtime_brain',
+}
+
+export function isRealtimeConnectionMode(value: string | null): value is RealtimeConnectionMode {
+  return value === 'relay' || value === 'realtime-brain'
+}
+
+export function defaultServerUrlForMode(mode: RealtimeConnectionMode): string {
+  return mode === 'realtime-brain' ? REALTIME_BRAIN_DEFAULT_SERVER_URL : RELAY_DEFAULT_SERVER_URL
+}
+
+export function serverUrlSettingKeyForMode(mode: RealtimeConnectionMode): string {
+  return SERVER_URL_SETTING_BY_MODE[mode]
+}
+
+export function resolveServerUrlForMode(
+  mode: RealtimeConnectionMode,
+  savedUrl: string | null
+): string {
+  const trimmed = savedUrl?.trim()
+  if (!trimmed) return defaultServerUrlForMode(mode)
+  if (mode === 'realtime-brain' && trimmed === RELAY_DEFAULT_SERVER_URL) {
+    return REALTIME_BRAIN_DEFAULT_SERVER_URL
+  }
+  if (mode === 'relay' && trimmed === REALTIME_BRAIN_DEFAULT_SERVER_URL) {
+    return RELAY_DEFAULT_SERVER_URL
+  }
+  return trimmed
+}

--- a/desktop/src/renderer/src/lib/use-realtime.ts
+++ b/desktop/src/renderer/src/lib/use-realtime.ts
@@ -3,13 +3,15 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { AudioEngine } from './audio-engine'
+import type { RealtimeConnectionMode } from './realtime-settings'
 
 export interface RealtimeConfig {
+  connectionMode?: RealtimeConnectionMode
   serverUrl: string
   voice: string
   model?: string
   brainAgent: 'enabled' | 'none'
-  apiKey: string
+  apiKey?: string
   sessionKey?: string
   volume?: number
   inputDeviceId?: string
@@ -20,7 +22,7 @@ export interface RealtimeConfig {
     deviceModel?: string
   }
   instructionsOverride?: string
-  conversationHistory?: { role: 'user' | 'assistant', text: string }[]
+  conversationHistory?: { role: 'user' | 'assistant'; text: string }[]
   tracingEnabled?: boolean
 }
 
@@ -72,7 +74,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
     if (!configRef.current?.tracingEnabled) return
     if (wsRef.current?.readyState !== WebSocket.OPEN) return
     wsRef.current.send(
-      JSON.stringify({ type: 'client.timing', phase, ms, turnId: turnId ?? undefined }),
+      JSON.stringify({ type: 'client.timing', phase, ms, turnId: turnId ?? undefined })
     )
   }, [])
 
@@ -160,7 +162,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
           break
       }
     },
-    [sendTiming],
+    [sendTiming]
   )
 
   const start = useCallback(
@@ -208,12 +210,12 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
             voice: config.voice,
             model: config.model,
             brainAgent: config.brainAgent,
-            apiKey: config.apiKey,
+            apiKey: config.apiKey ?? '',
             sessionKey: config.sessionKey,
             deviceContext: config.deviceContext,
             instructionsOverride: config.instructionsOverride,
             conversationHistory: config.conversationHistory,
-          }),
+          })
         )
 
         // Start mic capture — audio data flows to WebSocket
@@ -243,7 +245,9 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
         // Only surface the error on the initial connection attempt.
         // During reconnect, onclose handles retry logic.
         if (!hasConnectedRef.current && reconnectAttemptsRef.current === 0) {
-          callbacksRef.current.onError?.('Could not connect to relay server. Is it running?', 0)
+          const label =
+            config.connectionMode === 'realtime-brain' ? 'OpenClaw real-time brain' : 'relay server'
+          callbacksRef.current.onError?.(`Could not connect to ${label}. Is it running?`, 0)
         }
       }
 
@@ -263,7 +267,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
             reconnectAttemptsRef.current += 1
             setIsReconnecting(true)
             console.log(
-              `[useRealtime] Unexpected disconnect — reconnect attempt ${reconnectAttemptsRef.current}/${MAX_RECONNECT_ATTEMPTS} in ${delay}ms`,
+              `[useRealtime] Unexpected disconnect — reconnect attempt ${reconnectAttemptsRef.current}/${MAX_RECONNECT_ATTEMPTS} in ${delay}ms`
             )
             reconnectTimerRef.current = setTimeout(() => {
               reconnectTimerRef.current = null
@@ -279,7 +283,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
         }
       }
     },
-    [handleMessage],
+    [handleMessage]
   )
 
   const stop = useCallback(() => {

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -9,6 +9,13 @@ import { ScreenCapture, type ScreenSource } from '../lib/screen-capture'
 import { useRealtime, type RealtimeCallbacks } from '../lib/use-realtime'
 import { useConversationContext } from '../lib/conversation-context'
 import {
+  isRealtimeConnectionMode,
+  LEGACY_REALTIME_SERVER_URL_SETTING,
+  REALTIME_CONNECTION_MODE_SETTING,
+  resolveServerUrlForMode,
+  serverUrlSettingKeyForMode,
+} from '../lib/realtime-settings'
+import {
   addMessage,
   createConversation,
   getLatestConversation,
@@ -20,7 +27,16 @@ import {
 
 const DEFAULT_REALTIME_MODEL = 'gemini-3.1-flash-live-preview'
 const REALTIME_MODELS = ['gemini-3.1-flash-live-preview', 'grok-voice-think-fast-1.0'] as const
-const GEMINI_VOICES = ['Puck', 'Charon', 'Kore', 'Fenrir', 'Aoede', 'Leda', 'Orus', 'Zephyr'] as const
+const GEMINI_VOICES = [
+  'Puck',
+  'Charon',
+  'Kore',
+  'Fenrir',
+  'Aoede',
+  'Leda',
+  'Orus',
+  'Zephyr',
+] as const
 const XAI_VOICES = ['eve', 'ara', 'rex', 'sal', 'leo'] as const
 
 export function ChatPage() {
@@ -168,7 +184,7 @@ export function ChatPage() {
       setStreamingText('')
     },
     onError: (message) => {
-      console.error('[ChatPage] Relay error:', message)
+      console.error('[ChatPage] Realtime error:', message)
       setConnectionError(message)
       setIsConnecting(false)
       setIsCallActive(false)
@@ -183,7 +199,12 @@ export function ChatPage() {
   const startCall = useCallback(async () => {
     setConnectionError('')
     setIsConnecting(true)
-    const serverUrl = (await getSetting('realtime_server_url')) || 'ws://localhost:8080/ws'
+    const savedMode = await getSetting(REALTIME_CONNECTION_MODE_SETTING)
+    const connectionMode = isRealtimeConnectionMode(savedMode) ? savedMode : 'relay'
+    const savedUrl = await getSetting(serverUrlSettingKeyForMode(connectionMode))
+    const legacyUrl =
+      connectionMode === 'relay' ? await getSetting(LEGACY_REALTIME_SERVER_URL_SETTING) : null
+    const serverUrl = resolveServerUrlForMode(connectionMode, savedUrl || legacyUrl)
     const model = normalizeRealtimeModel(await getSetting('realtime_model'))
     const voice = normalizeRealtimeVoice(model, await getSetting('realtime_voice'))
     const apiKey = (await getSetting('realtime_api_key')) || ''
@@ -194,6 +215,7 @@ export function ChatPage() {
 
     setActiveRealtimeModel(model)
     realtime.start({
+      connectionMode,
       serverUrl,
       voice,
       model,
@@ -235,23 +257,26 @@ export function ChatPage() {
     titleGeneratedRef.current = false
   }, [isCallActive, endCall])
 
-  const startScreenShare = useCallback(async (source: ScreenSource) => {
-    if (activeRealtimeModel.startsWith('grok-voice-')) return
-    setShowScreenPicker(false)
-    const capture = new ScreenCapture()
-    capture.setSourceName(source.name)
-    screenCaptureRef.current = capture
-    try {
-      await capture.start(source.id, (base64Jpeg) => {
-        realtime.sendFrame(base64Jpeg)
-      })
-      setIsScreenSharing(true)
-      setScreenSourceName(source.name)
-    } catch (err) {
-      console.error('[ChatPage] Screen capture failed:', err)
-      screenCaptureRef.current = null
-    }
-  }, [activeRealtimeModel, realtime])
+  const startScreenShare = useCallback(
+    async (source: ScreenSource) => {
+      if (activeRealtimeModel.startsWith('grok-voice-')) return
+      setShowScreenPicker(false)
+      const capture = new ScreenCapture()
+      capture.setSourceName(source.name)
+      screenCaptureRef.current = capture
+      try {
+        await capture.start(source.id, (base64Jpeg) => {
+          realtime.sendFrame(base64Jpeg)
+        })
+        setIsScreenSharing(true)
+        setScreenSourceName(source.name)
+      } catch (err) {
+        console.error('[ChatPage] Screen capture failed:', err)
+        screenCaptureRef.current = null
+      }
+    },
+    [activeRealtimeModel, realtime]
+  )
 
   const stopScreenShare = useCallback(() => {
     screenCaptureRef.current?.stop()
@@ -267,7 +292,8 @@ export function ChatPage() {
     }
   }, [isCallActive, isScreenSharing, stopScreenShare])
 
-  const screenShareDisabled = isConnecting || (!isScreenSharing && activeRealtimeModel.startsWith('grok-voice-'))
+  const screenShareDisabled =
+    isConnecting || (!isScreenSharing && activeRealtimeModel.startsWith('grok-voice-'))
   const screenShareTitle = isScreenSharing
     ? 'Stop screen sharing'
     : activeRealtimeModel.startsWith('grok-voice-')
@@ -304,13 +330,11 @@ export function ChatPage() {
   }, [isCallActive, newConversation, toggleMute, endCall])
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
+    <div className="flex flex-1 flex-col overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-border">
+      <div className="flex items-center justify-between border-b border-border px-4 py-2">
         <div className="text-sm text-muted-foreground">
-          {messages.length > 0
-            ? `${messages.length} messages`
-            : 'Start a conversation'}
+          {messages.length > 0 ? `${messages.length} messages` : 'Start a conversation'}
         </div>
         <Button variant="ghost" size="sm" onClick={newConversation}>
           <Plus size={16} className="mr-1" />
@@ -321,10 +345,10 @@ export function ChatPage() {
       {/* Messages */}
       <div className="flex-1 overflow-y-auto px-4 py-4">
         {messages.length === 0 && !isCallActive && (
-          <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
-            <div className="text-4xl mb-4">🎙</div>
+          <div className="flex h-full flex-col items-center justify-center text-muted-foreground">
+            <div className="mb-4 text-4xl">🎙</div>
             <p className="text-lg font-medium">VoiceClaw Desktop</p>
-            <p className="text-sm mt-1">Press the call button to start a voice conversation</p>
+            <p className="mt-1 text-sm">Press the call button to start a voice conversation</p>
           </div>
         )}
         {messages.map((msg) => (
@@ -332,25 +356,23 @@ export function ChatPage() {
         ))}
         {/* Streaming text */}
         {streamingText && (
-          <div className={`flex ${streamingRole === 'user' ? 'justify-end' : 'justify-start'} mb-3`}>
+          <div
+            className={`flex ${streamingRole === 'user' ? 'justify-end' : 'justify-start'} mb-3`}>
             <div
-              className={`
-                max-w-[80%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed
-                ${streamingRole === 'user'
-                  ? 'bg-primary text-primary-foreground rounded-br-md'
-                  : 'bg-muted text-foreground rounded-bl-md'
-                }
-              `}
-            >
+              className={`max-w-[80%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
+                streamingRole === 'user'
+                  ? 'rounded-br-md bg-primary text-primary-foreground'
+                  : 'rounded-bl-md bg-muted text-foreground'
+              } `}>
               <span className="whitespace-pre-wrap">{streamingText}</span>
-              <span className="inline-block w-0.5 h-4 bg-current animate-pulse ml-0.5 align-middle" />
+              <span className="ml-0.5 inline-block h-4 w-0.5 animate-pulse bg-current align-middle" />
             </div>
           </div>
         )}
         {/* Thinking indicator */}
         {isThinking && !streamingText && (
-          <div className="flex justify-start mb-3">
-            <div className="bg-muted rounded-2xl rounded-bl-md px-4 py-2.5">
+          <div className="mb-3 flex justify-start">
+            <div className="rounded-2xl rounded-bl-md bg-muted px-4 py-2.5">
               <ThinkingDots />
             </div>
           </div>
@@ -360,13 +382,12 @@ export function ChatPage() {
 
       {/* Screen sharing indicator */}
       {isScreenSharing && (
-        <div className="px-4 py-1.5 flex items-center gap-2 text-xs text-green-500">
+        <div className="flex items-center gap-2 px-4 py-1.5 text-xs text-green-500">
           <Monitor size={14} />
           <span className="truncate">Sharing: {screenSourceName}</span>
           <button
             onClick={stopScreenShare}
-            className="ml-auto text-muted-foreground hover:text-destructive transition-colors"
-          >
+            className="ml-auto text-muted-foreground transition-colors hover:text-destructive">
             Stop
           </button>
         </div>
@@ -381,18 +402,15 @@ export function ChatPage() {
 
       {/* Connection error */}
       {connectionError && (
-        <div className="mx-4 mt-2 px-3 py-2 rounded-md bg-destructive/10 text-destructive text-sm text-center">
+        <div className="bg-destructive/10 mx-4 mt-2 rounded-md px-3 py-2 text-center text-sm text-destructive">
           {connectionError}
         </div>
       )}
 
       {/* Call controls */}
-      <div className="px-4 py-3 border-t border-border flex items-center justify-center gap-3">
+      <div className="flex items-center justify-center gap-3 border-t border-border px-4 py-3">
         {!isCallActive && !isConnecting ? (
-          <Button
-            onClick={startCall}
-            className="bg-green-500 hover:bg-green-600 text-white px-6"
-          >
+          <Button onClick={startCall} className="bg-green-500 px-6 text-white hover:bg-green-600">
             <Phone size={18} className="mr-2" />
             Start Call
           </Button>
@@ -402,8 +420,7 @@ export function ChatPage() {
               variant="ghost"
               size="icon"
               onClick={toggleMute}
-              className={isMuted ? 'text-destructive' : 'text-foreground'}
-            >
+              className={isMuted ? 'text-destructive' : 'text-foreground'}>
               {isMuted ? <MicOff size={20} /> : <Mic size={20} />}
             </Button>
             <span title={screenShareTitle} className="inline-flex">
@@ -411,25 +428,25 @@ export function ChatPage() {
                 variant="ghost"
                 size="icon"
                 onClick={isScreenSharing ? stopScreenShare : () => setShowScreenPicker(true)}
-                className={isScreenSharing ? 'text-green-500' : screenShareDisabled ? 'text-muted-foreground opacity-50' : 'text-foreground'}
-                disabled={screenShareDisabled}
-              >
+                className={
+                  isScreenSharing
+                    ? 'text-green-500'
+                    : screenShareDisabled
+                      ? 'text-muted-foreground opacity-50'
+                      : 'text-foreground'
+                }
+                disabled={screenShareDisabled}>
                 {isScreenSharing ? <MonitorOff size={20} /> : <Monitor size={20} />}
               </Button>
             </span>
-            <Button
-              variant="destructive"
-              size="icon"
-              onClick={endCall}
-              disabled={isConnecting}
-            >
+            <Button variant="destructive" size="icon" onClick={endCall} disabled={isConnecting}>
               <PhoneOff size={20} />
             </Button>
             {isConnecting && (
-              <span className="text-sm text-muted-foreground animate-pulse">Connecting...</span>
+              <span className="animate-pulse text-sm text-muted-foreground">Connecting...</span>
             )}
             {realtime.isReconnecting && (
-              <span className="text-sm text-yellow-500 animate-pulse">Reconnecting...</span>
+              <span className="animate-pulse text-sm text-yellow-500">Reconnecting...</span>
             )}
           </>
         )}
@@ -460,13 +477,16 @@ function generateTitle(text: string): string {
   return title.trim() + '...'
 }
 
-function normalizeRealtimeModel(model: string | null): typeof REALTIME_MODELS[number] {
+function normalizeRealtimeModel(model: string | null): (typeof REALTIME_MODELS)[number] {
   return (REALTIME_MODELS as readonly string[]).includes(model ?? '')
-    ? model as typeof REALTIME_MODELS[number]
+    ? (model as (typeof REALTIME_MODELS)[number])
     : DEFAULT_REALTIME_MODEL
 }
 
-function normalizeRealtimeVoice(model: typeof REALTIME_MODELS[number], voice: string | null): string {
+function normalizeRealtimeVoice(
+  model: (typeof REALTIME_MODELS)[number],
+  voice: string | null
+): string {
   if (model.startsWith('grok-voice-')) {
     return voice && (XAI_VOICES as readonly string[]).includes(voice) ? voice : 'eve'
   }

--- a/desktop/src/renderer/src/pages/SettingsPage.tsx
+++ b/desktop/src/renderer/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Wifi, WifiOff, Eye, EyeOff } from 'lucide-react'
+import { Wifi, WifiOff, Eye, EyeOff, Network, BrainCircuit } from 'lucide-react'
 import { Button } from '../components/ui/Button'
 import { Card } from '../components/ui/Card'
 import { Input } from '../components/ui/Input'
@@ -8,9 +8,27 @@ import { Toggle } from '../components/ui/Toggle'
 import { useTheme, type Theme } from '../lib/use-theme'
 import { enumerateAudioDevices, type AudioDevice } from '../lib/audio-engine'
 import { getSetting, setSetting } from '../lib/db'
+import {
+  defaultServerUrlForMode,
+  isRealtimeConnectionMode,
+  LEGACY_REALTIME_SERVER_URL_SETTING,
+  REALTIME_CONNECTION_MODE_SETTING,
+  resolveServerUrlForMode,
+  serverUrlSettingKeyForMode,
+  type RealtimeConnectionMode,
+} from '../lib/realtime-settings'
 
-const GEMINI_VOICES = ['Puck', 'Charon', 'Kore', 'Fenrir', 'Aoede', 'Leda', 'Orus', 'Zephyr'] as const
-const GEMINI_VOICE_LABELS: Record<typeof GEMINI_VOICES[number], string> = {
+const GEMINI_VOICES = [
+  'Puck',
+  'Charon',
+  'Kore',
+  'Fenrir',
+  'Aoede',
+  'Leda',
+  'Orus',
+  'Zephyr',
+] as const
+const GEMINI_VOICE_LABELS: Record<(typeof GEMINI_VOICES)[number], string> = {
   Puck: 'Puck (M)',
   Charon: 'Charon (M)',
   Kore: 'Kore (F)',
@@ -22,7 +40,7 @@ const GEMINI_VOICE_LABELS: Record<typeof GEMINI_VOICES[number], string> = {
 }
 
 const XAI_VOICES = ['eve', 'ara', 'rex', 'sal', 'leo'] as const
-const XAI_VOICE_LABELS: Record<typeof XAI_VOICES[number], string> = {
+const XAI_VOICE_LABELS: Record<(typeof XAI_VOICES)[number], string> = {
   eve: 'Eve (F)',
   ara: 'Ara (F)',
   rex: 'Rex (M)',
@@ -37,7 +55,8 @@ export function SettingsPage() {
   const { theme, setTheme } = useTheme()
 
   // Connection
-  const [serverUrl, setServerUrl] = useState('ws://localhost:8080/ws')
+  const [connectionMode, setConnectionMode] = useState<RealtimeConnectionMode>('relay')
+  const [serverUrl, setServerUrl] = useState(defaultServerUrlForMode('relay'))
   const [apiKey, setApiKey] = useState('')
   const [showApiKey, setShowApiKey] = useState(false)
   const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'ok' | 'error'>('idle')
@@ -63,8 +82,11 @@ export function SettingsPage() {
   // Load all settings on mount
   useEffect(() => {
     ;(async () => {
-      const url = await getSetting('realtime_server_url')
-      if (url) setServerUrl(url)
+      const mode = await getSetting(REALTIME_CONNECTION_MODE_SETTING)
+      const nextMode = isRealtimeConnectionMode(mode) ? mode : 'relay'
+      setConnectionMode(nextMode)
+      const url = await loadServerUrlForMode(nextMode)
+      setServerUrl(url)
       const key = await getSetting('realtime_api_key')
       if (key) setApiKey(key)
       const m = await getSetting('realtime_model')
@@ -99,52 +121,90 @@ export function SettingsPage() {
     setSetting(key, value)
   }, [])
 
-  const updateServerUrl = useCallback((v: string) => {
-    setServerUrl(v)
-    if (loadedRef.current) save('realtime_server_url', v)
-  }, [save])
+  const updateServerUrl = useCallback(
+    (v: string) => {
+      setServerUrl(v)
+      setTestStatus('idle')
+      if (loadedRef.current) {
+        save(serverUrlSettingKeyForMode(connectionMode), v)
+        if (connectionMode === 'relay') save(LEGACY_REALTIME_SERVER_URL_SETTING, v)
+      }
+    },
+    [connectionMode, save]
+  )
 
-  const updateApiKey = useCallback((v: string) => {
-    setApiKey(v)
-    if (loadedRef.current) save('realtime_api_key', v)
-  }, [save])
+  const updateApiKey = useCallback(
+    (v: string) => {
+      setApiKey(v)
+      setTestStatus('idle')
+      if (loadedRef.current) save('realtime_api_key', v)
+    },
+    [save]
+  )
 
-  const updateModel = useCallback((v: RealtimeModel) => {
-    setModel(v)
-    if (loadedRef.current) save('realtime_model', v)
-    // Reset voice when switching providers
-    const isGemini = v.startsWith('gemini-')
-    const currentIsGemini = (GEMINI_VOICES as readonly string[]).includes(voice)
-    const isXAI = v.startsWith('grok-voice-')
-    const currentIsXAI = (XAI_VOICES as readonly string[]).includes(voice)
-    if (isGemini && !currentIsGemini) {
-      setVoice('Zephyr')
-      save('realtime_voice', 'Zephyr')
-    } else if (isXAI && !currentIsXAI) {
-      setVoice('eve')
-      save('realtime_voice', 'eve')
-    }
-  }, [save, voice])
+  const updateModel = useCallback(
+    (v: RealtimeModel) => {
+      setModel(v)
+      if (loadedRef.current) save('realtime_model', v)
+      // Reset voice when switching providers
+      const isGemini = v.startsWith('gemini-')
+      const currentIsGemini = (GEMINI_VOICES as readonly string[]).includes(voice)
+      const isXAI = v.startsWith('grok-voice-')
+      const currentIsXAI = (XAI_VOICES as readonly string[]).includes(voice)
+      if (isGemini && !currentIsGemini) {
+        setVoice('Zephyr')
+        save('realtime_voice', 'Zephyr')
+      } else if (isXAI && !currentIsXAI) {
+        setVoice('eve')
+        save('realtime_voice', 'eve')
+      }
+    },
+    [save, voice]
+  )
 
-  const updateVoice = useCallback((v: string) => {
-    setVoice(v)
-    if (loadedRef.current) save('realtime_voice', v)
-  }, [save])
+  const updateConnectionMode = useCallback(
+    async (v: RealtimeConnectionMode) => {
+      setConnectionMode(v)
+      setTestStatus('idle')
+      if (loadedRef.current) save(REALTIME_CONNECTION_MODE_SETTING, v)
 
-  const updateVolume = useCallback((v: number) => {
-    setVolume(v)
-    if (loadedRef.current) save('realtime_volume', String(v))
-  }, [save])
+      const nextUrl = await loadServerUrlForMode(v)
+      setServerUrl(nextUrl)
+    },
+    [save]
+  )
 
-  const updateInputDevice = useCallback((v: string) => {
-    setInputDeviceId(v)
-    if (loadedRef.current) save('input_device_id', v)
-  }, [save])
+  const updateVoice = useCallback(
+    (v: string) => {
+      setVoice(v)
+      if (loadedRef.current) save('realtime_voice', v)
+    },
+    [save]
+  )
 
-  const updateOutputDevice = useCallback((v: string) => {
-    setOutputDeviceId(v)
-    if (loadedRef.current) save('output_device_id', v)
-  }, [save])
+  const updateVolume = useCallback(
+    (v: number) => {
+      setVolume(v)
+      if (loadedRef.current) save('realtime_volume', String(v))
+    },
+    [save]
+  )
+
+  const updateInputDevice = useCallback(
+    (v: string) => {
+      setInputDeviceId(v)
+      if (loadedRef.current) save('input_device_id', v)
+    },
+    [save]
+  )
+
+  const updateOutputDevice = useCallback(
+    (v: string) => {
+      setOutputDeviceId(v)
+      if (loadedRef.current) save('output_device_id', v)
+    },
+    [save]
+  )
 
   const toggleDebugMode = useCallback((v: boolean) => {
     setDebugMode(v)
@@ -181,54 +241,72 @@ export function SettingsPage() {
 
   const inputDevices = audioDevices.filter((d) => d.kind === 'audioinput')
   const outputDevices = audioDevices.filter((d) => d.kind === 'audiooutput')
+  const isRealtimeBrainMode = connectionMode === 'realtime-brain'
+  const serverUrlLabel = isRealtimeBrainMode ? 'OpenClaw Realtime URL' : 'Relay Server URL'
+  const serverUrlPlaceholder = defaultServerUrlForMode(connectionMode)
+  const apiKeyLabel = isRealtimeBrainMode ? 'OpenClaw Gateway Token' : 'API Key'
+  const apiKeyPlaceholder = isRealtimeBrainMode
+    ? 'Enter gateway token or password'
+    : 'Enter your API key'
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
-      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
-
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <div className="flex-1 space-y-4 overflow-y-auto px-4 py-4">
         {/* Connection */}
-        <Card className="p-4 space-y-4">
+        <Card className="space-y-4 p-4">
           <h3 className="text-sm font-semibold text-foreground">Connection</h3>
 
+          <div className="grid grid-cols-2 gap-1 rounded-lg bg-muted p-1">
+            {(
+              [
+                { value: 'relay', label: 'Relay', icon: Network },
+                { value: 'realtime-brain', label: 'Real-time brain', icon: BrainCircuit },
+              ] as const
+            ).map(({ value, label, icon: Icon }) => (
+              <button
+                key={value}
+                onClick={() => void updateConnectionMode(value)}
+                className={`flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${connectionMode === value ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'} `}>
+                <Icon size={15} />
+                <span>{label}</span>
+              </button>
+            ))}
+          </div>
+
           <div className="space-y-1.5">
-            <label className="text-xs text-muted-foreground">Relay Server URL</label>
+            <label className="text-xs text-muted-foreground">{serverUrlLabel}</label>
             <Input
               value={serverUrl}
               onChange={(e) => updateServerUrl(e.target.value)}
-              placeholder="ws://localhost:8080/ws"
+              placeholder={serverUrlPlaceholder}
             />
           </div>
 
           <div className="space-y-1.5">
-            <label className="text-xs text-muted-foreground">API Key</label>
+            <label className="text-xs text-muted-foreground">{apiKeyLabel}</label>
             <div className="flex gap-2">
-              <div className="flex-1 relative">
+              <div className="relative flex-1">
                 <Input
                   type={showApiKey ? 'text' : 'password'}
                   value={apiKey}
                   onChange={(e) => updateApiKey(e.target.value)}
-                  placeholder="Enter your API key"
+                  placeholder={apiKeyPlaceholder}
                   className="pr-10"
                 />
                 <button
                   onClick={() => setShowApiKey(!showApiKey)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                >
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground">
                   {showApiKey ? <EyeOff size={16} /> : <Eye size={16} />}
                 </button>
               </div>
             </div>
           </div>
 
-          <ConnectionStatus
-            status={testStatus}
-            error={testError}
-            onTest={testConnection}
-          />
+          <ConnectionStatus status={testStatus} error={testError} onTest={testConnection} />
         </Card>
 
         {/* Model */}
-        <Card className="p-4 space-y-4">
+        <Card className="space-y-4 p-4">
           <h3 className="text-sm font-semibold text-foreground">Model</h3>
           <div className="space-y-1.5">
             {(['gemini-3.1-flash-live-preview', 'grok-voice-think-fast-1.0'] as const).map((m) => {
@@ -236,18 +314,16 @@ export function SettingsPage() {
                 <button
                   key={m}
                   onClick={() => updateModel(m)}
-                  className={`w-full flex items-center gap-3 rounded-lg border px-3 py-2 text-left transition-colors
-                    ${model === m ? 'border-primary bg-primary/10' : 'border-input'}
-                    hover:bg-accent cursor-pointer
-                  `}
-                >
-                  <div className={`h-3.5 w-3.5 rounded-full border-2 flex items-center justify-center
-                    ${model === m ? 'border-primary' : 'border-muted-foreground'}
-                  `}>
+                  className={`flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-left transition-colors ${model === m ? 'bg-primary/10 border-primary' : 'border-input'} cursor-pointer hover:bg-accent`}>
+                  <div
+                    className={`flex h-3.5 w-3.5 items-center justify-center rounded-full border-2 ${model === m ? 'border-primary' : 'border-muted-foreground'} `}>
                     {model === m && <div className="h-1.5 w-1.5 rounded-full bg-primary" />}
                   </div>
-                  <span className={`text-sm ${model === m ? 'font-medium text-foreground' : 'text-muted-foreground'}`}>
-                    {m === 'gemini-3.1-flash-live-preview' ? 'Gemini 3.1 Flash Live' : 'Grok Voice Think Fast 1.0'}
+                  <span
+                    className={`text-sm ${model === m ? 'font-medium text-foreground' : 'text-muted-foreground'}`}>
+                    {m === 'gemini-3.1-flash-live-preview'
+                      ? 'Gemini 3.1 Flash Live'
+                      : 'Grok Voice Think Fast 1.0'}
                   </span>
                 </button>
               )
@@ -256,57 +332,54 @@ export function SettingsPage() {
         </Card>
 
         {/* Voice */}
-        <Card className="p-4 space-y-4">
+        <Card className="space-y-4 p-4">
           <h3 className="text-sm font-semibold text-foreground">Voice</h3>
           <div className="grid grid-cols-2 gap-1.5">
             {(model.startsWith('gemini-') ? GEMINI_VOICES : XAI_VOICES).map((v) => (
               <button
                 key={v}
                 onClick={() => updateVoice(v)}
-                className={`rounded-lg border px-3 py-2 text-sm text-left transition-colors
-                  ${voice === v ? 'border-primary bg-primary/10 font-medium text-foreground' : 'border-input text-muted-foreground hover:bg-accent'}
-                `}
-              >
+                className={`rounded-lg border px-3 py-2 text-left text-sm transition-colors ${voice === v ? 'bg-primary/10 border-primary font-medium text-foreground' : 'border-input text-muted-foreground hover:bg-accent'} `}>
                 {model.startsWith('gemini-')
-                  ? GEMINI_VOICE_LABELS[v as typeof GEMINI_VOICES[number]]
-                  : XAI_VOICE_LABELS[v as typeof XAI_VOICES[number]]}
+                  ? GEMINI_VOICE_LABELS[v as (typeof GEMINI_VOICES)[number]]
+                  : XAI_VOICE_LABELS[v as (typeof XAI_VOICES)[number]]}
               </button>
             ))}
           </div>
         </Card>
 
         {/* Audio Devices */}
-        <Card className="p-4 space-y-4">
+        <Card className="space-y-4 p-4">
           <h3 className="text-sm font-semibold text-foreground">Audio Devices</h3>
 
           <div className="space-y-1.5">
             <label className="text-xs text-muted-foreground">Input (Microphone)</label>
-            <Select
-              value={inputDeviceId}
-              onChange={(e) => updateInputDevice(e.target.value)}
-            >
+            <Select value={inputDeviceId} onChange={(e) => updateInputDevice(e.target.value)}>
               <option value="">System Default</option>
               {inputDevices.map((d) => (
-                <option key={d.deviceId} value={d.deviceId}>{d.label}</option>
+                <option key={d.deviceId} value={d.deviceId}>
+                  {d.label}
+                </option>
               ))}
             </Select>
           </div>
 
           <div className="space-y-1.5">
             <label className="text-xs text-muted-foreground">Output (Speaker)</label>
-            <Select
-              value={outputDeviceId}
-              onChange={(e) => updateOutputDevice(e.target.value)}
-            >
+            <Select value={outputDeviceId} onChange={(e) => updateOutputDevice(e.target.value)}>
               <option value="">System Default</option>
               {outputDevices.map((d) => (
-                <option key={d.deviceId} value={d.deviceId}>{d.label}</option>
+                <option key={d.deviceId} value={d.deviceId}>
+                  {d.label}
+                </option>
               ))}
             </Select>
           </div>
 
           <div className="space-y-1.5">
-            <label className="text-xs text-muted-foreground">Speaker Volume: {volume.toFixed(1)}x</label>
+            <label className="text-xs text-muted-foreground">
+              Speaker Volume: {volume.toFixed(1)}x
+            </label>
             <input
               type="range"
               min={0.5}
@@ -325,24 +398,20 @@ export function SettingsPage() {
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => enumerateAudioDevices().then(setAudioDevices)}
-          >
+            onClick={() => enumerateAudioDevices().then(setAudioDevices)}>
             Refresh Devices
           </Button>
         </Card>
 
         {/* Appearance */}
-        <Card className="p-4 space-y-4">
+        <Card className="space-y-4 p-4">
           <h3 className="text-sm font-semibold text-foreground">Appearance</h3>
           <div className="flex gap-2">
             {(['dark', 'light', 'system'] as Theme[]).map((t) => (
               <button
                 key={t}
                 onClick={() => setTheme(t)}
-                className={`flex-1 rounded-lg border px-3 py-2 text-sm capitalize transition-colors
-                  ${theme === t ? 'border-primary bg-primary/10 font-medium text-foreground' : 'border-input text-muted-foreground hover:bg-accent'}
-                `}
-              >
+                className={`flex-1 rounded-lg border px-3 py-2 text-sm capitalize transition-colors ${theme === t ? 'bg-primary/10 border-primary font-medium text-foreground' : 'border-input text-muted-foreground hover:bg-accent'} `}>
                 {t}
               </button>
             ))}
@@ -350,7 +419,7 @@ export function SettingsPage() {
         </Card>
 
         {/* Debug */}
-        <Card className="p-4 space-y-4">
+        <Card className="space-y-4 p-4">
           <h3 className="text-sm font-semibold text-foreground">Debug</h3>
 
           <div className="flex items-center justify-between">
@@ -364,7 +433,9 @@ export function SettingsPage() {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-foreground">Show Latency</p>
-              <p className="text-xs text-muted-foreground">Display latency badges on chat messages</p>
+              <p className="text-xs text-muted-foreground">
+                Display latency badges on chat messages
+              </p>
             </div>
             <Toggle checked={showLatency} onChange={toggleShowLatency} />
           </div>
@@ -372,23 +443,41 @@ export function SettingsPage() {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-foreground">Send Traces</p>
-              <p className="text-xs text-muted-foreground">Post per-turn latency to Langfuse via relay</p>
+              <p className="text-xs text-muted-foreground">
+                Post per-turn latency to Langfuse via the active realtime server
+              </p>
             </div>
             <Toggle checked={tracingEnabled} onChange={toggleTracing} />
           </div>
         </Card>
 
         {/* Setup Instructions */}
-        <Card className="p-4 space-y-2 text-xs text-muted-foreground">
+        <Card className="space-y-2 p-4 text-xs text-muted-foreground">
           <p className="font-medium">Setup</p>
-          <ol className="list-decimal list-inside space-y-0.5">
-            <li>Start the relay server: <code className="bg-muted px-1 py-0.5 rounded">cd relay-server && yarn dev</code></li>
-            <li>Enter the relay server URL shown on startup</li>
-            <li>Enter your API key for authentication</li>
-            <li>Click Test to verify the connection</li>
-          </ol>
+          {isRealtimeBrainMode ? (
+            <ol className="list-inside list-decimal space-y-0.5">
+              <li>Start OpenClaw from the realtime brain worktree on port 19789</li>
+              <li>
+                Set the URL to{' '}
+                <code className="rounded bg-muted px-1 py-0.5">
+                  ws://localhost:19789/voiceclaw/realtime
+                </code>
+              </li>
+              <li>Enter the OpenClaw gateway token or password if gateway auth is enabled</li>
+              <li>Click Test to verify the connection</li>
+            </ol>
+          ) : (
+            <ol className="list-inside list-decimal space-y-0.5">
+              <li>
+                Start the relay server:{' '}
+                <code className="rounded bg-muted px-1 py-0.5">cd relay-server && yarn dev</code>
+              </li>
+              <li>Enter the relay server URL shown on startup</li>
+              <li>Enter your API key for authentication</li>
+              <li>Click Test to verify the connection</li>
+            </ol>
+          )}
         </Card>
-
       </div>
     </div>
   )
@@ -412,6 +501,12 @@ function normalizeRealtimeVoice(model: RealtimeModel, voice: string | null): str
 
 // --- Helper Components ---
 
+async function loadServerUrlForMode(mode: RealtimeConnectionMode): Promise<string> {
+  const modeUrl = await getSetting(serverUrlSettingKeyForMode(mode))
+  const legacyUrl = mode === 'relay' ? await getSetting(LEGACY_REALTIME_SERVER_URL_SETTING) : null
+  return resolveServerUrlForMode(mode, modeUrl || legacyUrl)
+}
+
 function ConnectionStatus({
   status,
   error,
@@ -422,36 +517,43 @@ function ConnectionStatus({
   onTest: () => void
 }) {
   return (
-    <div className={`flex items-center justify-between rounded-lg border px-3 py-2
-      ${status === 'ok' ? 'border-green-500/30 bg-green-500/5'
-        : status === 'error' ? 'border-destructive/50 bg-destructive/5'
-        : 'border-input'}
-    `}>
+    <div
+      className={`flex items-center justify-between rounded-lg border px-3 py-2 ${
+        status === 'ok'
+          ? 'border-green-500/30 bg-green-500/5'
+          : status === 'error'
+            ? 'border-destructive/50 bg-destructive/5'
+            : 'border-input'
+      } `}>
       <div className="flex items-center gap-2">
         {status === 'testing' ? (
-          <div className="h-4 w-4 border-2 border-muted-foreground border-t-transparent rounded-full animate-spin" />
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
         ) : status === 'ok' ? (
           <Wifi size={16} className="text-green-500" />
         ) : (
-          <WifiOff size={16} className={status === 'error' ? 'text-destructive' : 'text-muted-foreground'} />
+          <WifiOff
+            size={16}
+            className={status === 'error' ? 'text-destructive' : 'text-muted-foreground'}
+          />
         )}
-        <span className={`text-sm ${
-          status === 'ok' ? 'text-green-500'
-          : status === 'error' ? 'text-destructive'
-          : 'text-muted-foreground'
-        }`}>
-          {status === 'ok' ? 'Connected'
-          : status === 'testing' ? 'Testing...'
-          : status === 'error' ? error
-          : 'Not tested'}
+        <span
+          className={`text-sm ${
+            status === 'ok'
+              ? 'text-green-500'
+              : status === 'error'
+                ? 'text-destructive'
+                : 'text-muted-foreground'
+          }`}>
+          {status === 'ok'
+            ? 'Connected'
+            : status === 'testing'
+              ? 'Testing...'
+              : status === 'error'
+                ? error
+                : 'Not tested'}
         </span>
       </div>
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={onTest}
-        disabled={status === 'testing'}
-      >
+      <Button variant="ghost" size="sm" onClick={onTest} disabled={status === 'testing'}>
         Test
       </Button>
     </div>


### PR DESCRIPTION
## Summary
- Add Relay and Real-time brain connection modes in desktop settings with separate persisted URLs.
- Wire chat startup through the selected mode and pass the matching OpenClaw realtime endpoint configuration.
- Update health-check URL derivation for both relay `/ws` and OpenClaw `/voiceclaw/realtime` endpoints.

## Test plan
- [x] `yarn workspace voiceclaw-desktop typecheck`
- [x] `yarn workspace voiceclaw-desktop build`
- [x] Claude Code review via `cc`; addressed blocking findings

Linear: NAN-656
