### PR TITLE
Fix electron-builder mac.identity — drop Developer ID Application prefix

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -21,8 +21,11 @@ mac:
       arch:
         - universal
 
-  # Identity string matches `security find-identity`.
-  identity: "Developer ID Application: Nano 3 Labs Ltd (HN6T5KD4ND)"
+  # electron-builder takes the CN suffix only — "Nano 3 Labs Ltd (HN6T5KD4ND)"
+  # — and infers the "Developer ID Application: " prefix itself. Including the
+  # prefix here makes it reject every cert with "identity not found", which
+  # silently breaks signing (the build finishes but the .app is unsigned).
+  identity: "Nano 3 Labs Ltd (HN6T5KD4ND)"
 
   # Hardened Runtime + entitlements are required for notarization.
   hardenedRuntime: true


### PR DESCRIPTION
## Summary

- `mac.identity` had `"Developer ID Application: Nano 3 Labs Ltd (HN6T5KD4ND)"` — electron-builder prepends that prefix itself and rejected the value, resulting in silently-unsigned .app bundles even when the build reported success
- Changed to `"Nano 3 Labs Ltd (HN6T5KD4ND)"` — the CN suffix only
- Verified: re-ran `yarn dist:mac` locally and got a fully signed + notarized + stapled 206 MB universal DMG

## Why

Hit this when debugging a local build. The cert is present (`security find-identity -v -p codesigning` lists it), but electron-builder's lookup never matched because the prefix was doubled. No error was raised — the .app just came out unsigned, which cascaded into failed notarization + stapling.

## Follow-ups (separate PRs, intentionally not in scope)

1. **DMG wrapper signing** — electron-builder signs the inner .app but leaves the DMG wrapper unsigned. Currently patched manually post-build; needs `dmg.sign` config or a post-build hook so CI produces a fully verifiable DMG.
2. **APPLE_TEAM_ID deprecation** — `notarize.teamId: HN6T5KD4ND` is deprecated; move to the `APPLE_TEAM_ID` env var.

## Test plan

- [x] Local `yarn dist:mac` succeeds with signed .app
- [x] `codesign --verify --deep --strict` passes on the .app
- [x] `xcrun stapler validate` confirms notarization ticket stapled
- [x] `spctl -a -t open` → accepted, source=Notarized Developer ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)