### PR TITLE
Avoid logging provider key env names

### DIFF
--- a/relay-server/src/adapters/openai.ts
+++ b/relay-server/src/adapters/openai.ts
@@ -158,7 +158,7 @@ export class OpenAIAdapter implements ProviderAdapter {
 
   private async openUpstream(config: SessionConfigEvent): Promise<void> {
     const apiKey = process.env[this.apiKeyEnv]
-    if (!apiKey) throw new Error(`${this.apiKeyEnv} not set`)
+    if (!apiKey) throw new Error(`${this.providerName} API key not configured`)
 
     this.resetResponseState()
 
@@ -262,7 +262,7 @@ export class OpenAIAdapter implements ProviderAdapter {
 
   private async openUpstreamWithSummary(config: SessionConfigEvent, summary: string): Promise<void> {
     const apiKey = process.env[this.apiKeyEnv]
-    if (!apiKey) throw new Error(`${this.apiKeyEnv} not set`)
+    if (!apiKey) throw new Error(`${this.providerName} API key not configured`)
 
     this.resetResponseState()
 


### PR DESCRIPTION
## Summary
- Replace missing-provider-key errors that included env var names with generic provider API key configuration errors
- Addresses the CodeQL clear-text sensitive information alert from PR #181

## Test plan
- [x] `yarn workspace relay-server build`