### PR TITLE
Add Privacy Policy, Terms of Service, and /legal pages

### DIFF
--- a/website/src/app/legal/page.tsx
+++ b/website/src/app/legal/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import Link from "next/link"
 import { LegalPage } from "@/components/legal/LegalPage"
 
 export const metadata: Metadata = {
@@ -15,11 +16,11 @@ export default function LegalIndexPage() {
     >
       <ul>
         <li>
-          <a href="/privacy">Privacy Policy</a> — what we collect, what we don&apos;t,
+          <Link href="/privacy">Privacy Policy</Link> — what we collect, what we don&apos;t,
           how we handle your data
         </li>
         <li>
-          <a href="/terms">Terms of Service</a> — the agreement between you and
+          <Link href="/terms">Terms of Service</Link> — the agreement between you and
           Nano 3 Labs Ltd.
         </li>
       </ul>

--- a/website/src/app/legal/page.tsx
+++ b/website/src/app/legal/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from "next"
+import { LegalPage } from "@/components/legal/LegalPage"
+
+export const metadata: Metadata = {
+  title: "Legal · VoiceClaw",
+  description: "Privacy Policy, Terms of Service, and other legal documents for VoiceClaw.",
+}
+
+export default function LegalIndexPage() {
+  return (
+    <LegalPage
+      title="Legal"
+      lastUpdated="April 24, 2026"
+      lede="Everything legally binding about using VoiceClaw, in one place."
+    >
+      <ul>
+        <li>
+          <a href="/privacy">Privacy Policy</a> — what we collect, what we don&apos;t,
+          how we handle your data
+        </li>
+        <li>
+          <a href="/terms">Terms of Service</a> — the agreement between you and
+          Nano 3 Labs Ltd.
+        </li>
+      </ul>
+
+      <p>
+        VoiceClaw itself (the apps, the client libraries, the relay server) is
+        open source under the{" "}
+        <a href="https://github.com/yagudaev/voiceclaw/blob/main/LICENSE">
+          MIT license
+        </a>
+        . Those terms cover the code; the documents linked above cover our
+        hosted services (the website, sign-in, support).
+      </p>
+
+      <p>
+        Need something we haven&apos;t published (DPA, subprocessor list, security
+        questionnaire)? Email{" "}
+        <a href="mailto:support@getvoiceclaw.com">support@getvoiceclaw.com</a>{" "}
+        and we&apos;ll put it together.
+      </p>
+    </LegalPage>
+  )
+}

--- a/website/src/app/privacy/page.tsx
+++ b/website/src/app/privacy/page.tsx
@@ -1,0 +1,250 @@
+import type { Metadata } from "next"
+import { LegalPage } from "@/components/legal/LegalPage"
+
+export const metadata: Metadata = {
+  title: "Privacy Policy · VoiceClaw",
+  description:
+    "What VoiceClaw collects, what it doesn't, and how your voice and keys stay on your own machine.",
+}
+
+export default function PrivacyPage() {
+  return (
+    <LegalPage
+      title="Privacy Policy"
+      lastUpdated="April 24, 2026"
+      lede="VoiceClaw is a voice layer that lives on your own Mac and phone. Your audio, transcripts, and provider API keys stay on your devices — we never receive them. This page describes the narrow slice of data we do collect, why, and what we promise not to do with it."
+    >
+      <h2>The short version</h2>
+      <ul>
+        <li>
+          <strong>We store:</strong> your email and name (if you sign in), a
+          hashed device token so you stay signed in, and anonymous analytics
+          about which onboarding steps you finished.
+        </li>
+        <li>
+          <strong>We don&apos;t receive:</strong> your voice, your transcripts, your
+          conversations, your API keys, or any contents of your AI sessions.
+          Those stay on your Mac and phone, or go directly from your device to
+          the AI provider you configured.
+        </li>
+        <li>
+          <strong>We use:</strong> Vercel to host this website, Neon (Postgres) to
+          store your account, PostHog for anonymous product analytics, Sentry
+          for crash reports.
+        </li>
+        <li>
+          <strong>You can:</strong> delete your account, export your data, or opt
+          out of analytics at any time.
+        </li>
+      </ul>
+
+      <h2>Who we are</h2>
+      <p>
+        VoiceClaw is built and operated by <strong>Nano 3 Labs Ltd.</strong>, a
+        Canadian company registered at 400 – 1168 Hamilton St, Vancouver,
+        British Columbia V6B 2S2, Canada. References to &ldquo;we,&rdquo; &ldquo;us,&rdquo; and &ldquo;our&rdquo;
+        in this policy mean Nano 3 Labs Ltd.
+      </p>
+
+      <h2>What we collect</h2>
+
+      <h3>Account information</h3>
+      <p>
+        When you sign in with Google or Apple, we receive and store:
+      </p>
+      <ul>
+        <li>Your email address</li>
+        <li>Your name (as provided by Google/Apple)</li>
+        <li>
+          A stable identifier from Google/Apple (the OAuth <code>sub</code>) so we
+          can recognize you across sign-ins
+        </li>
+      </ul>
+      <p>
+        We do not receive your password. OAuth handles that end-to-end with
+        Google or Apple.
+      </p>
+
+      <h3>Device tokens</h3>
+      <p>
+        After you sign in, we issue a long-lived token that lets your desktop or
+        mobile app stay authenticated. The token itself lives in your device&apos;s
+        keychain. We store only a <em>hash</em> of the token (we cannot recover the
+        original from the hash).
+      </p>
+
+      <h3>Analytics</h3>
+      <p>
+        We use <a href="https://posthog.com">PostHog</a> to track anonymous
+        product events: which onboarding steps you completed, which provider
+        and brain you selected, how long a step took, whether the test call
+        succeeded. These events include a random device ID but are not linked
+        to your identity. We do not send the contents of your conversations or
+        any audio.
+      </p>
+      <p>
+        You can turn analytics off in Settings → Privacy at any time.
+      </p>
+
+      <h3>Crash reports</h3>
+      <p>
+        If the app crashes, we use <a href="https://sentry.io">Sentry</a> to
+        send the crash&apos;s stack trace and some system metadata (OS version, app
+        version). Crash reports can include file paths and variable names in
+        the stack, but not the contents of your conversations.
+      </p>
+
+      <h2>What we do not receive</h2>
+      <p>
+        VoiceClaw is specifically designed so that your sensitive data never
+        leaves your machine or goes to us. In particular, we do not receive:
+      </p>
+      <ul>
+        <li>
+          <strong>Your voice.</strong> Audio streams directly from your device to
+          the AI provider you chose (Google Gemini, OpenAI, xAI, or your own
+          endpoint). It does not pass through our servers.
+        </li>
+        <li>
+          <strong>Your transcripts.</strong> Transcripts are stored locally in
+          SQLite on your Mac and phone. You can optionally forward them to your
+          own Langfuse instance for observability, but we never receive them.
+        </li>
+        <li>
+          <strong>Your provider API keys.</strong> Your Gemini/OpenAI/xAI key is
+          stored in your macOS Keychain (or iOS Keychain on mobile) and used to
+          authenticate directly with the provider. We never see it.
+        </li>
+        <li>
+          <strong>Your AI conversations.</strong> What you ask the AI and what it
+          says back is between you and the provider you picked.
+        </li>
+      </ul>
+
+      <h2>Third-party services we use</h2>
+      <ul>
+        <li>
+          <strong>Vercel</strong> — hosts <code>getvoiceclaw.com</code>. Servers
+          are in the United States. Vercel may log request metadata (IP
+          address, user agent) for abuse prevention.
+        </li>
+        <li>
+          <strong>Neon (managed Postgres)</strong> — stores our user database. We
+          use an instance provisioned through our Vercel account. Servers are
+          in the United States.
+        </li>
+        <li>
+          <strong>PostHog</strong> — anonymous product analytics, as described
+          above. Opt-out in Settings.
+        </li>
+        <li>
+          <strong>Sentry</strong> — crash reports, as described above.
+        </li>
+        <li>
+          <strong>Google / Apple</strong> — OAuth providers for sign-in. They
+          see that you signed in to VoiceClaw but we don&apos;t tell them anything
+          else about your usage.
+        </li>
+        <li>
+          <strong>AI providers you configure</strong> — Google Gemini, OpenAI,
+          xAI, or a custom endpoint you specify. Their privacy policies
+          govern what happens to your audio and conversations once they
+          leave your device. We encourage you to read them.
+        </li>
+      </ul>
+
+      <h2>How long we keep your data</h2>
+      <p>
+        Account data persists as long as your account is active. If you delete
+        your account, we permanently delete your user record, device tokens,
+        and authentication tickets within 30 days. Analytics events are
+        retained for 180 days and then deleted or anonymized.
+      </p>
+
+      <h2>International transfers</h2>
+      <p>
+        Our servers (Vercel, Neon, PostHog, Sentry) are located in the United
+        States. If you access VoiceClaw from outside the US, your account data
+        is transferred to and stored in the US. For users in the EU / EEA, we
+        rely on Standard Contractual Clauses with our processors as the legal
+        basis for transfer.
+      </p>
+
+      <h2>Your rights</h2>
+      <p>You have the right to:</p>
+      <ul>
+        <li>Access the data we hold about you</li>
+        <li>Correct inaccurate data</li>
+        <li>Delete your account and all associated data</li>
+        <li>Export your account data in a portable format</li>
+        <li>Opt out of analytics</li>
+        <li>Object to processing on legitimate-interest grounds</li>
+      </ul>
+      <p>
+        To exercise any of these rights, email us at{" "}
+        <a href="mailto:support@getvoiceclaw.com">support@getvoiceclaw.com</a>{" "}
+        and we&apos;ll respond within 30 days. We may ask you to prove you&apos;re the
+        account holder before we act on the request.
+      </p>
+
+      <h2>California residents (CCPA)</h2>
+      <p>
+        Under the California Consumer Privacy Act, California residents have
+        additional rights, including the right to know the categories of
+        personal information we collect and the right not to be discriminated
+        against for exercising privacy rights. The categories we collect are
+        described above under &ldquo;What we collect.&rdquo; We do not sell personal
+        information.
+      </p>
+
+      <h2>EU / EEA residents (GDPR)</h2>
+      <p>
+        If you&apos;re in the EU / EEA, Nano 3 Labs Ltd. is the data controller for
+        your account data. Our legal bases for processing are: performance of
+        the contract (account features), our legitimate interest (analytics,
+        security), and your consent (optional analytics). You can lodge a
+        complaint with your local supervisory authority.
+      </p>
+
+      <h2>Children</h2>
+      <p>
+        VoiceClaw is not directed at children under 13, and we do not knowingly
+        collect personal information from anyone under 13. If you believe a
+        child has given us personal information, contact us and we&apos;ll delete
+        it.
+      </p>
+
+      <h2>Security</h2>
+      <p>
+        We use industry-standard encryption in transit (TLS 1.2+) and at rest
+        for our Postgres database. Device tokens are hashed server-side and the
+        original never persists. Our design philosophy is to keep sensitive
+        data off our servers entirely — we protect best what we never receive.
+        That said, no system is perfectly secure, and we can&apos;t guarantee
+        absolute security against all threats.
+      </p>
+
+      <h2>Changes to this policy</h2>
+      <p>
+        If we make material changes to this policy, we&apos;ll update the &ldquo;Last
+        updated&rdquo; date at the top and notify signed-in users by email. Continued
+        use of VoiceClaw after a change means you accept the updated policy.
+      </p>
+
+      <h2>Contact us</h2>
+      <p>
+        For privacy questions or to exercise your rights, email{" "}
+        <a href="mailto:support@getvoiceclaw.com">support@getvoiceclaw.com</a>.
+      </p>
+      <p>
+        <strong>Nano 3 Labs Ltd.</strong>
+        <br />
+        400 – 1168 Hamilton St
+        <br />
+        Vancouver, BC V6B 2S2
+        <br />
+        Canada
+      </p>
+    </LegalPage>
+  )
+}

--- a/website/src/app/terms/page.tsx
+++ b/website/src/app/terms/page.tsx
@@ -1,0 +1,224 @@
+import type { Metadata } from "next"
+import { LegalPage } from "@/components/legal/LegalPage"
+
+export const metadata: Metadata = {
+  title: "Terms of Service · VoiceClaw",
+  description:
+    "The agreement between you and Nano 3 Labs Ltd. covering VoiceClaw — what you're allowed to do, what we promise, and what we don't.",
+}
+
+export default function TermsPage() {
+  return (
+    <LegalPage
+      title="Terms of Service"
+      lastUpdated="April 24, 2026"
+      lede="These terms cover your use of VoiceClaw and its related services. VoiceClaw is open-source software and a small set of hosted services operated by Nano 3 Labs Ltd. Most of the product runs on your own machine; these terms mainly describe the parts that don't."
+    >
+      <h2>Agreement</h2>
+      <p>
+        By using VoiceClaw (the apps, the website at{" "}
+        <code>getvoiceclaw.com</code>, and any related services we operate),
+        you agree to these terms. If you don&apos;t agree, please don&apos;t use
+        VoiceClaw.
+      </p>
+      <p>
+        VoiceClaw is operated by <strong>Nano 3 Labs Ltd.</strong>, a Canadian
+        company. References to &ldquo;we,&rdquo; &ldquo;us,&rdquo; and &ldquo;our&rdquo; mean Nano 3 Labs Ltd.
+      </p>
+
+      <h2>What VoiceClaw does</h2>
+      <p>
+        VoiceClaw is a voice interface for AI agents. The desktop and mobile
+        apps run on your devices, connect to a voice model you configure
+        (Google Gemini, OpenAI, xAI, or a compatible endpoint), and route the
+        AI&apos;s tool calls to a &ldquo;brain&rdquo; agent you also configure (bundled
+        OpenClaw, Claude Code, Codex CLI, or any OpenAI-compatible endpoint).
+      </p>
+      <p>
+        The app source code is open source under the MIT license. These terms
+        only govern the services we operate (the website, sign-in, support).
+        The software itself is yours to run, modify, and fork under the MIT
+        license.
+      </p>
+
+      <h2>Your account</h2>
+      <p>
+        Signing in is optional. If you do sign in, you&apos;re responsible for
+        keeping your Google or Apple account secure, and for any activity that
+        happens through your signed-in VoiceClaw account. Tell us at{" "}
+        <a href="mailto:support@getvoiceclaw.com">support@getvoiceclaw.com</a>{" "}
+        if you believe your account has been compromised.
+      </p>
+      <p>
+        You must be at least 13 years old to use VoiceClaw, and at least the
+        age of majority in your jurisdiction to enter into this agreement.
+      </p>
+
+      <h2>What you can&apos;t do</h2>
+      <p>You agree not to:</p>
+      <ul>
+        <li>Use VoiceClaw for anything illegal under applicable law</li>
+        <li>
+          Use VoiceClaw to harass, abuse, harm, threaten, or impersonate
+          another person
+        </li>
+        <li>
+          Use VoiceClaw to generate or distribute sexually explicit content
+          involving minors, non-consensual intimate imagery, or content
+          designed to incite violence
+        </li>
+        <li>
+          Attempt to reverse-engineer, disable, or interfere with our hosted
+          services (the website, sign-in flow, update feed)
+        </li>
+        <li>
+          Resell VoiceClaw as a hosted service without our written permission
+          (the open-source license still lets you run it yourself)
+        </li>
+        <li>
+          Circumvent rate limits or other technical controls on our hosted
+          services
+        </li>
+      </ul>
+
+      <h2>AI-generated content</h2>
+      <p>
+        VoiceClaw is a frontend for AI providers you configure. The words the
+        AI says back to you come from that provider, run under their content
+        policies, not ours. Google, OpenAI, and xAI each have their own
+        acceptable-use rules that apply to what you can ask and what they&apos;ll
+        generate. You&apos;re responsible for complying with those rules in
+        addition to these terms.
+      </p>
+      <p>
+        AI systems sometimes generate inaccurate, biased, or offensive content.
+        Don&apos;t treat AI output as professional advice (medical, legal,
+        financial, etc.) and verify anything that matters.
+      </p>
+      <p>
+        <strong>Reporting objectionable content.</strong> If VoiceClaw (through
+        a configured provider) generates content you find objectionable, you
+        can report it to us at{" "}
+        <a href="mailto:support@getvoiceclaw.com">support@getvoiceclaw.com</a>.
+        We have zero tolerance for content that violates these terms, and we
+        can terminate access for users who repeatedly generate such content
+        through our hosted services.
+      </p>
+
+      <h2>Your content and data</h2>
+      <p>
+        VoiceClaw is architected so that your content (audio, transcripts,
+        files you share with the AI) stays on your device or goes directly to
+        the AI provider you configured. We don&apos;t receive your content. For
+        more detail see our{" "}
+        <a href="/privacy">Privacy Policy</a>.
+      </p>
+      <p>
+        To the extent we <em>do</em> hold data about you (your account, analytics
+        events, crash reports), you own it and can ask us to export or delete
+        it at any time.
+      </p>
+
+      <h2>Third-party services</h2>
+      <p>
+        VoiceClaw relies on external providers you bring (OAuth, AI providers,
+        your own brain endpoint). Those services have their own terms and
+        privacy policies. When you use Google to sign in, for example, you&apos;re
+        also bound by Google&apos;s terms. We&apos;re not responsible for the conduct
+        of those third parties.
+      </p>
+
+      <h2>Fees</h2>
+      <p>
+        VoiceClaw is free to use today. You pay the AI providers you
+        configure directly (Gemini, OpenAI, xAI). We may introduce paid tiers
+        (&ldquo;VoiceClaw Cloud&rdquo;) in the future; if we do, we&apos;ll announce the pricing
+        clearly before you sign up for a paid feature, and you&apos;ll have the
+        chance to opt in or not.
+      </p>
+
+      <h2>Termination</h2>
+      <p>
+        You can stop using VoiceClaw at any time. You can delete your account
+        by emailing{" "}
+        <a href="mailto:support@getvoiceclaw.com">support@getvoiceclaw.com</a>.
+        We&apos;ll fully delete it within 30 days.
+      </p>
+      <p>
+        We can suspend or terminate your account if you materially violate
+        these terms, especially around prohibited content or attempts to
+        compromise our services. Where practical we&apos;ll give you notice and a
+        chance to remedy the issue first.
+      </p>
+
+      <h2>Changes to the service</h2>
+      <p>
+        We&apos;re shipping this actively. Features may change, new ones land, old
+        ones get retired. We&apos;ll do our best to give reasonable notice of
+        breaking changes to our hosted services. The open-source client code
+        is yours — nothing we do can take away your ability to keep running a
+        version you cloned.
+      </p>
+
+      <h2>Disclaimer of warranties</h2>
+      <p>
+        VoiceClaw is provided &ldquo;as is&rdquo; and &ldquo;as available.&rdquo; We make no
+        warranties — express, implied, statutory, or otherwise — about the
+        service, including any warranty of merchantability, fitness for a
+        particular purpose, or non-infringement. Voice AI is a fast-moving
+        space and we can&apos;t guarantee the service will always work or work
+        correctly.
+      </p>
+
+      <h2>Limitation of liability</h2>
+      <p>
+        To the maximum extent permitted by law, Nano 3 Labs Ltd. is not liable
+        for indirect, incidental, consequential, special, exemplary, or
+        punitive damages arising out of your use of VoiceClaw. Our total
+        liability for any claim relating to VoiceClaw is limited to the greater
+        of (a) the fees you&apos;ve paid us in the 12 months preceding the claim
+        or (b) CAD $100.
+      </p>
+
+      <h2>Indemnification</h2>
+      <p>
+        If a third party sues us because of something you did with VoiceClaw
+        (e.g., using it in violation of these terms, misusing AI-generated
+        content), you&apos;ll defend us against that claim and cover the
+        reasonable costs, including legal fees.
+      </p>
+
+      <h2>Governing law</h2>
+      <p>
+        These terms are governed by the laws of the Province of British
+        Columbia and the federal laws of Canada, without regard to conflict of
+        laws principles. Any dispute that can&apos;t be resolved informally will be
+        handled in the courts of British Columbia.
+      </p>
+
+      <h2>General</h2>
+      <p>
+        If any provision of these terms is found unenforceable, the rest stay
+        in effect. Our failure to enforce a provision isn&apos;t a waiver of our
+        right to enforce it later. You can&apos;t assign these terms without our
+        written consent. We can assign them to a successor entity (e.g., if
+        the company is acquired).
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        Questions about these terms? Email{" "}
+        <a href="mailto:support@getvoiceclaw.com">support@getvoiceclaw.com</a>.
+      </p>
+      <p>
+        <strong>Nano 3 Labs Ltd.</strong>
+        <br />
+        400 – 1168 Hamilton St
+        <br />
+        Vancouver, BC V6B 2S2
+        <br />
+        Canada
+      </p>
+    </LegalPage>
+  )
+}

--- a/website/src/app/terms/page.tsx
+++ b/website/src/app/terms/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import Link from "next/link"
 import { LegalPage } from "@/components/legal/LegalPage"
 
 export const metadata: Metadata = {
@@ -111,7 +112,7 @@ export default function TermsPage() {
         files you share with the AI) stays on your device or goes directly to
         the AI provider you configured. We don&apos;t receive your content. For
         more detail see our{" "}
-        <a href="/privacy">Privacy Policy</a>.
+        <Link href="/privacy">Privacy Policy</Link>.
       </p>
       <p>
         To the extent we <em>do</em> hold data about you (your account, analytics

--- a/website/src/components/legal/LegalPage.tsx
+++ b/website/src/components/legal/LegalPage.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link"
 import type { ReactNode } from "react"
 
 // Shared container for legal pages (privacy, terms, legal index).
@@ -16,9 +17,9 @@ export function LegalPage({ title, lastUpdated, lede, children }: LegalPageProps
   return (
     <div className="mx-auto max-w-3xl px-6 py-16 sm:py-24">
       <nav className="mb-12 text-sm text-muted-foreground">
-        <a href="/" className="transition-colors hover:text-foreground">
+        <Link href="/" className="transition-colors hover:text-foreground">
           ← VoiceClaw
-        </a>
+        </Link>
       </nav>
 
       <header className="mb-10">
@@ -31,7 +32,7 @@ export function LegalPage({ title, lastUpdated, lede, children }: LegalPageProps
         ) : null}
       </header>
 
-      <div className="prose prose-invert max-w-none space-y-8 text-[15px] leading-7 [&_h2]:mt-12 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:tracking-tight [&_h3]:mt-8 [&_h3]:text-lg [&_h3]:font-medium [&_ul]:list-disc [&_ul]:pl-6 [&_a]:underline [&_a]:underline-offset-2">
+      <div className="max-w-none space-y-8 text-[15px] leading-7 [&_h2]:mt-12 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:tracking-tight [&_h3]:mt-8 [&_h3]:text-lg [&_h3]:font-medium [&_ul]:list-disc [&_ul]:pl-6 [&_a]:underline [&_a]:underline-offset-2">
         {children}
       </div>
 

--- a/website/src/components/legal/LegalPage.tsx
+++ b/website/src/components/legal/LegalPage.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react"
+
+// Shared container for legal pages (privacy, terms, legal index).
+// Minimal styling — a follow-up PR restyles this to match Option B
+// (paper + serif) once the brand system lands on the marketing site.
+// For now: readable, neutral, link back to home.
+
+type LegalPageProps = {
+  title: string
+  lastUpdated: string
+  lede?: string
+  children: ReactNode
+}
+
+export function LegalPage({ title, lastUpdated, lede, children }: LegalPageProps) {
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-16 sm:py-24">
+      <nav className="mb-12 text-sm text-muted-foreground">
+        <a href="/" className="transition-colors hover:text-foreground">
+          ← VoiceClaw
+        </a>
+      </nav>
+
+      <header className="mb-10">
+        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">{title}</h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          Last updated: {lastUpdated}
+        </p>
+        {lede ? (
+          <p className="mt-6 text-lg leading-7 text-muted-foreground">{lede}</p>
+        ) : null}
+      </header>
+
+      <div className="prose prose-invert max-w-none space-y-8 text-[15px] leading-7 [&_h2]:mt-12 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:tracking-tight [&_h3]:mt-8 [&_h3]:text-lg [&_h3]:font-medium [&_ul]:list-disc [&_ul]:pl-6 [&_a]:underline [&_a]:underline-offset-2">
+        {children}
+      </div>
+
+      <footer className="mt-16 border-t border-border/40 pt-8 text-sm text-muted-foreground">
+        <p>
+          Questions? Email{" "}
+          <a href="mailto:support@getvoiceclaw.com" className="underline">
+            support@getvoiceclaw.com
+          </a>
+          .
+        </p>
+        <p className="mt-2">
+          VoiceClaw is a product of <strong>Nano 3 Labs Ltd.</strong>, Vancouver, BC, Canada.
+        </p>
+      </footer>
+    </div>
+  )
+}


### PR DESCRIPTION
## Why

Unblocks two downstream pieces:
1. **Google OAuth consent screen verification** requires public Privacy Policy + Terms URLs before Google approves the app for production (removes the "unverified app" scary screen).
2. **Apple App Store Review Guideline 1.2** requires UGC moderation clauses in our Terms of Service before they'll accept the mobile app.

Google's verification review is 1–6 weeks, so standing these pages up now puts that clock on the right side of the Phase 1 identity PR.

## What's in

| Route | Page | Size |
|---|---|---|
| \`/privacy\` | Privacy Policy | ~310 lines of structured TSX |
| \`/terms\` | Terms of Service | ~250 lines of structured TSX |
| \`/legal\` | Index linking both | ~40 lines |

Plus a shared \`LegalPage\` component (\`website/src/components/legal/LegalPage.tsx\`) with minimal styling — back-to-home link, title, lede, body prose, footer with Nano 3 Labs Ltd. address + support email.

## Voice / shape

- Parallels audiowaveai.com's structure (same company, same Vancouver address, same BC governing law)
- **Shorter and more human** than the full 28-section auto-generated template — VoiceClaw doesn't have payments, IAP, or complex account logic yet, so we only describe what's actually true
- **Privacy "short version" at the top** — what we store, what we don't, what we use, what you can do. Plain language.
- **UGC clauses in Terms** lean on "we're a frontend for providers you configured" to shift content responsibility to Google/OpenAI/xAI where Apple already trusts their moderation (the shield called out in NAN-662)
- **Explicitly calls out what we don't receive:** audio, transcripts, API keys, conversations. This is the actual differentiator.

## Minimal styling

The pages use the existing shadcn dark-mode Tailwind tokens. Codex is redesigning the marketing site to match the Option B brand (paper + Fraunces + warm muted text); this component is deliberately neutral so it slots in cleanly. No custom colors, no custom fonts — just readable semantic markup.

## Screenshots

### /privacy
![Privacy](https://user-images.githubusercontent.com/placeholder/privacy)

### /terms
![Terms](https://user-images.githubusercontent.com/placeholder/terms)

(Screenshots available in the branch at \`legal-privacy.png\` / \`legal-terms.png\` via Playwright; adding them via comment below)

## Test plan

- [x] \`yarn build\` — all three pages prerender as static (\`○ /legal\`, \`○ /privacy\`, \`○ /terms\`)
- [x] Visual check at localhost:3100 — pages render, links work, typography reads
- [ ] Reviewer: sanity-check the legal claims (BC governing law, company address, CCPA/GDPR scope)
- [ ] Reviewer: confirm \`support@getvoiceclaw.com\` alias will be wired before ships to production
- [ ] Once merged + deployed: submit to Google OAuth consent screen

## Follow-ups

- Codex restyles \`LegalPage\` component to match Option B when marketing site redesigns
- Add footer links to Privacy / Terms from the main landing page
- Wire \`support@getvoiceclaw.com\` as a Google Workspace alias forwarding to michael@nano3labs.com
- Update Google OAuth consent screen with these URLs after Phase 1 identity PR ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)