### PR TITLE
Point Mac download CTA to latest DMG (NAN-669)

### DIFF
--- a/website/src/app/api/download/mac/route.ts
+++ b/website/src/app/api/download/mac/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server"
+import {
+  getLatestMacReleaseDownload,
+  getMacDownloadFallbackUrl,
+} from "@/lib/downloads"
+
+export async function GET() {
+  const release = await getLatestMacReleaseDownload()
+
+  return NextResponse.redirect(
+    release?.downloadUrl ?? getMacDownloadFallbackUrl(),
+    307,
+  )
+}

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -19,31 +19,41 @@ import {
   VoiceClawMark,
 } from "@/components/brand/brand-system"
 import { ThemeSwitcher } from "@/components/theme-switcher"
+import {
+  getLatestMacReleaseDownload,
+  type MacReleaseDownload,
+} from "@/lib/downloads"
 
 const REPO_URL = "https://github.com/yagudaev/voiceclaw"
-const MAC_DOWNLOAD_URL = "https://github.com/yagudaev/voiceclaw/releases"
+const MAC_DOWNLOAD_URL = "/api/download/mac"
 const TESTFLIGHT_SIGNUP_URL = ""
 const DEMO_EMBED_URL = "https://www.youtube.com/embed/iAS7vj2vRaA"
 const HERO_BARS = [26, 44, 58, 42, 24, 34, 52, 78, 50, 31, 66, 86, 60, 38, 54, 82, 48, 72]
 
