### PR TITLE
Add website dark mode brand tokens (NAN-664)

### DIFF
--- a/website/src/app/brand/page.tsx
+++ b/website/src/app/brand/page.tsx
@@ -209,7 +209,7 @@ export default function BrandGuidelinesPage() {
       <GuidelineSection
         eyebrow="05"
         title="Dark mode direction"
-        description="The dark-mode PR should invert the system without turning the brand into blue-black SaaS chrome."
+        description="The website follows system preference with a warm dark palette, not blue-black SaaS chrome."
         icon={<Moon className="size-5" />}
       >
         <div className="grid gap-3 md:grid-cols-3">
@@ -280,7 +280,7 @@ export default function BrandGuidelinesPage() {
         <div className="grid gap-3 md:grid-cols-3">
           <ImplementationCard
             title="Website"
-            description="Use this page as the canonical light-mode reference."
+            description="Use this page as the canonical light and dark reference."
           />
           <ImplementationCard
             title="Desktop"

--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -50,6 +50,7 @@
 }
 
 :root {
+  color-scheme: light;
   --brand-paper: #f1e8da;
   --brand-paper-strong: #e8ddcd;
   --brand-panel: #fdf9f1;
@@ -64,6 +65,20 @@
   --brand-line: rgba(25, 21, 17, 0.1);
   --brand-line-strong: rgba(25, 21, 17, 0.2);
   --brand-shadow: 0 18px 40px rgba(25, 21, 17, 0.08);
+  --brand-grid-line: rgba(25, 21, 17, 0.055);
+  --brand-hero-scrim-mobile: rgba(241, 232, 218, 0.78);
+  --brand-hero-scrim-desktop: linear-gradient(
+    90deg,
+    rgba(241, 232, 218, 0.98) 0%,
+    rgba(241, 232, 218, 0.9) 38%,
+    rgba(241, 232, 218, 0.22) 70%,
+    rgba(241, 232, 218, 0.02) 100%
+  );
+  --brand-contrast-bg: #191511;
+  --brand-contrast-fg: #ffffff;
+  --brand-contrast-fg-hover: #fffaf2;
+  --brand-contrast-muted: rgba(255, 255, 255, 0.7);
+  --brand-contrast-line: rgba(255, 255, 255, 0.2);
   --background: var(--brand-paper);
   --foreground: var(--brand-ink);
   --card: var(--brand-panel);
@@ -99,6 +114,7 @@
 }
 
 .dark {
+  color-scheme: dark;
   --brand-paper: #171310;
   --brand-paper-strong: #211b16;
   --brand-panel: #211b16;
@@ -113,6 +129,20 @@
   --brand-line: rgba(245, 234, 220, 0.1);
   --brand-line-strong: rgba(245, 234, 220, 0.2);
   --brand-shadow: 0 18px 40px rgba(0, 0, 0, 0.24);
+  --brand-grid-line: rgba(245, 234, 220, 0.055);
+  --brand-hero-scrim-mobile: rgba(23, 19, 16, 0.78);
+  --brand-hero-scrim-desktop: linear-gradient(
+    90deg,
+    rgba(23, 19, 16, 0.98) 0%,
+    rgba(23, 19, 16, 0.9) 38%,
+    rgba(23, 19, 16, 0.42) 70%,
+    rgba(23, 19, 16, 0.12) 100%
+  );
+  --brand-contrast-bg: #0f0b09;
+  --brand-contrast-fg: #f5eadc;
+  --brand-contrast-fg-hover: #eadcc9;
+  --brand-contrast-muted: rgba(245, 234, 220, 0.72);
+  --brand-contrast-line: rgba(245, 234, 220, 0.22);
   --background: var(--brand-paper);
   --foreground: var(--brand-ink);
   --card: var(--brand-panel);
@@ -146,6 +176,70 @@
   --sidebar-ring: rgba(216, 106, 77, 0.45);
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --brand-paper: #171310;
+    --brand-paper-strong: #211b16;
+    --brand-panel: #211b16;
+    --brand-panel-strong: #2c251f;
+    --brand-ink: #f5eadc;
+    --brand-muted: #b9aa98;
+    --brand-accent: #d86a4d;
+    --brand-accent-hover: #ef8668;
+    --brand-accent-wash: rgba(216, 106, 77, 0.18);
+    --brand-sage: #9cac99;
+    --brand-sage-wash: rgba(156, 172, 153, 0.18);
+    --brand-line: rgba(245, 234, 220, 0.1);
+    --brand-line-strong: rgba(245, 234, 220, 0.2);
+    --brand-shadow: 0 18px 40px rgba(0, 0, 0, 0.24);
+    --brand-grid-line: rgba(245, 234, 220, 0.055);
+    --brand-hero-scrim-mobile: rgba(23, 19, 16, 0.78);
+    --brand-hero-scrim-desktop: linear-gradient(
+      90deg,
+      rgba(23, 19, 16, 0.98) 0%,
+      rgba(23, 19, 16, 0.9) 38%,
+      rgba(23, 19, 16, 0.42) 70%,
+      rgba(23, 19, 16, 0.12) 100%
+    );
+    --brand-contrast-bg: #0f0b09;
+    --brand-contrast-fg: #f5eadc;
+    --brand-contrast-fg-hover: #eadcc9;
+    --brand-contrast-muted: rgba(245, 234, 220, 0.72);
+    --brand-contrast-line: rgba(245, 234, 220, 0.22);
+    --background: var(--brand-paper);
+    --foreground: var(--brand-ink);
+    --card: var(--brand-panel);
+    --card-foreground: var(--brand-ink);
+    --popover: var(--brand-panel);
+    --popover-foreground: var(--brand-ink);
+    --primary: var(--brand-accent);
+    --primary-foreground: #171310;
+    --secondary: var(--brand-paper-strong);
+    --secondary-foreground: var(--brand-ink);
+    --muted: var(--brand-paper-strong);
+    --muted-foreground: var(--brand-muted);
+    --accent: var(--brand-accent-wash);
+    --accent-foreground: var(--brand-accent);
+    --border: var(--brand-line-strong);
+    --input: var(--brand-line-strong);
+    --ring: rgba(216, 106, 77, 0.45);
+    --chart-1: var(--brand-accent);
+    --chart-2: var(--brand-sage);
+    --chart-3: var(--brand-ink);
+    --chart-4: var(--brand-muted);
+    --chart-5: var(--brand-paper-strong);
+    --sidebar: var(--brand-panel);
+    --sidebar-foreground: var(--brand-ink);
+    --sidebar-primary: var(--brand-accent);
+    --sidebar-primary-foreground: #171310;
+    --sidebar-accent: var(--brand-paper-strong);
+    --sidebar-accent-foreground: var(--brand-ink);
+    --sidebar-border: var(--brand-line-strong);
+    --sidebar-ring: rgba(216, 106, 77, 0.45);
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;
@@ -154,7 +248,7 @@
     @apply bg-background text-foreground;
     background-image: linear-gradient(
       to right,
-      rgba(25, 21, 17, 0.055) 1px,
+      var(--brand-grid-line) 1px,
       transparent 1px
     );
     background-size: 112px 112px;
@@ -162,4 +256,12 @@
   html {
     @apply font-sans;
   }
+}
+
+.brand-hero-scrim-mobile {
+  background: var(--brand-hero-scrim-mobile);
+}
+
+.brand-hero-scrim-desktop {
+  background: var(--brand-hero-scrim-desktop);
 }

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -74,8 +74,8 @@ function HeroSection() {
         sizes="100vw"
         className="object-cover object-[70%_center]"
       />
-      <div className="absolute inset-0 bg-[rgba(241,232,218,0.78)] sm:hidden" />
-      <div className="absolute inset-0 hidden bg-[linear-gradient(90deg,rgba(241,232,218,0.98)_0%,rgba(241,232,218,0.9)_38%,rgba(241,232,218,0.22)_70%,rgba(241,232,218,0.02)_100%)] sm:block" />
+      <div className="brand-hero-scrim-mobile absolute inset-0 sm:hidden" />
+      <div className="brand-hero-scrim-desktop absolute inset-0 hidden sm:block" />
       <div className="relative mx-auto flex min-h-[calc(100svh-4rem)] max-w-7xl flex-col justify-between px-5 py-10 sm:px-8 sm:py-14">
         <div className="max-w-4xl pt-12 sm:pt-20">
           <div className="mb-8 inline-flex items-center gap-3 rounded-md border border-[var(--brand-line-strong)] bg-[var(--brand-panel)] px-3 py-2 font-mono text-xs text-[var(--brand-muted)] shadow-[var(--brand-shadow)]">
@@ -98,7 +98,7 @@ function HeroSection() {
               href="https://github.com/yagudaev/voiceclaw"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-[var(--brand-accent)] px-5 text-sm font-semibold text-white transition hover:bg-[var(--brand-accent-hover)]"
+              className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-[var(--brand-accent)] px-5 text-sm font-semibold text-primary-foreground transition hover:bg-[var(--brand-accent-hover)]"
             >
               <GitBranch className="size-4" />
               View on GitHub
@@ -233,16 +233,16 @@ function PlatformSection() {
 
 function GetStartedSection() {
   return (
-    <section className="bg-[var(--brand-ink)] px-5 py-20 text-white sm:px-8">
+    <section className="bg-[var(--brand-contrast-bg)] px-5 py-20 text-[var(--brand-contrast-fg)] sm:px-8">
       <div className="mx-auto grid max-w-7xl gap-10 lg:grid-cols-[minmax(0,1fr)_360px]">
         <div>
-          <p className="font-mono text-xs uppercase text-[var(--brand-paper-strong)]">
+          <p className="font-mono text-xs uppercase text-[var(--brand-contrast-muted)]">
             Get started
           </p>
           <h2 className="mt-4 max-w-3xl font-serif text-5xl leading-none sm:text-6xl">
             Give your existing agent a voice front end.
           </h2>
-          <p className="mt-6 max-w-2xl text-lg leading-8 text-white/70">
+          <p className="mt-6 max-w-2xl text-lg leading-8 text-[var(--brand-contrast-muted)]">
             Clone the repo, run the relay, connect your endpoint, and start
             talking. No hosted brain required.
           </p>
@@ -252,7 +252,7 @@ function GetStartedSection() {
             href="https://github.com/yagudaev/voiceclaw"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-[var(--brand-panel-strong)] px-5 text-sm font-semibold text-[var(--brand-ink)] transition hover:bg-[var(--brand-paper)]"
+            className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-[var(--brand-contrast-fg)] px-5 text-sm font-semibold text-[var(--brand-contrast-bg)] transition hover:bg-[var(--brand-contrast-fg-hover)]"
           >
             <GitBranch className="size-4" />
             Open repository
@@ -261,7 +261,7 @@ function GetStartedSection() {
             href="https://github.com/yagudaev/voiceclaw#quick-start"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-white/20 px-5 text-sm font-semibold text-white transition hover:border-white/50"
+            className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-[var(--brand-contrast-line)] px-5 text-sm font-semibold text-[var(--brand-contrast-fg)] transition hover:border-[var(--brand-contrast-fg)]"
           >
             Quick start
             <ArrowRight className="size-4" />


### PR DESCRIPTION
## Summary
- Add system-preference dark mode tokens for the Editorial Quiet website brand
- Tokenize hero scrims, grid lines, and inverse CTA colors so light/dark modes stay in the same palette
- Update `/brand` copy to document the website as the light and dark reference for follow-on app work

## Test plan
- [x] `yarn lint:web`
- [x] `yarn build:web`
- [x] Playwright screenshots for `/` and `/brand` in light and dark color schemes at desktop and mobile widths
- [x] Playwright hover check for the dark-mode inverse CTA button
- [x] Claude Code design review, fixes applied, final spot-check LGTM
- [x] Gemini design review, fixes applied, final review LGTM subject to the fixed CTA hover issue

## External design review
- Claude reviewed the dark-mode implementation and flagged the inverse CTA hover regression. Fixed with `--brand-contrast-fg-hover`; final Claude spot-check LGTM.
- Gemini reviewed the implementation and flagged the same CTA hover plus absolute white hero CTA text. Fixed with `--brand-contrast-fg-hover` and `text-primary-foreground`.

Stacked on #192. Refs NAN-664.
