### PR TITLE
Update desktop app to Editorial Quiet brand (NAN-665)

### DIFF
--- a/desktop/src/renderer/index.html
+++ b/desktop/src/renderer/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -44,7 +44,7 @@ export function App() {
 
   return (
     <ConversationProvider>
-      <div className="h-screen flex flex-col bg-background text-foreground">
+      <div className="h-screen flex flex-col bg-background text-foreground vc-window-surface">
         <TabBar activeTab={activeTab} onTabChange={setActiveTab} />
         <main className="flex-1 flex flex-col overflow-hidden relative">
           <div className={`flex-1 flex flex-col overflow-hidden ${activeTab !== 'chat' ? 'hidden' : ''}`}>

--- a/desktop/src/renderer/src/components/AudioLevelMeter.tsx
+++ b/desktop/src/renderer/src/components/AudioLevelMeter.tsx
@@ -26,9 +26,9 @@ export function AudioLevelMeter({ getLevel, active }: AudioLevelMeterProps) {
   const width = Math.min(100, level * 500)
 
   return (
-    <div className="h-1 bg-muted rounded-full overflow-hidden">
+    <div className="h-1 overflow-hidden rounded-full bg-muted">
       <div
-        className="h-full bg-green-500 transition-[width] duration-100"
+        className="h-full bg-primary transition-[width] duration-100"
         style={{ width: `${width}%` }}
       />
     </div>

--- a/desktop/src/renderer/src/components/MessageBubble.tsx
+++ b/desktop/src/renderer/src/components/MessageBubble.tsx
@@ -16,10 +16,10 @@ export function MessageBubble({ message, showLatency }: MessageBubbleProps) {
     <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-3`}>
       <div
         className={`
-          max-w-[80%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed
+          max-w-[80%] rounded-md px-4 py-2.5 text-sm leading-relaxed
           ${isUser
-            ? 'bg-primary text-primary-foreground rounded-br-md'
-            : 'bg-muted text-foreground rounded-bl-md'
+            ? 'bg-primary text-primary-foreground'
+            : 'bg-card text-foreground border border-border'
           }
         `}
       >
@@ -33,7 +33,7 @@ export function MessageBubble({ message, showLatency }: MessageBubbleProps) {
               key={i}
               src={part.url}
               alt={part.alt}
-              className="rounded-lg max-w-full mt-2 mb-1"
+              className="rounded-md max-w-full mt-2 mb-1"
               loading="lazy"
             />
           ),

--- a/desktop/src/renderer/src/components/ScreenSharePicker.tsx
+++ b/desktop/src/renderer/src/components/ScreenSharePicker.tsx
@@ -21,7 +21,7 @@ export function ScreenSharePicker({ onSelect, onCancel }: ScreenSharePickerProps
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-      <div className="bg-card border border-border rounded-2xl shadow-2xl w-[640px] max-h-[80vh] flex flex-col">
+      <div className="w-[640px] max-h-[80vh] flex flex-col rounded-md border border-border bg-card vc-panel-shadow">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-border">
           <h2 className="text-lg font-semibold text-foreground">Share Screen</h2>
@@ -42,12 +42,12 @@ export function ScreenSharePicker({ onSelect, onCancel }: ScreenSharePickerProps
                 <button
                   key={source.id}
                   onClick={() => onSelect(source)}
-                  className="group rounded-xl border border-border bg-background p-2 hover:border-primary/50 hover:bg-accent transition-colors text-left"
+                  className="group rounded-md border border-border bg-background p-2 hover:border-primary/50 hover:bg-accent transition-colors text-left"
                 >
                   <img
                     src={source.thumbnailDataURL}
                     alt={source.name}
-                    className="w-full h-32 object-contain rounded-lg bg-muted mb-2"
+                    className="w-full h-32 object-contain rounded-md bg-muted mb-2"
                   />
                   <p className="text-xs text-muted-foreground group-hover:text-foreground truncate px-1">
                     {source.name}

--- a/desktop/src/renderer/src/components/TabBar.tsx
+++ b/desktop/src/renderer/src/components/TabBar.tsx
@@ -1,4 +1,5 @@
 import { MessageCircle, Clock, Settings } from 'lucide-react'
+import { VoiceClawMark } from './brand/VoiceClawMark'
 
 export type TabId = 'chat' | 'history' | 'settings'
 
@@ -15,9 +16,16 @@ const tabs: { id: TabId, label: string, icon: typeof MessageCircle }[] = [
 
 export function TabBar({ activeTab, onTabChange }: TabBarProps) {
   return (
-    <div className="flex items-center gap-1 px-4 py-2 border-b border-border bg-card">
+    <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-card/90 backdrop-blur">
       {/* macOS traffic light spacer */}
       <div className="w-16 drag-region" />
+
+      <div className="no-drag mr-2 flex items-center gap-2 text-foreground">
+        <span className="flex size-8 items-center justify-center rounded-md border border-border bg-background">
+          <VoiceClawMark className="size-5" accent />
+        </span>
+        <span className="text-sm font-semibold">VoiceClaw</span>
+      </div>
 
       {tabs.map((tab) => {
         const Icon = tab.icon
@@ -27,11 +35,11 @@ export function TabBar({ activeTab, onTabChange }: TabBarProps) {
             key={tab.id}
             onClick={() => onTabChange(tab.id)}
             className={`
-              no-drag flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium
+              no-drag flex items-center gap-2 px-3 py-2 rounded-md border text-sm font-medium
               transition-colors duration-150
               ${isActive
-                ? 'bg-accent text-accent-foreground'
-                : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'
+                ? 'border-primary/40 bg-accent text-accent-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground hover:bg-accent/50'
               }
             `}
           >

--- a/desktop/src/renderer/src/components/brand/VoiceClawMark.tsx
+++ b/desktop/src/renderer/src/components/brand/VoiceClawMark.tsx
@@ -1,0 +1,76 @@
+import type { SVGProps } from 'react'
+
+export function VoiceClawMark({
+  className,
+  accent = false,
+  ...props
+}: SVGProps<SVGSVGElement> & {
+  accent?: boolean
+}) {
+  return (
+    <svg
+      viewBox="0 0 64 64"
+      fill="none"
+      aria-hidden="true"
+      className={className}
+      {...props}
+    >
+      <path
+        d="M20 10 H14 V54 H20"
+        stroke="currentColor"
+        strokeWidth="4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M20 10 L27 17"
+        stroke="currentColor"
+        strokeWidth="4"
+        strokeLinecap="round"
+      />
+      <path
+        d="M20 54 L27 47"
+        stroke="currentColor"
+        strokeWidth="4"
+        strokeLinecap="round"
+      />
+      <path
+        d="M44 10 H50 V54 H44"
+        stroke="currentColor"
+        strokeWidth="4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M44 10 L37 17"
+        stroke="currentColor"
+        strokeWidth="4"
+        strokeLinecap="round"
+      />
+      <path
+        d="M44 54 L37 47"
+        stroke="currentColor"
+        strokeWidth="4"
+        strokeLinecap="round"
+      />
+      <path
+        d="M29 40 V24"
+        stroke={accent ? 'var(--brand-accent)' : 'currentColor'}
+        strokeWidth="4.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M35 46 V18"
+        stroke="currentColor"
+        strokeWidth="4.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M41 37 V27"
+        stroke="currentColor"
+        strokeWidth="4.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}

--- a/desktop/src/renderer/src/components/ui/Button.tsx
+++ b/desktop/src/renderer/src/components/ui/Button.tsx
@@ -10,7 +10,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const variantStyles: Record<Variant, string> = {
-  default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+  default: 'bg-primary text-primary-foreground hover:bg-[var(--brand-accent-hover)]',
   secondary: 'bg-muted text-foreground hover:bg-muted/80',
   destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
   ghost: 'hover:bg-accent hover:text-accent-foreground',
@@ -31,7 +31,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         ref={ref}
         disabled={disabled}
         className={cn(
-          'inline-flex items-center justify-center rounded-lg font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 disabled:opacity-50 disabled:pointer-events-none',
+          'inline-flex items-center justify-center rounded-md font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 disabled:opacity-50 disabled:pointer-events-none',
           variantStyles[variant],
           sizeStyles[size],
           className,

--- a/desktop/src/renderer/src/components/ui/Card.tsx
+++ b/desktop/src/renderer/src/components/ui/Card.tsx
@@ -5,7 +5,7 @@ interface CardProps extends HTMLAttributes<HTMLDivElement> {}
 export function Card({ className = '', ...props }: CardProps) {
   return (
     <div
-      className={`rounded-xl border border-border bg-card text-card-foreground ${className}`}
+      className={`rounded-md border border-border bg-card text-card-foreground vc-panel-shadow ${className}`}
       {...props}
     />
   )

--- a/desktop/src/renderer/src/components/ui/Input.tsx
+++ b/desktop/src/renderer/src/components/ui/Input.tsx
@@ -8,7 +8,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       <input
         ref={ref}
         className={`
-          w-full rounded-lg border border-input bg-background px-3 py-2 text-sm
+          w-full rounded-md border border-input bg-background px-3 py-2 text-sm
           text-foreground placeholder:text-muted-foreground
           focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary/50
           disabled:opacity-50 disabled:cursor-not-allowed

--- a/desktop/src/renderer/src/components/ui/Select.tsx
+++ b/desktop/src/renderer/src/components/ui/Select.tsx
@@ -8,7 +8,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
       <select
         ref={ref}
         className={`
-          w-full rounded-lg border border-input bg-background px-3 py-2 text-sm
+          w-full rounded-md border border-input bg-background px-3 py-2 text-sm
           text-foreground appearance-none cursor-pointer
           focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary/50
           disabled:opacity-50 disabled:cursor-not-allowed

--- a/desktop/src/renderer/src/index.css
+++ b/desktop/src/renderer/src/index.css
@@ -4,42 +4,114 @@
 
 @layer base {
   :root {
-    --background: #ffffff;
-    --foreground: #0a0a0a;
-    --card: #ffffff;
-    --card-foreground: #0a0a0a;
-    --primary: #18181b;
-    --primary-foreground: #fafafa;
-    --muted: #f4f4f5;
-    --muted-foreground: #71717a;
-    --border: #e4e4e7;
-    --input: #e4e4e7;
+    color-scheme: light;
+    --brand-paper: #f1e8da;
+    --brand-paper-strong: #e8ddcd;
+    --brand-panel: #fdf9f1;
+    --brand-panel-strong: #ffffff;
+    --brand-ink: #191511;
+    --brand-muted: #665f58;
+    --brand-accent: #b4492f;
+    --brand-accent-hover: #963a25;
+    --brand-accent-wash: rgba(180, 73, 47, 0.14);
+    --brand-sage: #697668;
+    --brand-sage-wash: rgba(105, 118, 104, 0.15);
+    --brand-line: rgba(25, 21, 17, 0.1);
+    --brand-line-strong: rgba(25, 21, 17, 0.2);
+    --brand-shadow: 0 18px 40px rgba(25, 21, 17, 0.08);
+    --brand-grid-line: rgba(25, 21, 17, 0.055);
+    --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --font-serif: Fraunces, Georgia, ui-serif, serif;
+    --font-mono: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+    --background: var(--brand-paper);
+    --foreground: var(--brand-ink);
+    --card: var(--brand-panel);
+    --card-foreground: var(--brand-ink);
+    --primary: var(--brand-accent);
+    --primary-foreground: #fffaf2;
+    --muted: var(--brand-paper-strong);
+    --muted-foreground: var(--brand-muted);
+    --border: var(--brand-line-strong);
+    --input: var(--brand-line-strong);
     --destructive: #ef4444;
     --destructive-foreground: #fafafa;
-    --accent: #f4f4f5;
-    --accent-foreground: #18181b;
+    --accent: var(--brand-accent-wash);
+    --accent-foreground: var(--brand-accent);
   }
 
   .dark {
-    --background: #0a0a0a;
-    --foreground: #fafafa;
-    --card: #111111;
-    --card-foreground: #fafafa;
-    --primary: #fafafa;
-    --primary-foreground: #18181b;
-    --muted: #1a1a1a;
-    --muted-foreground: #a1a1aa;
-    --border: #27272a;
-    --input: #27272a;
+    color-scheme: dark;
+    --brand-paper: #171310;
+    --brand-paper-strong: #211b16;
+    --brand-panel: #211b16;
+    --brand-panel-strong: #2c251f;
+    --brand-ink: #f5eadc;
+    --brand-muted: #b9aa98;
+    --brand-accent: #d86a4d;
+    --brand-accent-hover: #ef8668;
+    --brand-accent-wash: rgba(216, 106, 77, 0.18);
+    --brand-sage: #9cac99;
+    --brand-sage-wash: rgba(156, 172, 153, 0.18);
+    --brand-line: rgba(245, 234, 220, 0.1);
+    --brand-line-strong: rgba(245, 234, 220, 0.2);
+    --brand-shadow: 0 18px 40px rgba(0, 0, 0, 0.24);
+    --brand-grid-line: rgba(245, 234, 220, 0.055);
+    --background: var(--brand-paper);
+    --foreground: var(--brand-ink);
+    --card: var(--brand-panel);
+    --card-foreground: var(--brand-ink);
+    --primary: var(--brand-accent);
+    --primary-foreground: #171310;
+    --muted: var(--brand-paper-strong);
+    --muted-foreground: var(--brand-muted);
+    --border: var(--brand-line-strong);
+    --input: var(--brand-line-strong);
     --destructive: #ef4444;
     --destructive-foreground: #fafafa;
-    --accent: #27272a;
-    --accent-foreground: #fafafa;
+    --accent: var(--brand-accent-wash);
+    --accent-foreground: var(--brand-accent);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not(.light) {
+      color-scheme: dark;
+      --brand-paper: #171310;
+      --brand-paper-strong: #211b16;
+      --brand-panel: #211b16;
+      --brand-panel-strong: #2c251f;
+      --brand-ink: #f5eadc;
+      --brand-muted: #b9aa98;
+      --brand-accent: #d86a4d;
+      --brand-accent-hover: #ef8668;
+      --brand-accent-wash: rgba(216, 106, 77, 0.18);
+      --brand-sage: #9cac99;
+      --brand-sage-wash: rgba(156, 172, 153, 0.18);
+      --brand-line: rgba(245, 234, 220, 0.1);
+      --brand-line-strong: rgba(245, 234, 220, 0.2);
+      --brand-shadow: 0 18px 40px rgba(0, 0, 0, 0.24);
+      --brand-grid-line: rgba(245, 234, 220, 0.055);
+      --background: var(--brand-paper);
+      --foreground: var(--brand-ink);
+      --card: var(--brand-panel);
+      --card-foreground: var(--brand-ink);
+      --primary: var(--brand-accent);
+      --primary-foreground: #171310;
+      --muted: var(--brand-paper-strong);
+      --muted-foreground: var(--brand-muted);
+      --border: var(--brand-line-strong);
+      --input: var(--brand-line-strong);
+      --accent: var(--brand-accent-wash);
+      --accent-foreground: var(--brand-accent);
+    }
   }
 
   body {
     @apply bg-background text-foreground antialiased;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    background-image:
+      linear-gradient(var(--brand-grid-line) 1px, transparent 1px),
+      linear-gradient(90deg, var(--brand-grid-line) 1px, transparent 1px);
+    background-size: 28px 28px;
+    font-family: var(--font-sans);
     margin: 0;
     overflow: hidden;
   }
@@ -52,6 +124,29 @@
   .no-drag {
     -webkit-app-region: no-drag;
   }
+
+  ::selection {
+    background: var(--brand-accent-wash);
+    color: var(--brand-ink);
+  }
+}
+
+.vc-font-serif {
+  font-family: var(--font-serif);
+}
+
+.vc-font-mono {
+  font-family: var(--font-mono);
+}
+
+.vc-window-surface {
+  background:
+    radial-gradient(circle at top left, var(--brand-sage-wash), transparent 30%),
+    var(--background);
+}
+
+.vc-panel-shadow {
+  box-shadow: var(--brand-shadow);
 }
 
 @keyframes thinking-bounce {

--- a/desktop/src/renderer/src/lib/use-theme.ts
+++ b/desktop/src/renderer/src/lib/use-theme.ts
@@ -3,9 +3,10 @@ import { useCallback, useEffect, useState } from 'react'
 export type Theme = 'dark' | 'light' | 'system'
 
 const THEME_KEY = 'theme'
+const DEFAULT_THEME: Theme = 'system'
 
 export function useTheme() {
-  const [theme, setThemeState] = useState<Theme>('dark')
+  const [theme, setThemeState] = useState<Theme>(DEFAULT_THEME)
 
   const applyTheme = useCallback((t: Theme) => {
     const isDark =
@@ -25,13 +26,13 @@ export function useTheme() {
 
   useEffect(() => {
     const saved = localStorage.getItem(THEME_KEY) as Theme | null
-    const initial = saved || 'dark'
+    const initial = saved || DEFAULT_THEME
     setThemeState(initial)
     applyTheme(initial)
 
     const mq = window.matchMedia('(prefers-color-scheme: dark)')
     const handler = () => {
-      const current = (localStorage.getItem(THEME_KEY) as Theme) || 'dark'
+      const current = (localStorage.getItem(THEME_KEY) as Theme) || DEFAULT_THEME
       if (current === 'system') applyTheme('system')
     }
     mq.addEventListener('change', handler)

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -4,6 +4,7 @@ import { Button } from '../components/ui/Button'
 import { MessageBubble } from '../components/MessageBubble'
 import { ThinkingDots } from '../components/ThinkingDots'
 import { AudioLevelMeter } from '../components/AudioLevelMeter'
+import { VoiceClawMark } from '../components/brand/VoiceClawMark'
 import { ScreenSharePicker } from '../components/ScreenSharePicker'
 import { ScreenCapture, type ScreenSource } from '../lib/screen-capture'
 import { useRealtime, type RealtimeCallbacks } from '../lib/use-realtime'
@@ -306,7 +307,7 @@ export function ChatPage() {
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-border">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-background/65 backdrop-blur">
         <div className="text-sm text-muted-foreground">
           {messages.length > 0
             ? `${messages.length} messages`
@@ -321,10 +322,14 @@ export function ChatPage() {
       {/* Messages */}
       <div className="flex-1 overflow-y-auto px-4 py-4">
         {messages.length === 0 && !isCallActive && (
-          <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
-            <div className="text-4xl mb-4">🎙</div>
-            <p className="text-lg font-medium">VoiceClaw Desktop</p>
-            <p className="text-sm mt-1">Press the call button to start a voice conversation</p>
+          <div className="flex h-full flex-col items-center justify-center text-center text-muted-foreground">
+            <div className="mb-5 flex size-16 items-center justify-center rounded-md border border-border bg-card text-foreground vc-panel-shadow">
+              <VoiceClawMark className="size-10" accent />
+            </div>
+            <p className="vc-font-serif text-2xl leading-none text-foreground">VoiceClaw Desktop</p>
+            <p className="mt-3 max-w-sm text-sm leading-6">
+              Start a call to speak with your agent through the precise voice layer.
+            </p>
           </div>
         )}
         {messages.map((msg) => (
@@ -335,10 +340,10 @@ export function ChatPage() {
           <div className={`flex ${streamingRole === 'user' ? 'justify-end' : 'justify-start'} mb-3`}>
             <div
               className={`
-                max-w-[80%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed
+                max-w-[80%] rounded-md px-4 py-2.5 text-sm leading-relaxed
                 ${streamingRole === 'user'
-                  ? 'bg-primary text-primary-foreground rounded-br-md'
-                  : 'bg-muted text-foreground rounded-bl-md'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-card text-foreground border border-border'
                 }
               `}
             >
@@ -350,7 +355,7 @@ export function ChatPage() {
         {/* Thinking indicator */}
         {isThinking && !streamingText && (
           <div className="flex justify-start mb-3">
-            <div className="bg-muted rounded-2xl rounded-bl-md px-4 py-2.5">
+            <div className="rounded-md border border-border bg-card px-4 py-2.5">
               <ThinkingDots />
             </div>
           </div>
@@ -360,7 +365,7 @@ export function ChatPage() {
 
       {/* Screen sharing indicator */}
       {isScreenSharing && (
-        <div className="px-4 py-1.5 flex items-center gap-2 text-xs text-green-500">
+        <div className="px-4 py-1.5 flex items-center gap-2 text-xs text-[var(--brand-sage)]">
           <Monitor size={14} />
           <span className="truncate">Sharing: {screenSourceName}</span>
           <button
@@ -391,7 +396,7 @@ export function ChatPage() {
         {!isCallActive && !isConnecting ? (
           <Button
             onClick={startCall}
-            className="bg-green-500 hover:bg-green-600 text-white px-6"
+            className="px-6"
           >
             <Phone size={18} className="mr-2" />
             Start Call
@@ -411,7 +416,7 @@ export function ChatPage() {
                 variant="ghost"
                 size="icon"
                 onClick={isScreenSharing ? stopScreenShare : () => setShowScreenPicker(true)}
-                className={isScreenSharing ? 'text-green-500' : screenShareDisabled ? 'text-muted-foreground opacity-50' : 'text-foreground'}
+                className={isScreenSharing ? 'text-[var(--brand-sage)]' : screenShareDisabled ? 'text-muted-foreground opacity-50' : 'text-foreground'}
                 disabled={screenShareDisabled}
               >
                 {isScreenSharing ? <MonitorOff size={20} /> : <Monitor size={20} />}
@@ -429,7 +434,7 @@ export function ChatPage() {
               <span className="text-sm text-muted-foreground animate-pulse">Connecting...</span>
             )}
             {realtime.isReconnecting && (
-              <span className="text-sm text-yellow-500 animate-pulse">Reconnecting...</span>
+              <span className="text-sm text-[var(--brand-sage)] animate-pulse">Reconnecting...</span>
             )}
           </>
         )}

--- a/desktop/src/renderer/src/pages/HistoryPage.tsx
+++ b/desktop/src/renderer/src/pages/HistoryPage.tsx
@@ -85,7 +85,7 @@ export function HistoryPage({ isVisible, onNavigateToChat }: HistoryPageProps) {
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 border-b border-border">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-background/65 backdrop-blur">
         <div className="text-sm text-muted-foreground">
           {conversations.length} conversation{conversations.length === 1 ? '' : 's'}
         </div>
@@ -131,7 +131,7 @@ export function HistoryPage({ isVisible, onNavigateToChat }: HistoryPageProps) {
                         e.stopPropagation()
                         handleDelete(conv.id, getDisplayTitle(conv))
                       }}
-                      className="opacity-0 group-hover:opacity-100 p-1 rounded text-muted-foreground hover:text-destructive transition-all"
+                      className="opacity-0 group-hover:opacity-100 p-1 rounded-md text-muted-foreground hover:text-destructive transition-all"
                     >
                       <Trash2 size={14} />
                     </button>

--- a/desktop/src/renderer/src/pages/SettingsPage.tsx
+++ b/desktop/src/renderer/src/pages/SettingsPage.tsx
@@ -236,8 +236,8 @@ export function SettingsPage() {
                 <button
                   key={m}
                   onClick={() => updateModel(m)}
-                  className={`w-full flex items-center gap-3 rounded-lg border px-3 py-2 text-left transition-colors
-                    ${model === m ? 'border-primary bg-primary/10' : 'border-input'}
+                  className={`w-full flex items-center gap-3 rounded-md border px-3 py-2 text-left transition-colors
+                    ${model === m ? 'border-primary bg-accent' : 'border-input'}
                     hover:bg-accent cursor-pointer
                   `}
                 >
@@ -263,8 +263,8 @@ export function SettingsPage() {
               <button
                 key={v}
                 onClick={() => updateVoice(v)}
-                className={`rounded-lg border px-3 py-2 text-sm text-left transition-colors
-                  ${voice === v ? 'border-primary bg-primary/10 font-medium text-foreground' : 'border-input text-muted-foreground hover:bg-accent'}
+                className={`rounded-md border px-3 py-2 text-sm text-left transition-colors
+                  ${voice === v ? 'border-primary bg-accent font-medium text-foreground' : 'border-input text-muted-foreground hover:bg-accent'}
                 `}
               >
                 {model.startsWith('gemini-')
@@ -339,8 +339,8 @@ export function SettingsPage() {
               <button
                 key={t}
                 onClick={() => setTheme(t)}
-                className={`flex-1 rounded-lg border px-3 py-2 text-sm capitalize transition-colors
-                  ${theme === t ? 'border-primary bg-primary/10 font-medium text-foreground' : 'border-input text-muted-foreground hover:bg-accent'}
+                className={`flex-1 rounded-md border px-3 py-2 text-sm capitalize transition-colors
+                  ${theme === t ? 'border-primary bg-accent font-medium text-foreground' : 'border-input text-muted-foreground hover:bg-accent'}
                 `}
               >
                 {t}
@@ -382,7 +382,7 @@ export function SettingsPage() {
         <Card className="p-4 space-y-2 text-xs text-muted-foreground">
           <p className="font-medium">Setup</p>
           <ol className="list-decimal list-inside space-y-0.5">
-            <li>Start the relay server: <code className="bg-muted px-1 py-0.5 rounded">cd relay-server && yarn dev</code></li>
+            <li>Start the relay server: <code className="rounded bg-muted px-1 py-0.5">cd relay-server && yarn dev</code></li>
             <li>Enter the relay server URL shown on startup</li>
             <li>Enter your API key for authentication</li>
             <li>Click Test to verify the connection</li>
@@ -422,8 +422,8 @@ function ConnectionStatus({
   onTest: () => void
 }) {
   return (
-    <div className={`flex items-center justify-between rounded-lg border px-3 py-2
-      ${status === 'ok' ? 'border-green-500/30 bg-green-500/5'
+    <div className={`flex items-center justify-between rounded-md border px-3 py-2
+      ${status === 'ok' ? 'border-[var(--brand-sage)] bg-[var(--brand-sage-wash)]'
         : status === 'error' ? 'border-destructive/50 bg-destructive/5'
         : 'border-input'}
     `}>
@@ -431,12 +431,12 @@ function ConnectionStatus({
         {status === 'testing' ? (
           <div className="h-4 w-4 border-2 border-muted-foreground border-t-transparent rounded-full animate-spin" />
         ) : status === 'ok' ? (
-          <Wifi size={16} className="text-green-500" />
+          <Wifi size={16} className="text-[var(--brand-sage)]" />
         ) : (
           <WifiOff size={16} className={status === 'error' ? 'text-destructive' : 'text-muted-foreground'} />
         )}
         <span className={`text-sm ${
-          status === 'ok' ? 'text-green-500'
+          status === 'ok' ? 'text-[var(--brand-sage)]'
           : status === 'error' ? 'text-destructive'
           : 'text-muted-foreground'
         }`}>

--- a/website/src/app/brand/page.tsx
+++ b/website/src/app/brand/page.tsx
@@ -51,7 +51,7 @@ const SURFACE_NOTES = [
   },
   {
     title: "Desktop",
-    description: "Respect system preference, keep panels compact, and reserve rust for active routing.",
+    description: "Respect system preference, keep panels compact, use rust wash for navigation, and reserve solid rust for calls or live signal.",
   },
   {
     title: "Mobile",
@@ -209,7 +209,7 @@ export default function BrandGuidelinesPage() {
       <GuidelineSection
         eyebrow="05"
         title="Dark mode direction"
-        description="The website follows system preference with a warm dark palette, not blue-black SaaS chrome."
+        description="Website and platform apps follow system preference with a warm dark palette, not blue-black SaaS chrome."
         icon={<Moon className="size-5" />}
       >
         <div className="grid gap-3 md:grid-cols-3">
@@ -284,7 +284,7 @@ export default function BrandGuidelinesPage() {
           />
           <ImplementationCard
             title="Desktop"
-            description="Respect system preference and keep controls compact."
+            description="Default to system theme, keep controls compact, and use sage for calm connection state."
           />
           <ImplementationCard
             title="Mobile"


### PR DESCRIPTION
## Summary
- Apply the Editorial Quiet brand tokens, mark, compact radii, and warm light/dark surfaces to the desktop renderer
- Default desktop theme behavior to system preference while preserving explicit light/dark settings
- Update the brand guidelines page with desktop-specific platform decisions

## Test plan
- [x] `yarn install --immutable`
- [x] `cd desktop && yarn typecheck`
- [x] `cd desktop && yarn build`
- [x] `yarn lint:web`
- [x] `yarn build:web`
- [x] Served the built renderer and verified light/dark system classes and token values with Playwright
- [x] Captured Playwright screenshots for chat and settings in light/dark renderer previews

## External design review
- Claude Code reviewed the desktop diff, flagged active navigation overusing solid rust, reconnecting semantics, and a possible light-theme concern; solid rust nav was changed to rust wash, reconnecting was changed to sage, and Playwright verified explicit light mode wins via `.light` on a dark-system media path.
- Gemini reviewed the desktop diff, confirmed the radius/color direction, and flagged a CSS media query issue that was not present in the actual file; the media query and final build were rechecked.
- Claude Code final re-review: LGTM, with residual non-blocking notes around optional Fraunces loading, duplicated dark token declarations, and the intentional calm reconnecting state.

Stacked after #193. References NAN-665.