-export default function Home() {
+export default async function Home() {
+  const macRelease = await getLatestMacReleaseDownload()
+
   return (
     <div className="min-h-screen text-[var(--brand-ink)]">
-      <Header />
+      <Header macRelease={macRelease} />
       <main>
-        <HeroSection />
+        <HeroSection macRelease={macRelease} />
         <DemoSection />
         <ProofSection />
         <WorkflowSection />
         <PlatformSection />
-        <GetStartedSection />
+        <GetStartedSection macRelease={macRelease} />
       </main>
       <Footer />
     </div>
   )
 }
 
-function Header() {
+function Header({
+  macRelease,
+}: {
+  macRelease: MacReleaseDownload | null
+}) {
   return (
     <header className="sticky top-0 z-50 border-b border-[var(--brand-line-strong)] bg-[var(--brand-paper)]/90 backdrop-blur-md">
       <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-5 sm:px-8">
@@ -57,10 +67,8 @@ function Header() {
           <ThemeSwitcher />
           <a
             href={MAC_DOWNLOAD_URL}
-            target="_blank"
-            rel="noopener noreferrer"
             aria-label="Download for Mac"
-            title="Download for Mac"
+            title={downloadTitle(macRelease)}
             className="inline-flex items-center gap-2 rounded-md border border-[var(--brand-line-strong)] bg-[var(--brand-panel)] px-3 py-2 text-[var(--brand-ink)] shadow-[var(--brand-shadow)] transition hover:border-[var(--brand-accent)]"
           >
             <Download className="size-4" />
@@ -72,7 +80,11 @@ function Header() {
   )
 }
 
-function HeroSection() {
+function HeroSection({
+  macRelease,
+}: {
+  macRelease: MacReleaseDownload | null
+}) {
   return (
     <section className="relative isolate overflow-hidden border-b border-[var(--brand-line-strong)] bg-[var(--brand-paper)]">
       <div className="brand-hero-field absolute inset-0" />
@@ -97,8 +109,7 @@ function HeroSection() {
             <div className="mt-9 flex flex-col gap-3 sm:flex-row">
               <a
                 href={MAC_DOWNLOAD_URL}
-                target="_blank"
-                rel="noopener noreferrer"
+                title={downloadTitle(macRelease)}
                 className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-[var(--brand-accent)] px-5 text-sm font-semibold text-primary-foreground transition hover:bg-[var(--brand-accent-hover)]"
               >
                 <Download className="size-4" />
@@ -112,7 +123,8 @@ function HeroSection() {
                 Watch demo
               </Link>
             </div>
-            <p className="mt-4 max-w-xl text-sm leading-6 text-[var(--brand-muted)]">
+            <MacDownloadVersion release={macRelease} />
+            <p className="mt-3 max-w-xl text-sm leading-6 text-[var(--brand-muted)]">
               <TestFlightSignupNotice />
             </p>
             <div className="mt-8 lg:hidden">
@@ -344,7 +356,11 @@ function PlatformSection() {
   )
 }
 
-function GetStartedSection() {
+function GetStartedSection({
+  macRelease,
+}: {
+  macRelease: MacReleaseDownload | null
+}) {
   return (
     <section className="bg-[var(--brand-contrast-bg)] px-5 py-20 text-[var(--brand-contrast-fg)] sm:px-8">
       <div className="mx-auto grid max-w-7xl gap-10 lg:grid-cols-[minmax(0,1fr)_360px]">
@@ -363,13 +379,13 @@ function GetStartedSection() {
         <div className="flex flex-col justify-end gap-3">
           <a
             href={MAC_DOWNLOAD_URL}
-            target="_blank"
-            rel="noopener noreferrer"
+            title={downloadTitle(macRelease)}
             className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-[var(--brand-contrast-fg)] px-5 text-sm font-semibold text-[var(--brand-contrast-bg)] transition hover:bg-[var(--brand-contrast-fg-hover)]"
           >
             <Download className="size-4" />
             Download for Mac
           </a>
+          <MacDownloadVersion release={macRelease} contrast />
           <a
             href={REPO_URL}
             target="_blank"
@@ -405,6 +421,40 @@ function Footer() {
         </div>
       </div>
     </footer>
+  )
+}
+
+function MacDownloadVersion({
+  release,
+  contrast = false,
+}: {
+  release: MacReleaseDownload | null
+  contrast?: boolean
+}) {
+  if (!release) {
+    return (
+      <p
+        className={`mt-3 font-mono text-xs ${
+          contrast
+            ? "text-[var(--brand-contrast-muted)]"
+            : "text-[var(--brand-muted)]"
+        }`}
+      >
+        Resolves to the latest Mac build.
+      </p>
+    )
+  }
+
+  return (
+    <p
+      className={`mt-3 font-mono text-xs ${
+        contrast
+          ? "text-[var(--brand-contrast-muted)]"
+          : "text-[var(--brand-muted)]"
+      }`}
+    >
+      Latest Mac build: {release.tagName} · {formatFileSize(release.size)}
+    </p>
   )
 }
 
@@ -586,4 +636,17 @@ function TranscriptBubble({
       <p className="mt-2 text-sm leading-6">{children}</p>
     </div>
   )
+}
+
+function downloadTitle(release: MacReleaseDownload | null) {
+  if (!release) {
+    return "Download latest Mac build"
+  }
+
+  return `Download ${release.tagName} for Mac`
+}
+
+function formatFileSize(size: number) {
+  const megabytes = size / 1024 / 1024
+  return `${Math.round(megabytes)} MB`
 }

--- a/website/src/lib/downloads.ts
+++ b/website/src/lib/downloads.ts
@@ -1,0 +1,95 @@
+const GITHUB_RELEASES_API =
+  "https://api.github.com/repos/yagudaev/voiceclaw/releases"
+const RELEASES_FALLBACK_URL = "https://github.com/yagudaev/voiceclaw/releases"
+const RELEASE_REVALIDATE_SECONDS = 300
+
+type GitHubRelease = {
+  tag_name: string
+  name: string | null
+  html_url: string
+  draft: boolean
+  prerelease: boolean
+  assets: GitHubAsset[]
+}
+
+type GitHubAsset = {
+  name: string
+  browser_download_url: string
+  content_type: string
+  size: number
+}
+
+export type MacReleaseDownload = {
+  tagName: string
+  releaseName: string
+  releaseUrl: string
+  assetName: string
+  downloadUrl: string
+  size: number
+  isPrerelease: boolean
+}
+
+export async function getLatestMacReleaseDownload(): Promise<MacReleaseDownload | null> {
+  try {
+    const response = await fetch(GITHUB_RELEASES_API, {
+      headers: githubHeaders(),
+      next: {
+        revalidate: RELEASE_REVALIDATE_SECONDS,
+      },
+    })
+
+    if (!response.ok) {
+      return null
+    }
+
+    const releases = (await response.json()) as GitHubRelease[]
+    for (const release of releases) {
+      if (release.draft) {
+        continue
+      }
+
+      const dmg = release.assets.find(isMacDmgAsset)
+      if (!dmg) {
+        continue
+      }
+
+      return {
+        tagName: release.tag_name,
+        releaseName: release.name ?? release.tag_name,
+        releaseUrl: release.html_url,
+        assetName: dmg.name,
+        downloadUrl: dmg.browser_download_url,
+        size: dmg.size,
+        isPrerelease: release.prerelease,
+      }
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+export function getMacDownloadFallbackUrl() {
+  return RELEASES_FALLBACK_URL
+}
+
+function isMacDmgAsset(asset: GitHubAsset) {
+  return (
+    asset.name.toLowerCase().endsWith(".dmg") ||
+    asset.content_type === "application/x-apple-diskimage"
+  )
+}
+
+function githubHeaders() {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  }
+
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`
+  }
+
+  return headers
+}


### PR DESCRIPTION
## Summary
- Add a stable `/api/download/mac` redirect that resolves the latest GitHub release containing a DMG.
- Point all website Mac download CTAs to the stable route and show the resolved latest Mac build version.
- Fall back to the GitHub releases page if no DMG release is available.

## Test plan
- [x] `cd website && yarn lint`
- [x] `cd website && yarn build`
- [x] `curl -I http://localhost:3000/api/download/mac` redirects to `v0.1.0-alpha.1` DMG
- [x] Verified the page renders `Latest Mac build: v0.1.0-alpha.1 · 206 MB`