### PR TITLE
feat(desktop): wire onboarding wizard to first-run + SQLite resume

### DIFF
--- a/desktop/src/main/auth.ts
+++ b/desktop/src/main/auth.ts
@@ -1,0 +1,131 @@
+import { app, net, safeStorage, shell } from 'electron'
+import { getDb } from './db'
+import { ensureOnboardingSchema } from './onboarding'
+import { getMainWindow } from './window-lifecycle'
+
+// Desktop sign-in flow:
+//
+//   1. Renderer asks main to start sign-in. We open the browser to
+//      https://getvoiceclaw.com/api/auth/google/start?target=desktop.
+//   2. Browser completes Google OAuth, the website redirects back to
+//      voiceclaw://auth/callback?ticket=…
+//   3. macOS hands the URL to this process via the open-url event. We
+//      POST the ticket to /api/auth/ticket/redeem and persist the
+//      returned device token in SQLite (encrypted with safeStorage).
+//   4. Renderer is notified via `onboarding:auth-callback` so the
+//      wizard can mark the user as signed-in and advance.
+
+export const DEEP_LINK_SCHEME = 'voiceclaw'
+const DEFAULT_AUTH_BASE_URL = 'https://getvoiceclaw.com'
+
+export function registerAuthDeepLink(): void {
+  // Register the custom scheme with macOS. argv handling for non-mac
+  // platforms is unused for now.
+  if (process.defaultApp) {
+    if (process.argv.length >= 2) {
+      app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME, process.execPath, [
+        process.argv[1] ?? '',
+      ])
+    }
+  } else {
+    app.setAsDefaultProtocolClient(DEEP_LINK_SCHEME)
+  }
+
+  app.on('open-url', (event, url) => {
+    event.preventDefault()
+    void handleDeepLink(url).catch((err) => {
+      console.warn('[auth] deep-link handler failed', err)
+    })
+  })
+}
+
+export function startSignInFlow(provider: 'google' | 'apple' = 'google'): void {
+  const base = process.env.VOICECLAW_AUTH_BASE_URL ?? DEFAULT_AUTH_BASE_URL
+  const url = `${base}/api/auth/${provider}/start?target=desktop`
+  void shell.openExternal(url)
+}
+
+async function handleDeepLink(rawUrl: string): Promise<void> {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    return
+  }
+  if (parsed.protocol.replace(':', '') !== DEEP_LINK_SCHEME) return
+  // path is "/auth/callback" or similar; we accept anything ending in
+  // /auth/callback for forward compatibility.
+  const isAuthCallback =
+    parsed.host === 'auth' && parsed.pathname.startsWith('/callback')
+  if (!isAuthCallback) return
+  const ticket = parsed.searchParams.get('ticket')
+  const error = parsed.searchParams.get('error')
+
+  const window = getMainWindow()
+  if (error || !ticket) {
+    window?.webContents.send('onboarding:auth-callback', {
+      ok: false,
+      error: error ?? 'missing_ticket',
+    })
+    return
+  }
+
+  try {
+    const result = await redeemTicket(ticket)
+    window?.webContents.send('onboarding:auth-callback', {
+      ok: true,
+      user: result.user,
+    })
+  } catch (err) {
+    window?.webContents.send('onboarding:auth-callback', {
+      ok: false,
+      error: err instanceof Error ? err.message : 'unknown_error',
+    })
+  }
+}
+
+async function redeemTicket(ticket: string): Promise<{
+  user: { id?: string; email?: string | null; name?: string | null } | null
+}> {
+  const base = process.env.VOICECLAW_AUTH_BASE_URL ?? DEFAULT_AUTH_BASE_URL
+  const response = await net.fetch(`${base}/api/auth/ticket/redeem`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ticket, platform: 'desktop-macos', label: 'VoiceClaw Desktop' }),
+  })
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    throw new Error(`redeem_failed_${response.status}: ${text.slice(0, 120)}`)
+  }
+  const body = (await response.json()) as {
+    token: string
+    device: { id: string; label: string | null; platform: string | null }
+    user: { id: string; email: string | null; name: string | null } | null
+  }
+
+  ensureOnboardingSchema()
+  if (!safeStorage.isEncryptionAvailable()) {
+    throw new Error('safeStorage_unavailable')
+  }
+  const tokenEnc = safeStorage.encryptString(body.token)
+  const db = getDb()
+  db.prepare(
+    `INSERT INTO devices (id, user_id, user_email, user_name, token_enc, platform, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       user_id = excluded.user_id,
+       user_email = excluded.user_email,
+       user_name = excluded.user_name,
+       token_enc = excluded.token_enc,
+       platform = excluded.platform`,
+  ).run(
+    body.device.id,
+    body.user?.id ?? null,
+    body.user?.email ?? null,
+    body.user?.name ?? null,
+    tokenEnc,
+    body.device.platform ?? 'desktop-macos',
+    Date.now(),
+  )
+  return { user: body.user }
+}

--- a/desktop/src/main/brain-detect.ts
+++ b/desktop/src/main/brain-detect.ts
@@ -1,0 +1,60 @@
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+
+// Detect locally-installed brain CLIs (Claude, Codex) by shelling
+// `which`. The renderer surfaces detected entries on step 5 so the
+// user can pick a brain that already exists on their PATH instead of
+// the bundled OpenClaw.
+
+export type BrainDetection = {
+  openclaw: { available: true } // bundled — always shown
+  claude: { available: boolean; path?: string }
+  codex: { available: boolean; path?: string }
+}
+
+export async function detectBrains(): Promise<BrainDetection> {
+  const [claudePath, codexPath] = await Promise.all([whichSafe('claude'), whichSafe('codex')])
+  return {
+    openclaw: { available: true },
+    claude: claudePath
+      ? { available: true, path: claudePath }
+      : { available: false },
+    codex: codexPath ? { available: true, path: codexPath } : { available: false },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function whichSafe(name: string): Promise<string | null> {
+  // Sanitize: only allow alphanumerics + dashes + underscores. We'll
+  // pass this as an argv element to /usr/bin/which but defense-in-depth
+  // never hurts when shelling out.
+  if (!/^[a-zA-Z0-9_-]+$/.test(name)) return null
+  try {
+    const { stdout } = await execFileAsync('/usr/bin/which', [name], {
+      timeout: 1500,
+      env: {
+        ...process.env,
+        // Make sure homebrew paths resolve even when launched from
+        // login items where PATH is minimal.
+        PATH: [
+          '/opt/homebrew/bin',
+          '/usr/local/bin',
+          '/usr/bin',
+          '/bin',
+          process.env.PATH ?? '',
+        ]
+          .filter(Boolean)
+          .join(':'),
+      },
+    })
+    const trimmed = stdout.trim()
+    return trimmed.length > 0 ? trimmed : null
+  } catch {
+    return null
+  }
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -14,6 +14,8 @@ import { serviceManager } from './services/service-manager'
 import { startBundledOpenClaw } from './services/openclaw-gateway'
 import { ensureDefault as ensureLaunchAtLoginDefault } from './login-items'
 import { initAutoUpdater } from './updater'
+import { ensureOnboardingSchema, resetOnboarding } from './onboarding'
+import { registerAuthDeepLink } from './auth'
 
 const isDev = !app.isPackaged
 
@@ -28,6 +30,15 @@ app.on('second-instance', () => {
 })
 
 app.whenReady().then(async () => {
+  ensureOnboardingSchema()
+  // Dev escape hatch: VOICECLAW_RESET_ONBOARDING=1 yarn dev wipes the
+  // wizard cursor before window creation so the wizard reappears at
+  // step 1. Saved keys/devices stay intact.
+  if (isDev && process.env.VOICECLAW_RESET_ONBOARDING === '1') {
+    resetOnboarding()
+  }
+
+  registerAuthDeepLink()
   registerIpcHandlers()
   registerScreenCaptureHandlers()
 

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -1,8 +1,26 @@
-import { ipcMain, net } from 'electron'
+import { dialog, ipcMain, net, shell, systemPreferences } from 'electron'
 import { getDb } from './db'
 import { isLaunchAtLoginEnabled, setLaunchAtLogin } from './login-items'
 import { serviceManager } from './services/service-manager'
 import { getAllocatedPorts } from './ports'
+import {
+  type OnboardingPayload,
+  type WizardStepId,
+  getOnboardingState,
+  markOnboardingComplete,
+  resetOnboarding,
+  updateOnboardingStep,
+} from './onboarding'
+import {
+  type ProviderId,
+  geminiSmokeCall,
+  listConfiguredProviders,
+  setProviderKey,
+  validateProviderKey,
+} from './provider-keys'
+import { detectBrains } from './brain-detect'
+import { startSignInFlow } from './auth'
+import { getMainWindow } from './window-lifecycle'
 
 export function registerIpcHandlers() {
   // App lifecycle / system integration
@@ -154,6 +172,86 @@ export function registerIpcHandlers() {
     const rows = db.prepare('SELECT * FROM settings').all() as { key: string, value: string }[]
     return Object.fromEntries(rows.map((r) => [r.key, r.value]))
   })
+
+  // Onboarding state
+  ipcMain.handle('onboarding:getState', () => getOnboardingState())
+  ipcMain.handle(
+    'onboarding:updateStep',
+    (_e, step: WizardStepId, patch: OnboardingPayload | undefined) =>
+      updateOnboardingStep(step, patch ?? {}),
+  )
+  ipcMain.handle('onboarding:complete', () => markOnboardingComplete())
+  ipcMain.handle('onboarding:reset', async () => {
+    const window = getMainWindow()
+    const result = window
+      ? await dialog.showMessageBox(window, {
+          type: 'warning',
+          buttons: ['Start over', 'Cancel'],
+          defaultId: 1,
+          cancelId: 1,
+          title: 'Restart onboarding?',
+          message: 'Restart onboarding from step 1?',
+          detail:
+            'Saved API keys and sign-in remain in place — only the wizard cursor resets.',
+        })
+      : { response: 0 }
+    if (result.response !== 0) return { ok: false }
+    resetOnboarding()
+    return { ok: true, state: getOnboardingState() }
+  })
+  ipcMain.handle('onboarding:startSignIn', () => {
+    startSignInFlow('google')
+    return { ok: true }
+  })
+
+  // Permissions (macOS) — read + request mic / screen / accessibility.
+  ipcMain.handle('perm:getMediaStatus', (_e, kind: 'microphone' | 'screen') => {
+    if (process.platform !== 'darwin') return 'granted'
+    return systemPreferences.getMediaAccessStatus(kind)
+  })
+  ipcMain.handle('perm:requestMic', async () => {
+    if (process.platform !== 'darwin') return true
+    return systemPreferences.askForMediaAccess('microphone')
+  })
+  ipcMain.handle('perm:getAccessibility', () => {
+    if (process.platform !== 'darwin') return true
+    return systemPreferences.isTrustedAccessibilityClient(false)
+  })
+  ipcMain.handle('perm:openSettings', (_e, pane: 'mic' | 'screen' | 'accessibility') => {
+    if (process.platform !== 'darwin') return
+    const anchor =
+      pane === 'mic'
+        ? 'Privacy_Microphone'
+        : pane === 'screen'
+          ? 'Privacy_ScreenCapture'
+          : 'Privacy_Accessibility'
+    void shell.openExternal(`x-apple.systempreferences:com.apple.preference.security?${anchor}`)
+  })
+
+  // Provider keys + smoke test
+  ipcMain.handle('provider:listConfigured', () => listConfiguredProviders())
+  ipcMain.handle(
+    'provider:validateAndSave',
+    async (_e, provider: ProviderId, key: string) => {
+      const result = await validateProviderKey(provider, key)
+      if (!result.ok) return result
+      try {
+        setProviderKey(provider, key)
+        return { ok: true as const }
+      } catch (err) {
+        return {
+          ok: false as const,
+          error: err instanceof Error ? err.message : 'Could not save key.',
+        }
+      }
+    },
+  )
+  ipcMain.handle('provider:geminiSmoke', async (_e, prompt: string) => {
+    return geminiSmokeCall(prompt)
+  })
+
+  // Brain detection
+  ipcMain.handle('brain:detect', () => detectBrains())
 
   // Network: test relay server connection from main process (avoids CORS)
   ipcMain.handle('net:healthCheck', async (_e, url: string) => {

--- a/desktop/src/main/onboarding.ts
+++ b/desktop/src/main/onboarding.ts
@@ -1,0 +1,144 @@
+import { getDb } from './db'
+
+// Onboarding state — single-row table (id=1) capturing the wizard's
+// resume point and accumulated payload. Renderer reads on mount; if
+// completed_at is null, we show the wizard. Each step transition
+// merges a payload patch and bumps current_step so a quit-mid-flow
+// resumes cleanly.
+
+export type WizardStepId =
+  | 'welcome'
+  | 'signin'
+  | 'permissions'
+  | 'provider'
+  | 'brain'
+  | 'testcall'
+
+export type OnboardingPayload = {
+  signedIn?: boolean
+  permissions?: {
+    mic?: 'granted' | 'denied' | 'not-determined' | 'restricted' | 'unknown'
+    screen?: 'granted' | 'denied' | 'not-determined' | 'restricted' | 'unknown'
+    accessibility?: 'granted' | 'denied' | 'unknown'
+  }
+  provider?: 'gemini' | 'openai' | 'xai'
+  providerKeyValidated?: boolean
+  brain?: 'openclaw' | 'claude' | 'codex' | { url: string }
+  user?: { id?: string; email?: string | null; name?: string | null }
+}
+
+export type OnboardingState = {
+  currentStep: WizardStepId
+  payload: OnboardingPayload
+  completedAt: string | null
+}
+
+export function ensureOnboardingSchema(): void {
+  const db = getDb()
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS onboarding_state (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      current_step TEXT NOT NULL DEFAULT 'welcome',
+      payload TEXT NOT NULL DEFAULT '{}',
+      completed_at TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS provider_keys (
+      provider TEXT PRIMARY KEY,
+      key_enc BLOB NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS devices (
+      id TEXT PRIMARY KEY,
+      user_id TEXT,
+      user_email TEXT,
+      user_name TEXT,
+      token_enc BLOB NOT NULL,
+      platform TEXT,
+      created_at INTEGER NOT NULL
+    );
+  `)
+}
+
+export function getOnboardingState(): OnboardingState {
+  ensureOnboardingSchema()
+  const db = getDb()
+  const row = db
+    .prepare(
+      'SELECT current_step as currentStep, payload, completed_at as completedAt FROM onboarding_state WHERE id = 1',
+    )
+    .get() as { currentStep: WizardStepId; payload: string; completedAt: string | null } | undefined
+
+  if (!row) {
+    db.prepare(
+      "INSERT INTO onboarding_state (id, current_step, payload, completed_at) VALUES (1, 'welcome', '{}', NULL)",
+    ).run()
+    return { currentStep: 'welcome', payload: {}, completedAt: null }
+  }
+
+  return {
+    currentStep: row.currentStep,
+    payload: parsePayload(row.payload),
+    completedAt: row.completedAt,
+  }
+}
+
+export function updateOnboardingStep(
+  step: WizardStepId,
+  payloadPatch: OnboardingPayload = {},
+): OnboardingState {
+  ensureOnboardingSchema()
+  const current = getOnboardingState()
+  const merged = mergePayload(current.payload, payloadPatch)
+  const db = getDb()
+  db.prepare(
+    'UPDATE onboarding_state SET current_step = ?, payload = ? WHERE id = 1',
+  ).run(step, JSON.stringify(merged))
+  return { currentStep: step, payload: merged, completedAt: current.completedAt }
+}
+
+export function markOnboardingComplete(): OnboardingState {
+  ensureOnboardingSchema()
+  const completedAt = new Date().toISOString()
+  const db = getDb()
+  db.prepare('UPDATE onboarding_state SET completed_at = ? WHERE id = 1').run(completedAt)
+  return { ...getOnboardingState(), completedAt }
+}
+
+export function resetOnboarding(): OnboardingState {
+  ensureOnboardingSchema()
+  const db = getDb()
+  db.prepare('DELETE FROM onboarding_state').run()
+  // Don't wipe provider_keys / devices here — those are useful even if
+  // the user re-runs the wizard. Reset only the wizard's resume cursor.
+  return getOnboardingState()
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parsePayload(raw: string): OnboardingPayload {
+  try {
+    const parsed = JSON.parse(raw)
+    return typeof parsed === 'object' && parsed !== null ? (parsed as OnboardingPayload) : {}
+  } catch {
+    return {}
+  }
+}
+
+function mergePayload(
+  current: OnboardingPayload,
+  patch: OnboardingPayload,
+): OnboardingPayload {
+  return {
+    ...current,
+    ...patch,
+    permissions: patch.permissions
+      ? { ...(current.permissions ?? {}), ...patch.permissions }
+      : current.permissions,
+    user: patch.user ? { ...(current.user ?? {}), ...patch.user } : current.user,
+  }
+}

--- a/desktop/src/main/provider-keys.ts
+++ b/desktop/src/main/provider-keys.ts
@@ -1,0 +1,154 @@
+import { net, safeStorage } from 'electron'
+import { getDb } from './db'
+import { ensureOnboardingSchema } from './onboarding'
+
+// Provider API key vault. Keys are encrypted with Electron's
+// safeStorage (Keychain-backed on macOS) before they ever touch
+// SQLite. Plaintext only exists in memory transiently while we
+// validate the key with the upstream provider.
+
+export type ProviderId = 'gemini' | 'openai' | 'xai'
+
+export type ValidateKeyResult = { ok: true } | { ok: false; error: string; status?: number }
+
+export function setProviderKey(provider: ProviderId, plaintextKey: string): void {
+  ensureOnboardingSchema()
+  if (!safeStorage.isEncryptionAvailable()) {
+    throw new Error('safeStorage is not available — Keychain access denied?')
+  }
+  const enc = safeStorage.encryptString(plaintextKey)
+  const now = Date.now()
+  const db = getDb()
+  db.prepare(
+    `INSERT INTO provider_keys (provider, key_enc, created_at, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(provider) DO UPDATE SET key_enc = excluded.key_enc, updated_at = excluded.updated_at`,
+  ).run(provider, enc, now, now)
+}
+
+export function getProviderKey(provider: ProviderId): string | null {
+  ensureOnboardingSchema()
+  const db = getDb()
+  const row = db
+    .prepare('SELECT key_enc FROM provider_keys WHERE provider = ?')
+    .get(provider) as { key_enc: Buffer } | undefined
+  if (!row) return null
+  if (!safeStorage.isEncryptionAvailable()) return null
+  try {
+    return safeStorage.decryptString(row.key_enc)
+  } catch {
+    return null
+  }
+}
+
+export function listConfiguredProviders(): ProviderId[] {
+  ensureOnboardingSchema()
+  const db = getDb()
+  const rows = db.prepare('SELECT provider FROM provider_keys').all() as { provider: string }[]
+  return rows.map((r) => r.provider).filter(isProviderId)
+}
+
+export async function validateProviderKey(
+  provider: ProviderId,
+  key: string,
+): Promise<ValidateKeyResult> {
+  if (!key || key.length < 8) {
+    return { ok: false, error: 'Key looks too short.' }
+  }
+
+  try {
+    if (provider === 'gemini') {
+      const response = await net.fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(key)}`,
+        { method: 'GET' },
+      )
+      if (response.ok) return { ok: true }
+      return {
+        ok: false,
+        status: response.status,
+        error: keyErrorMessage(response.status),
+      }
+    }
+    if (provider === 'openai') {
+      const response = await net.fetch('https://api.openai.com/v1/models', {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${key}` },
+      })
+      if (response.ok) return { ok: true }
+      return {
+        ok: false,
+        status: response.status,
+        error: keyErrorMessage(response.status),
+      }
+    }
+    // xai uses an OpenAI-compatible endpoint
+    const response = await net.fetch('https://api.x.ai/v1/models', {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${key}` },
+    })
+    if (response.ok) return { ok: true }
+    return {
+      ok: false,
+      status: response.status,
+      error: keyErrorMessage(response.status),
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : 'Network error',
+    }
+  }
+}
+
+// Used by the smoke test on step 6: text-only generateContent against
+// Gemini using the saved key. Returns the model's reply text. If the
+// model errors, we surface the error message verbatim so the user can
+// see exactly what went wrong.
+//
+// TODO(voice-test-call): replace this with the real bidirectional Live
+// audio call (NAN-670). This function intentionally does not stream.
+export async function geminiSmokeCall(prompt: string): Promise<{ ok: true; text: string } | { ok: false; error: string }> {
+  const key = getProviderKey('gemini')
+  if (!key) return { ok: false, error: 'No Gemini key configured.' }
+
+  try {
+    const response = await net.fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${encodeURIComponent(key)}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [{ role: 'user', parts: [{ text: prompt }] }],
+          generationConfig: { temperature: 0.4, maxOutputTokens: 64 },
+        }),
+      },
+    )
+    if (!response.ok) {
+      const text = await response.text().catch(() => '')
+      return { ok: false, error: `Gemini ${response.status}: ${text.slice(0, 200)}` }
+    }
+    const body = (await response.json()) as {
+      candidates?: { content?: { parts?: { text?: string }[] } }[]
+    }
+    const text = body.candidates?.[0]?.content?.parts?.map((p) => p.text ?? '').join('').trim()
+    if (!text) return { ok: false, error: 'Empty response from Gemini.' }
+    return { ok: true, text }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'Network error' }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isProviderId(v: string): v is ProviderId {
+  return v === 'gemini' || v === 'openai' || v === 'xai'
+}
+
+function keyErrorMessage(status: number): string {
+  if (status === 401 || status === 403) return "That key doesn't look right."
+  if (status === 404) return 'Provider rejected the key (404).'
+  if (status === 429) return 'Rate limited — try again in a moment.'
+  return `Provider returned ${status}.`
+}

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,6 +1,35 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
 
 export type ElectronAPI = typeof electronAPI
+
+type WizardStepId =
+  | 'welcome'
+  | 'signin'
+  | 'permissions'
+  | 'provider'
+  | 'brain'
+  | 'testcall'
+
+type OnboardingPayload = {
+  signedIn?: boolean
+  permissions?: {
+    mic?: 'granted' | 'denied' | 'not-determined' | 'restricted' | 'unknown'
+    screen?: 'granted' | 'denied' | 'not-determined' | 'restricted' | 'unknown'
+    accessibility?: 'granted' | 'denied' | 'unknown'
+  }
+  provider?: 'gemini' | 'openai' | 'xai'
+  providerKeyValidated?: boolean
+  brain?: 'openclaw' | 'claude' | 'codex' | { url: string }
+  user?: { id?: string; email?: string | null; name?: string | null }
+}
+
+type OnboardingState = {
+  currentStep: WizardStepId
+  payload: OnboardingPayload
+  completedAt: string | null
+}
+
+type AuthCallback = { ok: true; user: { id?: string; email?: string | null; name?: string | null } | null } | { ok: false; error: string }
 
 const electronAPI = {
   platform: process.platform,
@@ -36,6 +65,52 @@ const electronAPI = {
     getSetting: (key: string) => ipcRenderer.invoke('db:getSetting', key),
     setSetting: (key: string, value: string) => ipcRenderer.invoke('db:setSetting', key, value),
     getAllSettings: () => ipcRenderer.invoke('db:getAllSettings'),
+  },
+  onboarding: {
+    getState: () => ipcRenderer.invoke('onboarding:getState') as Promise<OnboardingState>,
+    updateStep: (step: WizardStepId, patch?: OnboardingPayload) =>
+      ipcRenderer.invoke('onboarding:updateStep', step, patch ?? {}) as Promise<OnboardingState>,
+    complete: () => ipcRenderer.invoke('onboarding:complete') as Promise<OnboardingState>,
+    reset: () =>
+      ipcRenderer.invoke('onboarding:reset') as Promise<
+        { ok: false } | { ok: true; state: OnboardingState }
+      >,
+    startSignIn: () => ipcRenderer.invoke('onboarding:startSignIn') as Promise<{ ok: boolean }>,
+    onAuthCallback: (handler: (payload: AuthCallback) => void) => {
+      const wrapped = (_event: IpcRendererEvent, payload: AuthCallback) => handler(payload)
+      ipcRenderer.on('onboarding:auth-callback', wrapped)
+      return () => ipcRenderer.removeListener('onboarding:auth-callback', wrapped)
+    },
+  },
+  permissions: {
+    getMediaStatus: (kind: 'microphone' | 'screen') =>
+      ipcRenderer.invoke('perm:getMediaStatus', kind) as Promise<
+        'not-determined' | 'granted' | 'denied' | 'restricted' | 'unknown'
+      >,
+    requestMic: () => ipcRenderer.invoke('perm:requestMic') as Promise<boolean>,
+    getAccessibility: () => ipcRenderer.invoke('perm:getAccessibility') as Promise<boolean>,
+    openSettings: (pane: 'mic' | 'screen' | 'accessibility') =>
+      ipcRenderer.invoke('perm:openSettings', pane) as Promise<void>,
+  },
+  provider: {
+    listConfigured: () =>
+      ipcRenderer.invoke('provider:listConfigured') as Promise<('gemini' | 'openai' | 'xai')[]>,
+    validateAndSave: (provider: 'gemini' | 'openai' | 'xai', key: string) =>
+      ipcRenderer.invoke('provider:validateAndSave', provider, key) as Promise<
+        { ok: true } | { ok: false; error: string; status?: number }
+      >,
+    geminiSmoke: (prompt: string) =>
+      ipcRenderer.invoke('provider:geminiSmoke', prompt) as Promise<
+        { ok: true; text: string } | { ok: false; error: string }
+      >,
+  },
+  brain: {
+    detect: () =>
+      ipcRenderer.invoke('brain:detect') as Promise<{
+        openclaw: { available: true }
+        claude: { available: boolean; path?: string }
+        codex: { available: boolean; path?: string }
+      }>,
   },
   screen: {
     getSources: () => ipcRenderer.invoke('screen:getSources'),

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -6,6 +6,7 @@ import { SettingsPage } from './pages/SettingsPage'
 import { ConversationProvider } from './lib/conversation-context'
 import { useTheme } from './lib/use-theme'
 import { OnboardingWizard, type WizardStepId } from './pages/onboarding/OnboardingWizard'
+import { onboarding, type OnboardingState } from './lib/onboarding-api'
 
 const ONBOARDING_STEP_IDS: WizardStepId[] = [
   'welcome',
@@ -16,24 +17,42 @@ const ONBOARDING_STEP_IDS: WizardStepId[] = [
   'testcall',
 ]
 
-function parseOnboardingFlag(): { enabled: boolean; step: WizardStepId } | null {
-  if (typeof window === 'undefined') return null
-  const params = new URLSearchParams(window.location.search)
-  if (params.get('onboarding') !== '1') return null
-  const stepParam = params.get('step') ?? 'welcome'
-  const step = (ONBOARDING_STEP_IDS as string[]).includes(stepParam)
-    ? (stepParam as WizardStepId)
-    : 'welcome'
-  return { enabled: true, step }
-}
-
 export function App() {
   const [activeTab, setActiveTab] = useState<TabId>('chat')
+  const [bootState, setBootState] = useState<OnboardingState | null>(null)
+  const [showWizard, setShowWizard] = useState(false)
+  const [bootChecked, setBootChecked] = useState(false)
+
   const onboardingFlag = parseOnboardingFlag()
+
   // Initialize theme system (applies dark/light class to html)
   useTheme()
 
   const navigateToChat = useCallback(() => setActiveTab('chat'), [])
+
+  // First-mount: ask main whether onboarding is complete. The wizard
+  // shows iff completedAt is null. The ?onboarding=1 URL flag (used by
+  // Storybook-style design previews) forces the wizard regardless.
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const state = await onboarding.getState()
+        if (cancelled) return
+        setBootState(state)
+        setShowWizard(state.completedAt === null)
+      } catch (err) {
+        // If the bridge isn't available yet (e.g. preview mode in a
+        // browser tab) fall back to showing the main app.
+        console.warn('[onboarding] getState failed', err)
+      } finally {
+        if (!cancelled) setBootChecked(true)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   // Global keyboard shortcuts
   useEffect(() => {
@@ -64,8 +83,37 @@ export function App() {
     return () => window.removeEventListener('keydown', handler)
   }, [])
 
+  // Design-preview override: ?onboarding=1[&step=…] always shows the
+  // wizard at the requested step with empty payload. Used by the docs
+  // site previews where there is no main process to talk to.
   if (onboardingFlag?.enabled) {
-    return <OnboardingWizard initialStep={onboardingFlag.step} />
+    return (
+      <OnboardingWizard
+        initialState={{
+          currentStep: onboardingFlag.step,
+          payload: {},
+          completedAt: null,
+        }}
+        previewMode
+      />
+    )
+  }
+
+  // Hold the splash blank for a single tick while we decide. Avoids
+  // briefly flashing the main app then swapping to the wizard.
+  if (!bootChecked) {
+    return <div className="h-screen w-screen bg-background" />
+  }
+
+  if (showWizard) {
+    return (
+      <OnboardingWizard
+        initialState={
+          bootState ?? { currentStep: 'welcome', payload: {}, completedAt: null }
+        }
+        onComplete={() => setShowWizard(false)}
+      />
+    )
   }
 
   return (
@@ -86,4 +134,19 @@ export function App() {
       </div>
     </ConversationProvider>
   )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseOnboardingFlag(): { enabled: boolean; step: WizardStepId } | null {
+  if (typeof window === 'undefined') return null
+  const params = new URLSearchParams(window.location.search)
+  if (params.get('onboarding') !== '1') return null
+  const stepParam = params.get('step') ?? 'welcome'
+  const step = (ONBOARDING_STEP_IDS as string[]).includes(stepParam)
+    ? (stepParam as WizardStepId)
+    : 'welcome'
+  return { enabled: true, step }
 }

--- a/desktop/src/renderer/src/lib/onboarding-api.ts
+++ b/desktop/src/renderer/src/lib/onboarding-api.ts
@@ -1,0 +1,113 @@
+// Renderer-side typed wrapper around the onboarding IPC bridge. Keeps
+// every wizard step honest about what shapes flow across the bridge.
+
+export type WizardStepId =
+  | 'welcome'
+  | 'signin'
+  | 'permissions'
+  | 'provider'
+  | 'brain'
+  | 'testcall'
+
+export type ProviderId = 'gemini' | 'openai' | 'xai'
+
+export type PermissionStatus =
+  | 'granted'
+  | 'denied'
+  | 'not-determined'
+  | 'restricted'
+  | 'unknown'
+
+export type OnboardingPayload = {
+  signedIn?: boolean
+  permissions?: {
+    mic?: PermissionStatus
+    screen?: PermissionStatus
+    accessibility?: 'granted' | 'denied' | 'unknown'
+  }
+  provider?: ProviderId
+  providerKeyValidated?: boolean
+  brain?: 'openclaw' | 'claude' | 'codex' | { url: string }
+  user?: { id?: string; email?: string | null; name?: string | null }
+}
+
+export type OnboardingState = {
+  currentStep: WizardStepId
+  payload: OnboardingPayload
+  completedAt: string | null
+}
+
+export type AuthCallback =
+  | { ok: true; user: { id?: string; email?: string | null; name?: string | null } | null }
+  | { ok: false; error: string }
+
+export type BrainDetection = {
+  openclaw: { available: true }
+  claude: { available: boolean; path?: string }
+  codex: { available: boolean; path?: string }
+}
+
+declare global {
+  interface Window {
+    electronAPI: Window['electronAPI'] & {
+      onboarding: {
+        getState: () => Promise<OnboardingState>
+        updateStep: (step: WizardStepId, patch?: OnboardingPayload) => Promise<OnboardingState>
+        complete: () => Promise<OnboardingState>
+        reset: () => Promise<{ ok: false } | { ok: true; state: OnboardingState }>
+        startSignIn: () => Promise<{ ok: boolean }>
+        onAuthCallback: (handler: (payload: AuthCallback) => void) => () => void
+      }
+      permissions: {
+        getMediaStatus: (kind: 'microphone' | 'screen') => Promise<PermissionStatus>
+        requestMic: () => Promise<boolean>
+        getAccessibility: () => Promise<boolean>
+        openSettings: (pane: 'mic' | 'screen' | 'accessibility') => Promise<void>
+      }
+      provider: {
+        listConfigured: () => Promise<ProviderId[]>
+        validateAndSave: (
+          provider: ProviderId,
+          key: string,
+        ) => Promise<{ ok: true } | { ok: false; error: string; status?: number }>
+        geminiSmoke: (
+          prompt: string,
+        ) => Promise<{ ok: true; text: string } | { ok: false; error: string }>
+      }
+      brain: {
+        detect: () => Promise<BrainDetection>
+      }
+    }
+  }
+}
+
+export const onboarding = {
+  getState: () => window.electronAPI.onboarding.getState(),
+  updateStep: (step: WizardStepId, patch?: OnboardingPayload) =>
+    window.electronAPI.onboarding.updateStep(step, patch),
+  complete: () => window.electronAPI.onboarding.complete(),
+  reset: () => window.electronAPI.onboarding.reset(),
+  startSignIn: () => window.electronAPI.onboarding.startSignIn(),
+  onAuthCallback: (handler: (payload: AuthCallback) => void) =>
+    window.electronAPI.onboarding.onAuthCallback(handler),
+}
+
+export const permissions = {
+  getMediaStatus: (kind: 'microphone' | 'screen') =>
+    window.electronAPI.permissions.getMediaStatus(kind),
+  requestMic: () => window.electronAPI.permissions.requestMic(),
+  getAccessibility: () => window.electronAPI.permissions.getAccessibility(),
+  openSettings: (pane: 'mic' | 'screen' | 'accessibility') =>
+    window.electronAPI.permissions.openSettings(pane),
+}
+
+export const providerApi = {
+  listConfigured: () => window.electronAPI.provider.listConfigured(),
+  validateAndSave: (provider: ProviderId, key: string) =>
+    window.electronAPI.provider.validateAndSave(provider, key),
+  geminiSmoke: (prompt: string) => window.electronAPI.provider.geminiSmoke(prompt),
+}
+
+export const brainApi = {
+  detect: () => window.electronAPI.brain.detect(),
+}

--- a/desktop/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/desktop/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import './brand.css'
 import { StepWelcome } from './StepWelcome'
 import { StepSignIn } from './StepSignIn'
@@ -6,62 +6,175 @@ import { StepPermissions } from './StepPermissions'
 import { StepProvider } from './StepProvider'
 import { StepBrain } from './StepBrain'
 import { StepTestCall } from './StepTestCall'
+import {
+  onboarding,
+  type OnboardingPayload,
+  type OnboardingState,
+  type WizardStepId,
+} from '../../lib/onboarding-api'
 
-export type WizardStepId =
-  | 'welcome'
-  | 'signin'
-  | 'permissions'
-  | 'provider'
-  | 'brain'
-  | 'testcall'
+export type { WizardStepId }
 
 const STEPS: WizardStepId[] = ['welcome', 'signin', 'permissions', 'provider', 'brain', 'testcall']
 
 type Props = {
-  initialStep?: WizardStepId
+  initialState?: OnboardingState
   onComplete?: () => void
+  /**
+   * Skip all main-process IPC calls. Used by the docs-site preview where
+   * the renderer runs in a normal browser without an Electron bridge.
+   */
+  previewMode?: boolean
 }
 
-export function OnboardingWizard({ initialStep = 'welcome', onComplete }: Props) {
-  const [stepId, setStepId] = useState<WizardStepId>(initialStep)
+export function OnboardingWizard({ initialState, onComplete, previewMode = false }: Props) {
+  const [stepId, setStepId] = useState<WizardStepId>(initialState?.currentStep ?? 'welcome')
+  const [payload, setPayload] = useState<OnboardingPayload>(initialState?.payload ?? {})
   const currentIndex = STEPS.indexOf(stepId)
 
-  const next = () => {
-    const nextIndex = currentIndex + 1
-    if (nextIndex >= STEPS.length) {
-      onComplete?.()
-      return
-    }
-    setStepId(STEPS[nextIndex])
-  }
+  const persist = useCallback(
+    async (nextStep: WizardStepId, patch: OnboardingPayload = {}) => {
+      const merged = mergePayload(payload, patch)
+      setPayload(merged)
+      setStepId(nextStep)
+      if (previewMode) return
+      try {
+        await onboarding.updateStep(nextStep, patch)
+      } catch (err) {
+        console.warn('[onboarding] updateStep failed', err)
+      }
+    },
+    [payload, previewMode],
+  )
 
-  const back = () => {
+  const next = useCallback(
+    (patch: OnboardingPayload = {}) => {
+      const nextIndex = currentIndex + 1
+      if (nextIndex >= STEPS.length) {
+        return finish(patch)
+      }
+      void persist(STEPS[nextIndex], patch)
+    },
+    [currentIndex, persist],
+  )
+
+  const back = useCallback(() => {
     const prevIndex = currentIndex - 1
     if (prevIndex < 0) return
-    setStepId(STEPS[prevIndex])
-  }
+    void persist(STEPS[prevIndex])
+  }, [currentIndex, persist])
 
-  const startOver = () => setStepId('welcome')
+  const finish = useCallback(
+    async (patch: OnboardingPayload = {}) => {
+      const merged = mergePayload(payload, patch)
+      setPayload(merged)
+      if (!previewMode) {
+        try {
+          if (Object.keys(patch).length > 0) {
+            await onboarding.updateStep('testcall', patch)
+          }
+          await onboarding.complete()
+        } catch (err) {
+          console.warn('[onboarding] complete failed', err)
+        }
+      }
+      onComplete?.()
+    },
+    [onComplete, payload, previewMode],
+  )
+
+  const startOver = useCallback(async () => {
+    if (previewMode) {
+      setPayload({})
+      setStepId('welcome')
+      return
+    }
+    const result = await onboarding.reset()
+    if (!result.ok) return
+    setPayload(result.state.payload)
+    setStepId(result.state.currentStep)
+  }, [previewMode])
 
   switch (stepId) {
     case 'welcome':
-      return <StepWelcome onContinue={next} onStartOver={startOver} />
+      return <StepWelcome onContinue={() => next()} onStartOver={startOver} />
     case 'signin':
-      return <StepSignIn onContinue={next} onBack={back} onSkip={next} onStartOver={startOver} />
+      return (
+        <StepSignIn
+          onContinue={(patch) => next(patch)}
+          onBack={back}
+          onSkip={() => next({ signedIn: false })}
+          onStartOver={startOver}
+          initialSignedIn={payload.signedIn ?? false}
+          previewMode={previewMode}
+        />
+      )
     case 'permissions':
       return (
         <StepPermissions
-          onContinue={next}
+          onContinue={(patch) => next(patch)}
           onBack={back}
-          onSkip={next}
+          onSkip={() => next()}
           onStartOver={startOver}
+          previewMode={previewMode}
         />
       )
     case 'provider':
-      return <StepProvider onContinue={next} onBack={back} onStartOver={startOver} />
+      return (
+        <StepProvider
+          onContinue={(patch) => next(patch)}
+          onBack={back}
+          onStartOver={startOver}
+          initialProvider={payload.provider ?? 'gemini'}
+          previewMode={previewMode}
+        />
+      )
     case 'brain':
-      return <StepBrain onContinue={next} onBack={back} onStartOver={startOver} />
+      return (
+        <StepBrain
+          onContinue={(patch) => next(patch)}
+          onBack={back}
+          onStartOver={startOver}
+          initialBrain={resolveInitialBrainId(payload.brain)}
+          initialCustomUrl={typeof payload.brain === 'object' ? payload.brain.url : ''}
+          previewMode={previewMode}
+        />
+      )
     case 'testcall':
-      return <StepTestCall onContinue={onComplete} onBack={back} onStartOver={startOver} />
+      return (
+        <StepTestCall
+          onContinue={() => finish()}
+          onBack={back}
+          onStartOver={startOver}
+          providerId={payload.provider ?? 'gemini'}
+          previewMode={previewMode}
+        />
+      )
   }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mergePayload(
+  current: OnboardingPayload,
+  patch: OnboardingPayload,
+): OnboardingPayload {
+  return {
+    ...current,
+    ...patch,
+    permissions: patch.permissions
+      ? { ...(current.permissions ?? {}), ...patch.permissions }
+      : current.permissions,
+    user: patch.user ? { ...(current.user ?? {}), ...patch.user } : current.user,
+  }
+}
+
+function resolveInitialBrainId(
+  brain: OnboardingPayload['brain'],
+): 'openclaw' | 'claude' | 'codex' | 'custom' {
+  if (!brain) return 'openclaw'
+  if (typeof brain === 'object') return 'custom'
+  return brain
 }

--- a/desktop/src/renderer/src/pages/onboarding/StepBrain.tsx
+++ b/desktop/src/renderer/src/pages/onboarding/StepBrain.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { ReactElement, SVGProps } from 'react'
 import { StepFrame } from './StepFrame'
+import { brainApi, type BrainDetection, type OnboardingPayload } from '../../lib/onboarding-api'
 
 type BrainId = 'openclaw' | 'claude' | 'codex' | 'custom'
 
@@ -14,53 +15,76 @@ type Brain = {
   recommended?: boolean
 }
 
-const BRAINS: Brain[] = [
-  {
-    id: 'openclaw',
-    name: 'OpenClaw (bundled)',
-    character: 'A calm, generalist agent. Does the right thing most of the time.',
-    detail: 'Ships inside VoiceClaw. No separate install, no signing in, no extra ports to worry about.',
-    status: 'bundled',
-    icon: IconBracket,
-    recommended: true,
-  },
-  {
-    id: 'claude',
-    name: 'Claude Code',
-    character: 'The careful one. Great at actual work — code, docs, research.',
-    detail: 'Detected at /usr/local/bin/claude. Already signed in as your account.',
-    status: 'detected',
-    icon: IconC,
-  },
-  {
-    id: 'codex',
-    name: 'Codex CLI',
-    character: 'Fast, terse, no small talk. OpenAI-flavored thinker.',
-    detail: 'Detected at /opt/homebrew/bin/codex.',
-    status: 'detected',
-    icon: IconSlash,
-  },
-  {
-    id: 'custom',
-    name: 'Custom endpoint',
-    character: 'Anything that speaks OpenAI-compatible chat completions.',
-    detail: 'Bring your own agent. Paste the URL and an auth header if you need one.',
-    status: 'custom',
-    icon: IconLink,
-  },
-]
+const PREVIEW_DETECTION: BrainDetection = {
+  openclaw: { available: true },
+  claude: { available: true, path: '/usr/local/bin/claude' },
+  codex: { available: true, path: '/opt/homebrew/bin/codex' },
+}
 
 type Props = {
-  onContinue?: () => void
+  onContinue?: (patch: OnboardingPayload) => void
   onBack?: () => void
   onStartOver?: () => void
   initialBrain?: BrainId
+  initialCustomUrl?: string
+  previewMode?: boolean
 }
 
-export function StepBrain({ onContinue, onBack, onStartOver, initialBrain = 'openclaw' }: Props) {
+export function StepBrain({
+  onContinue,
+  onBack,
+  onStartOver,
+  initialBrain = 'openclaw',
+  initialCustomUrl = '',
+  previewMode = false,
+}: Props) {
   const [selected, setSelected] = useState<BrainId>(initialBrain)
-  const [customUrl, setCustomUrl] = useState('')
-  const canContinue = selected !== 'custom' || customUrl.length > 10
+  const [customUrl, setCustomUrl] = useState(initialCustomUrl)
+  const [detection, setDetection] = useState<BrainDetection>(
+    previewMode
+      ? PREVIEW_DETECTION
+      : {
+          openclaw: { available: true },
+          claude: { available: false },
+          codex: { available: false },
+        },
+  )
+
+  useEffect(() => {
+    if (previewMode) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const result = await brainApi.detect()
+        if (!cancelled) setDetection(result)
+      } catch (err) {
+        console.warn('[onboarding] brain detect failed', err)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [previewMode])
+
+  const customUrlValid = isValidHttpUrl(customUrl)
+  const canContinue = selected !== 'custom' || customUrlValid
+
+  const brains: Brain[] = buildBrains(detection)
+  const visibleBrains = brains.filter((brain) => {
+    if (brain.id === 'claude') return detection.claude.available
+    if (brain.id === 'codex') return detection.codex.available
+    return true
+  })
+
+  const handleContinue = () => {
+    if (!canContinue) return
+    let brainPayload: OnboardingPayload['brain']
+    if (selected === 'custom') brainPayload = { url: customUrl.trim() }
+    else if (selected === 'openclaw') brainPayload = 'openclaw'
+    else if (selected === 'claude') brainPayload = 'claude'
+    else brainPayload = 'codex'
+    onContinue?.({ brain: brainPayload })
+  }
 
   return (
     <StepFrame
@@ -69,12 +93,12 @@ export function StepBrain({ onContinue, onBack, onStartOver, initialBrain = 'ope
       eyebrow="05 / Brain"
       title="Who's actually doing the thinking?"
       description="The voice you picked last step handles conversation. The brain does the work — answering questions, running tools, remembering context. Pick one. You can switch later."
-      primaryAction={{ label: 'Continue', onClick: onContinue, disabled: !canContinue }}
+      primaryAction={{ label: 'Continue', onClick: handleContinue, disabled: !canContinue }}
       secondaryAction={{ label: 'Back', onClick: onBack }}
       onStartOver={onStartOver}
     >
       <div className="flex flex-col gap-3">
-        {BRAINS.map((brain) => (
+        {visibleBrains.map((brain) => (
           <BrainRow
             key={brain.id}
             brain={brain}
@@ -118,10 +142,75 @@ export function StepBrain({ onContinue, onBack, onStartOver, initialBrain = 'ope
           <p className="mt-3 text-[12px]" style={{ color: 'var(--muted)' }}>
             Must speak the OpenAI chat completions protocol. Streaming responses preferred.
           </p>
+          {customUrl.length > 0 && !customUrlValid ? (
+            <p
+              className="mt-2 text-[12px]"
+              style={{ color: 'var(--accent)' }}
+            >
+              That doesn't look like an http(s):// URL.
+            </p>
+          ) : null}
         </div>
       ) : null}
     </StepFrame>
   )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildBrains(detection: BrainDetection): Brain[] {
+  return [
+    {
+      id: 'openclaw',
+      name: 'OpenClaw (bundled)',
+      character: 'A calm, generalist agent. Does the right thing most of the time.',
+      detail:
+        'Ships inside VoiceClaw. No separate install, no signing in, no extra ports to worry about.',
+      status: 'bundled',
+      icon: IconBracket,
+      recommended: true,
+    },
+    {
+      id: 'claude',
+      name: 'Claude Code',
+      character: 'The careful one. Great at actual work — code, docs, research.',
+      detail: detection.claude.available
+        ? `Detected at ${detection.claude.path ?? 'your PATH'}. Already signed in as your account.`
+        : 'Not detected on this Mac.',
+      status: detection.claude.available ? 'detected' : 'not-detected',
+      icon: IconC,
+    },
+    {
+      id: 'codex',
+      name: 'Codex CLI',
+      character: 'Fast, terse, no small talk. OpenAI-flavored thinker.',
+      detail: detection.codex.available
+        ? `Detected at ${detection.codex.path ?? 'your PATH'}.`
+        : 'Not detected on this Mac.',
+      status: detection.codex.available ? 'detected' : 'not-detected',
+      icon: IconSlash,
+    },
+    {
+      id: 'custom',
+      name: 'Custom endpoint',
+      character: 'Anything that speaks OpenAI-compatible chat completions.',
+      detail: 'Bring your own agent. Paste the URL and an auth header if you need one.',
+      status: 'custom',
+      icon: IconLink,
+    },
+  ]
+}
+
+function isValidHttpUrl(raw: string): boolean {
+  if (!raw) return false
+  try {
+    const parsed = new URL(raw.trim())
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
 }
 
 function BrainRow({

--- a/desktop/src/renderer/src/pages/onboarding/StepPermissions.tsx
+++ b/desktop/src/renderer/src/pages/onboarding/StepPermissions.tsx
@@ -1,14 +1,20 @@
+import { useCallback, useEffect, useState } from 'react'
 import type { ReactElement, SVGProps } from 'react'
 import { StepFrame } from './StepFrame'
+import {
+  permissions,
+  type OnboardingPayload,
+  type PermissionStatus,
+} from '../../lib/onboarding-api'
 
-type PermissionStatus = 'pending' | 'granted' | 'denied'
+type PermissionId = 'mic' | 'screen' | 'accessibility'
 
 type Permission = {
-  id: 'mic' | 'screen' | 'accessibility'
+  id: PermissionId
   name: string
   purpose: string
   detail: string
-  status: PermissionStatus
+  optional: boolean
   icon: (props: SVGProps<SVGSVGElement>) => ReactElement
 }
 
@@ -18,7 +24,7 @@ const PERMISSIONS: Permission[] = [
     name: 'Microphone',
     purpose: 'So your words can reach the AI.',
     detail: 'Audio streams directly to the provider you pick. Nothing lingers on our side.',
-    status: 'granted',
+    optional: false,
     icon: IconMic,
   },
   {
@@ -26,28 +32,99 @@ const PERMISSIONS: Permission[] = [
     name: 'Screen Recording',
     purpose: "So the AI can see what you're looking at, when you ask.",
     detail: 'Off until you start a share. The green dot in the menu bar will tell you.',
-    status: 'pending',
+    optional: true,
     icon: IconScreen,
   },
   {
     id: 'accessibility',
     name: 'Accessibility',
     purpose: 'So push-to-talk works from anywhere.',
-    detail: 'Lets VoiceClaw listen for your hotkey even when another app is focused.',
-    status: 'denied',
+    detail:
+      "Lets VoiceClaw listen for your hotkey even when another app is focused. Skippable, but recommended.",
+    optional: true,
     icon: IconAccessibility,
   },
 ]
 
 type Props = {
-  onContinue?: () => void
+  onContinue?: (patch: OnboardingPayload) => void
   onBack?: () => void
   onSkip?: () => void
   onStartOver?: () => void
+  previewMode?: boolean
 }
 
-export function StepPermissions({ onContinue, onBack, onSkip, onStartOver }: Props) {
-  const allHandled = PERMISSIONS.every((p) => p.status !== 'pending')
+type StatusMap = Record<PermissionId, PermissionStatus | 'granted' | 'denied' | 'unknown'>
+
+const PREVIEW_STATUS: StatusMap = {
+  mic: 'granted',
+  screen: 'not-determined',
+  accessibility: 'denied',
+}
+
+export function StepPermissions({
+  onContinue,
+  onBack,
+  onSkip,
+  onStartOver,
+  previewMode = false,
+}: Props) {
+  const [statuses, setStatuses] = useState<StatusMap>(
+    previewMode
+      ? PREVIEW_STATUS
+      : { mic: 'unknown', screen: 'unknown', accessibility: 'unknown' },
+  )
+
+  const refresh = useCallback(async () => {
+    if (previewMode) return
+    try {
+      const [mic, screen, accessibility] = await Promise.all([
+        permissions.getMediaStatus('microphone'),
+        permissions.getMediaStatus('screen'),
+        permissions.getAccessibility(),
+      ])
+      setStatuses({
+        mic,
+        screen,
+        accessibility: accessibility ? 'granted' : 'denied',
+      })
+    } catch (err) {
+      console.warn('[onboarding] perm refresh failed', err)
+    }
+  }, [previewMode])
+
+  // Initial fetch + 1s poll while on this step. Captures permission
+  // grants the user makes in System Settings without us having to listen
+  // for app focus events explicitly.
+  useEffect(() => {
+    void refresh()
+    if (previewMode) return
+    const id = window.setInterval(() => void refresh(), 1000)
+    return () => window.clearInterval(id)
+  }, [previewMode, refresh])
+
+  const handleAction = async (id: PermissionId, current: PermissionStatus | 'unknown') => {
+    if (previewMode) return
+    if (id === 'mic' && current === 'not-determined') {
+      try {
+        await permissions.requestMic()
+      } catch (err) {
+        console.warn('[onboarding] requestMic failed', err)
+      }
+      void refresh()
+      return
+    }
+    // For screen / accessibility, and for any denied state, jump straight
+    // to the matching pane in System Settings.
+    void permissions.openSettings(id)
+  }
+
+  // We treat the mic as the only required permission. Screen + a11y can
+  // be added later. Allow continue if mic is granted OR not-determined
+  // (user can grant mid-flow), and let the user explicitly skip too.
+  const micUsable = statuses.mic === 'granted' || statuses.mic === 'not-determined'
+  const allHandled = micUsable
+
   return (
     <StepFrame
       stepIndex={3}
@@ -55,14 +132,35 @@ export function StepPermissions({ onContinue, onBack, onSkip, onStartOver }: Pro
       eyebrow="03 / Permissions"
       title="A few things the Mac needs from you."
       description="macOS asks once per permission. If you click the wrong thing, we'll send you to the right pane in System Settings — no terminal gymnastics."
-      primaryAction={{ label: 'Continue', onClick: onContinue, disabled: !allHandled }}
+      primaryAction={{
+        label: 'Continue',
+        onClick: () =>
+          onContinue?.({
+            permissions: {
+              mic: normalizeStatus(statuses.mic),
+              screen: normalizeStatus(statuses.screen),
+              accessibility:
+                statuses.accessibility === 'granted'
+                  ? 'granted'
+                  : statuses.accessibility === 'denied'
+                    ? 'denied'
+                    : 'unknown',
+            },
+          }),
+        disabled: !allHandled,
+      }}
       secondaryAction={{ label: 'Back', onClick: onBack }}
       skipAction={{ label: 'Handle this later', onClick: onSkip }}
       onStartOver={onStartOver}
     >
       <div className="flex flex-col gap-4">
         {PERMISSIONS.map((permission) => (
-          <PermissionRow key={permission.id} permission={permission} />
+          <PermissionRow
+            key={permission.id}
+            permission={permission}
+            status={statuses[permission.id] ?? 'unknown'}
+            onAction={() => handleAction(permission.id, statuses[permission.id] ?? 'unknown')}
+          />
         ))}
       </div>
 
@@ -93,8 +191,23 @@ export function StepPermissions({ onContinue, onBack, onSkip, onStartOver }: Pro
   )
 }
 
-function PermissionRow({ permission }: { permission: Permission }) {
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type DisplayStatus = 'granted' | 'pending' | 'denied'
+
+function PermissionRow({
+  permission,
+  status,
+  onAction,
+}: {
+  permission: Permission
+  status: PermissionStatus | 'unknown'
+  onAction: () => void
+}) {
   const Icon = permission.icon
+  const display = toDisplayStatus(status)
   return (
     <div
       className="flex items-center gap-5 rounded-[18px] border px-5 py-4"
@@ -128,14 +241,19 @@ function PermissionRow({ permission }: { permission: Permission }) {
         </p>
       </div>
 
-      <StatusPill status={permission.status} />
-      <ActionButton status={permission.status} />
+      <StatusPill status={display} />
+      <ActionButton
+        permissionId={permission.id}
+        status={status}
+        display={display}
+        onAction={onAction}
+      />
     </div>
   )
 }
 
-function StatusPill({ status }: { status: PermissionStatus }) {
-  const styles: Record<PermissionStatus, { bg: string; text: string; label: string }> = {
+function StatusPill({ status }: { status: DisplayStatus }) {
+  const styles: Record<DisplayStatus, { bg: string; text: string; label: string }> = {
     granted: {
       bg: 'rgba(97, 145, 79, 0.14)',
       text: '#3f6230',
@@ -168,17 +286,31 @@ function StatusPill({ status }: { status: PermissionStatus }) {
   )
 }
 
-function ActionButton({ status }: { status: PermissionStatus }) {
-  if (status === 'granted') {
+function ActionButton({
+  permissionId,
+  status,
+  display,
+  onAction,
+}: {
+  permissionId: PermissionId
+  status: PermissionStatus | 'unknown'
+  display: DisplayStatus
+  onAction: () => void
+}) {
+  if (display === 'granted') {
     return (
       <span className="w-[170px] text-right text-[13px]" style={{ color: 'var(--muted)' }}>
         ✓ All set
       </span>
     )
   }
-  const label = status === 'denied' ? 'Open System Settings' : 'Allow'
+  // mic + not-determined → "Allow" (in-app prompt). Everything else
+  // (screen, accessibility, anything denied) → System Settings shortcut.
+  const inAppRequest = permissionId === 'mic' && status === 'not-determined'
+  const label = inAppRequest ? 'Allow' : 'Open System Settings'
   return (
     <button
+      onClick={onAction}
       className="rounded-full border px-5 py-[8px] text-[13px] font-medium transition-colors hover:bg-white/70"
       style={{
         borderColor: 'var(--line-strong)',
@@ -190,6 +322,17 @@ function ActionButton({ status }: { status: PermissionStatus }) {
       {label}
     </button>
   )
+}
+
+function toDisplayStatus(status: PermissionStatus | 'unknown'): DisplayStatus {
+  if (status === 'granted') return 'granted'
+  if (status === 'denied' || status === 'restricted') return 'denied'
+  return 'pending'
+}
+
+function normalizeStatus(raw: PermissionStatus | 'unknown'): PermissionStatus {
+  if (raw === 'unknown') return 'unknown'
+  return raw
 }
 
 function IconMic(props: SVGProps<SVGSVGElement>) {

--- a/desktop/src/renderer/src/pages/onboarding/StepProvider.tsx
+++ b/desktop/src/renderer/src/pages/onboarding/StepProvider.tsx
@@ -1,7 +1,10 @@
 import { useState } from 'react'
 import { StepFrame } from './StepFrame'
-
-type ProviderId = 'gemini' | 'openai' | 'xai'
+import {
+  providerApi,
+  type OnboardingPayload,
+  type ProviderId,
+} from '../../lib/onboarding-api'
 
 type Provider = {
   id: ProviderId
@@ -51,12 +54,19 @@ const PROVIDERS: Provider[] = [
   },
 ]
 
+type ValidationState =
+  | { kind: 'empty' }
+  | { kind: 'typing' }
+  | { kind: 'validating' }
+  | { kind: 'valid' }
+  | { kind: 'invalid'; error: string }
+
 type Props = {
-  onContinue?: () => void
+  onContinue?: (patch: OnboardingPayload) => void
   onBack?: () => void
   onStartOver?: () => void
   initialProvider?: ProviderId
-  initialKey?: string
+  previewMode?: boolean
 }
 
 export function StepProvider({
@@ -64,12 +74,63 @@ export function StepProvider({
   onBack,
   onStartOver,
   initialProvider = 'gemini',
-  initialKey = '',
+  previewMode = false,
 }: Props) {
   const [selected, setSelected] = useState<ProviderId>(initialProvider)
-  const [apiKey, setApiKey] = useState(initialKey)
+  const [apiKey, setApiKey] = useState('')
+  const [validation, setValidation] = useState<ValidationState>({ kind: 'empty' })
   const active = PROVIDERS.find((p) => p.id === selected)!
-  const looksValid = apiKey.length > 20 && apiKey.startsWith(active.prefix)
+
+  const handleKeyChange = (key: string) => {
+    setApiKey(key)
+    if (key.length === 0) {
+      setValidation({ kind: 'empty' })
+    } else {
+      setValidation({ kind: 'typing' })
+    }
+  }
+
+  const handleValidate = async () => {
+    if (apiKey.length < 8) {
+      setValidation({ kind: 'invalid', error: 'Key looks too short.' })
+      return
+    }
+    if (previewMode) {
+      setValidation({ kind: 'valid' })
+      return
+    }
+    setValidation({ kind: 'validating' })
+    try {
+      const result = await providerApi.validateAndSave(selected, apiKey)
+      if (result.ok) {
+        setValidation({ kind: 'valid' })
+      } else {
+        setValidation({ kind: 'invalid', error: result.error })
+      }
+    } catch (err) {
+      setValidation({
+        kind: 'invalid',
+        error: err instanceof Error ? err.message : 'Validation failed.',
+      })
+    }
+  }
+
+  const handleContinue = async () => {
+    if (validation.kind !== 'valid') {
+      await handleValidate()
+      // re-read state inside handleValidate; handleContinue stops here
+      // and the user clicks Continue again once they see the green check.
+      return
+    }
+    onContinue?.({ provider: selected, providerKeyValidated: true })
+  }
+
+  const continueLabel =
+    validation.kind === 'valid'
+      ? 'Continue'
+      : validation.kind === 'validating'
+        ? 'Checking…'
+        : 'Validate + continue'
 
   return (
     <StepFrame
@@ -79,9 +140,9 @@ export function StepProvider({
       title="Pick a voice. Paste a key."
       description="VoiceClaw doesn't keep your key. It goes straight into macOS Keychain on this machine, encrypted the way the OS encrypts your Wi-Fi passwords."
       primaryAction={{
-        label: looksValid ? 'Validate + continue' : 'Continue',
-        onClick: onContinue,
-        disabled: !looksValid,
+        label: continueLabel,
+        onClick: () => void handleContinue(),
+        disabled: validation.kind === 'validating' || apiKey.length === 0,
       }}
       secondaryAction={{ label: 'Back', onClick: onBack }}
       onStartOver={onStartOver}
@@ -95,6 +156,7 @@ export function StepProvider({
             onSelect={() => {
               setSelected(provider.id)
               setApiKey('')
+              setValidation({ kind: 'empty' })
             }}
           />
         ))}
@@ -140,7 +202,12 @@ export function StepProvider({
             <input
               type="password"
               value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
+              onChange={(e) => handleKeyChange(e.target.value)}
+              onBlur={() => {
+                if (apiKey.length > 0 && validation.kind === 'typing') {
+                  void handleValidate()
+                }
+              }}
               placeholder={active.placeholder}
               className="w-full rounded-[14px] border px-5 py-4 text-[15px] outline-none transition-colors focus:border-[var(--ink)]"
               style={{
@@ -152,8 +219,17 @@ export function StepProvider({
               }}
             />
           </div>
-          <ValidationBadge state={apiKey.length === 0 ? 'empty' : looksValid ? 'valid' : 'typing'} />
+          <ValidationBadge state={validation} />
         </div>
+
+        {validation.kind === 'invalid' ? (
+          <p
+            className="mt-3 text-[12px] leading-[1.55]"
+            style={{ color: 'var(--accent)', fontFamily: 'var(--font-sans)' }}
+          >
+            {validation.error}
+          </p>
+        ) : null}
 
         <p className="mt-4 text-[12px] leading-[1.6]" style={{ color: 'var(--muted)' }}>
           Your key never leaves this Mac. The test call is a token mint against{' '}
@@ -172,6 +248,10 @@ export function StepProvider({
     </StepFrame>
   )
 }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function ProviderCard({
   provider,
@@ -248,32 +328,75 @@ function RadioDot({ selected }: { selected: boolean }) {
   )
 }
 
-function ValidationBadge({ state }: { state: 'empty' | 'typing' | 'valid' }) {
-  if (state === 'empty') return null
-  const isValid = state === 'valid'
+function ValidationBadge({ state }: { state: ValidationState }) {
+  if (state.kind === 'empty') return null
+  const visual = mapVisual(state)
   return (
     <div
       className="flex items-center gap-2 rounded-[14px] border px-4"
       style={{
-        borderColor: isValid ? 'var(--accent)' : 'var(--line-strong)',
-        backgroundColor: isValid ? 'var(--accent-soft)' : 'var(--panel-strong)',
+        borderColor: visual.border,
+        backgroundColor: visual.background,
         minWidth: 140,
       }}
     >
       <span
         className="h-2 w-2 rounded-full"
-        style={{ backgroundColor: isValid ? 'var(--accent)' : 'var(--muted)' }}
+        style={{ backgroundColor: visual.dot }}
       />
       <span
         className="text-[12px] uppercase"
         style={{
           fontFamily: 'var(--font-mono)',
           letterSpacing: '0.2em',
-          color: isValid ? 'var(--accent)' : 'var(--muted)',
+          color: visual.color,
         }}
       >
-        {isValid ? 'Looks valid' : 'Checking…'}
+        {visual.label}
       </span>
     </div>
   )
+}
+
+function mapVisual(state: ValidationState): {
+  border: string
+  background: string
+  color: string
+  dot: string
+  label: string
+} {
+  if (state.kind === 'valid') {
+    return {
+      border: 'var(--accent)',
+      background: 'var(--accent-soft)',
+      color: 'var(--accent)',
+      dot: 'var(--accent)',
+      label: 'Looks valid',
+    }
+  }
+  if (state.kind === 'invalid') {
+    return {
+      border: 'var(--accent)',
+      background: 'var(--panel-strong)',
+      color: 'var(--accent)',
+      dot: 'var(--accent)',
+      label: 'Invalid',
+    }
+  }
+  if (state.kind === 'validating') {
+    return {
+      border: 'var(--line-strong)',
+      background: 'var(--panel-strong)',
+      color: 'var(--muted)',
+      dot: 'var(--muted)',
+      label: 'Checking…',
+    }
+  }
+  return {
+    border: 'var(--line-strong)',
+    background: 'var(--panel-strong)',
+    color: 'var(--muted)',
+    dot: 'var(--muted)',
+    label: 'Press tab to check',
+  }
 }

--- a/desktop/src/renderer/src/pages/onboarding/StepSignIn.tsx
+++ b/desktop/src/renderer/src/pages/onboarding/StepSignIn.tsx
@@ -1,13 +1,66 @@
+import { useEffect, useState } from 'react'
 import { StepFrame } from './StepFrame'
+import { onboarding, type OnboardingPayload } from '../../lib/onboarding-api'
 
 type Props = {
-  onContinue?: () => void
+  onContinue?: (patch: OnboardingPayload) => void
   onBack?: () => void
   onSkip?: () => void
   onStartOver?: () => void
+  initialSignedIn?: boolean
+  previewMode?: boolean
 }
 
-export function StepSignIn({ onContinue, onBack, onSkip, onStartOver }: Props) {
+type SignInState =
+  | { kind: 'idle' }
+  | { kind: 'pending'; provider: 'google' | 'apple' }
+  | { kind: 'success'; user: { email?: string | null; name?: string | null } | null }
+  | { kind: 'error'; error: string }
+
+export function StepSignIn({
+  onContinue,
+  onBack,
+  onSkip,
+  onStartOver,
+  initialSignedIn = false,
+  previewMode = false,
+}: Props) {
+  const [state, setState] = useState<SignInState>(
+    initialSignedIn ? { kind: 'success', user: null } : { kind: 'idle' },
+  )
+
+  // Listen for the deep-link callback from main. The main process redeems
+  // the ticket and forwards a friendlier shape to the renderer.
+  useEffect(() => {
+    if (previewMode) return
+    const off = onboarding.onAuthCallback((payload) => {
+      if (payload.ok) {
+        setState({ kind: 'success', user: payload.user })
+      } else {
+        setState({ kind: 'error', error: humanizeAuthError(payload.error) })
+      }
+    })
+    return off
+  }, [previewMode])
+
+  const handleSignIn = async (provider: 'google' | 'apple') => {
+    if (previewMode) {
+      setState({ kind: 'success', user: { email: 'preview@voiceclaw.app', name: 'Preview' } })
+      return
+    }
+    setState({ kind: 'pending', provider })
+    try {
+      await onboarding.startSignIn()
+    } catch (err) {
+      setState({
+        kind: 'error',
+        error: err instanceof Error ? err.message : 'Could not open browser.',
+      })
+    }
+  }
+
+  const isSignedIn = state.kind === 'success'
+
   return (
     <StepFrame
       stepIndex={2}
@@ -15,15 +68,37 @@ export function StepSignIn({ onContinue, onBack, onSkip, onStartOver }: Props) {
       eyebrow="02 / Sign in"
       title="Tell us where to find you."
       description="We use your email to send build updates and reach out when something breaks. Not for marketing, not for training. If you'd rather keep things anonymous, skip this — it's safe."
-      primaryAction={{ label: 'Continue', onClick: onContinue, disabled: true }}
+      primaryAction={{
+        label: isSignedIn ? 'Continue' : 'Continue without signing in',
+        onClick: () =>
+          onContinue?.({
+            signedIn: isSignedIn,
+            user:
+              state.kind === 'success'
+                ? {
+                    email: state.user?.email ?? null,
+                    name: state.user?.name ?? null,
+                  }
+                : undefined,
+          }),
+      }}
       secondaryAction={{ label: 'Back', onClick: onBack }}
       skipAction={{ label: 'Skip — use without an account', onClick: onSkip }}
       onStartOver={onStartOver}
     >
       <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_minmax(0,380px)]">
         <div className="flex flex-col gap-3">
-          <AuthButton provider="google" />
-          <AuthButton provider="apple" />
+          <AuthButton
+            provider="google"
+            onClick={() => handleSignIn('google')}
+            pending={state.kind === 'pending' && state.provider === 'google'}
+          />
+          <AuthButton
+            provider="apple"
+            onClick={() => handleSignIn('apple')}
+            pending={state.kind === 'pending' && state.provider === 'apple'}
+            disabled
+          />
 
           <p
             className="mt-3 text-[13px] leading-[1.6]"
@@ -32,6 +107,24 @@ export function StepSignIn({ onContinue, onBack, onSkip, onStartOver }: Props) {
             We'll open your browser to finish signing in. You'll come back here
             automatically.
           </p>
+
+          {state.kind === 'pending' ? (
+            <StatusLine
+              tone="info"
+              text={`Waiting for ${state.provider} sign-in to finish in your browser…`}
+            />
+          ) : null}
+          {state.kind === 'error' ? <StatusLine tone="error" text={state.error} /> : null}
+          {state.kind === 'success' ? (
+            <StatusLine
+              tone="ok"
+              text={
+                state.user?.email
+                  ? `Signed in as ${state.user.email}.`
+                  : 'Signed in. Welcome aboard.'
+              }
+            />
+          ) : null}
         </div>
 
         <aside
@@ -104,11 +197,28 @@ export function StepSignIn({ onContinue, onBack, onSkip, onStartOver }: Props) {
   )
 }
 
-function AuthButton({ provider }: { provider: 'google' | 'apple' }) {
-  const label = provider === 'google' ? 'Continue with Google' : 'Continue with Apple'
+function AuthButton({
+  provider,
+  onClick,
+  pending = false,
+  disabled = false,
+}: {
+  provider: 'google' | 'apple'
+  onClick?: () => void
+  pending?: boolean
+  disabled?: boolean
+}) {
+  const label =
+    provider === 'google'
+      ? pending
+        ? 'Opening Google in your browser…'
+        : 'Continue with Google'
+      : 'Continue with Apple (coming soon)'
   return (
     <button
-      className="group flex items-center gap-4 rounded-[18px] border px-6 py-4 text-left transition-all hover:-translate-y-[1px]"
+      onClick={onClick}
+      disabled={disabled || pending}
+      className="group flex items-center gap-4 rounded-[18px] border px-6 py-4 text-left transition-all hover:-translate-y-[1px] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0"
       style={{
         borderColor: 'var(--line-strong)',
         backgroundColor: 'var(--panel)',
@@ -144,6 +254,35 @@ function AuthButton({ provider }: { provider: 'google' | 'apple' }) {
       </span>
     </button>
   )
+}
+
+function StatusLine({ tone, text }: { tone: 'info' | 'ok' | 'error'; text: string }) {
+  const color = tone === 'ok' ? '#3f6230' : tone === 'error' ? 'var(--accent)' : 'var(--muted)'
+  return (
+    <p
+      className="rounded-[12px] border px-3 py-2 text-[12px] leading-[1.55]"
+      style={{
+        borderColor: 'var(--line-strong)',
+        backgroundColor: 'var(--panel-strong)',
+        color,
+        fontFamily: 'var(--font-sans)',
+      }}
+    >
+      {text}
+    </p>
+  )
+}
+
+function humanizeAuthError(raw: string): string {
+  if (raw.startsWith('redeem_failed_501')) {
+    return "Sign-in isn't fully wired in this build. Skip for now — your keys still work."
+  }
+  if (raw.startsWith('redeem_failed_410')) return 'That sign-in link already expired. Try again.'
+  if (raw.startsWith('redeem_failed_404')) return "That sign-in link wasn't found."
+  if (raw === 'safeStorage_unavailable') {
+    return 'macOS Keychain is locked. Unlock it and try again.'
+  }
+  return `Sign-in failed: ${raw}`
 }
 
 function Check() {

--- a/desktop/src/renderer/src/pages/onboarding/StepTestCall.tsx
+++ b/desktop/src/renderer/src/pages/onboarding/StepTestCall.tsx
@@ -1,29 +1,81 @@
+// TODO(voice-test-call): replace this descoped text smoke test with the
+// real bidirectional Gemini Live audio call. Tracked separately so we
+// don't double the size of the wizard-wiring PR. Until then, the test
+// call confirms the saved provider key works end-to-end with a single
+// generateContent round trip — enough to flush the renderer→main→
+// provider path and surface auth errors before the user discovers them
+// the hard way.
+
+import { useEffect, useState } from 'react'
 import { StepFrame } from './StepFrame'
+import { providerApi, type ProviderId } from '../../lib/onboarding-api'
 
 type Props = {
   onContinue?: () => void
   onBack?: () => void
   onStartOver?: () => void
+  providerId?: ProviderId
+  previewMode?: boolean
 }
+
+const SMOKE_PROMPT = "Say 'Hi, I'm VoiceClaw' in five words."
+const PREVIEW_REPLY = "Hi, I'm VoiceClaw — ready."
+
+type TestState =
+  | { kind: 'idle' }
+  | { kind: 'running' }
+  | { kind: 'success'; reply: string; latencyMs: number }
+  | { kind: 'error'; error: string }
 
 const WAVEFORM = [32, 54, 72, 48, 28, 40, 62, 84, 56, 34, 22, 44, 68, 82, 60, 36, 24, 42, 66, 50, 30, 52, 76, 58]
 
-export function StepTestCall({ onContinue, onBack, onStartOver }: Props) {
+export function StepTestCall({
+  onContinue,
+  onBack,
+  onStartOver,
+  providerId = 'gemini',
+  previewMode = false,
+}: Props) {
+  const [state, setState] = useState<TestState>(
+    previewMode
+      ? { kind: 'success', reply: PREVIEW_REPLY, latencyMs: 312 }
+      : { kind: 'idle' },
+  )
+
+  // Auto-run the smoke call on first mount in non-preview mode. Saves a
+  // click and confirms the key works without making the user hunt for a
+  // button. They can rerun via the mic button if they want.
+  useEffect(() => {
+    if (previewMode) return
+    void runSmokeCall(providerId, setState)
+  }, [previewMode, providerId])
+
+  const reply =
+    state.kind === 'success' ? state.reply : state.kind === 'idle' ? '' : ''
+
   return (
     <StepFrame
       stepIndex={6}
       totalSteps={6}
       eyebrow="06 / First call"
       title="Say hi."
-      description="Tap the mic. Speak naturally — nothing fancy, just the kind of thing you'd say to a thoughtful colleague. VoiceClaw will listen, think, and talk back."
-      primaryAction={{ label: "I'm ready — take me in", onClick: onContinue, tone: 'accent' }}
+      description="One last check — we'll ping your provider with a tiny prompt to make sure the key is alive. Real bidirectional voice ships in the next build; this is just the smoke test."
+      primaryAction={{
+        label: state.kind === 'success' ? 'Take me in' : "I'm ready — take me in",
+        onClick: onContinue,
+        tone: 'accent',
+      }}
       secondaryAction={{ label: 'Back', onClick: onBack }}
       onStartOver={onStartOver}
       intense
     >
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)]">
-        <CallSurface />
-        <Transcript />
+        <CallSurface
+          state={state}
+          providerId={providerId}
+          onRerun={() => void runSmokeCall(providerId, setState)}
+        />
+        <Transcript state={state} reply={reply} prompt={SMOKE_PROMPT} />
       </div>
 
       <div
@@ -45,7 +97,7 @@ export function StepTestCall({ onContinue, onBack, onStartOver }: Props) {
             Route
           </span>
           <span className="text-[13px]" style={{ color: 'var(--ink)' }}>
-            Gemini Live · bundled OpenClaw
+            {providerLabel(providerId)} · text-only smoke test
           </span>
         </div>
         <span
@@ -56,14 +108,86 @@ export function StepTestCall({ onContinue, onBack, onStartOver }: Props) {
             color: 'var(--muted)',
           }}
         >
-          latency 182ms · first byte 310ms
+          {state.kind === 'success'
+            ? `latency ${state.latencyMs}ms`
+            : state.kind === 'running'
+              ? 'pinging…'
+              : state.kind === 'error'
+                ? 'check the error above'
+                : 'idle'}
         </span>
       </div>
+
+      <p
+        className="mt-4 text-[12px] leading-[1.55]"
+        style={{ color: 'var(--muted)', fontFamily: 'var(--font-sans)' }}
+      >
+        Your provider key works. Real voice comes next.
+      </p>
     </StepFrame>
   )
 }
 
-function CallSurface() {
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function runSmokeCall(
+  providerId: ProviderId,
+  setState: (s: TestState) => void,
+): Promise<void> {
+  if (providerId !== 'gemini') {
+    // For openai/xai we don't ship a smoke endpoint in this PR — the
+    // validateAndSave call already proved the key works, so we declare
+    // victory and let the user advance.
+    setState({
+      kind: 'success',
+      reply: 'Key validated earlier — skipping smoke test for this provider.',
+      latencyMs: 0,
+    })
+    return
+  }
+  setState({ kind: 'running' })
+  const start = Date.now()
+  try {
+    const result = await providerApi.geminiSmoke(SMOKE_PROMPT)
+    const latencyMs = Date.now() - start
+    if (result.ok) {
+      setState({ kind: 'success', reply: result.text, latencyMs })
+    } else {
+      setState({ kind: 'error', error: result.error })
+    }
+  } catch (err) {
+    setState({
+      kind: 'error',
+      error: err instanceof Error ? err.message : 'Smoke call failed.',
+    })
+  }
+}
+
+function providerLabel(id: ProviderId): string {
+  if (id === 'gemini') return 'Gemini'
+  if (id === 'openai') return 'OpenAI'
+  return 'Grok'
+}
+
+function CallSurface({
+  state,
+  providerId,
+  onRerun,
+}: {
+  state: TestState
+  providerId: ProviderId
+  onRerun: () => void
+}) {
+  const headline =
+    state.kind === 'running'
+      ? 'Pinging…'
+      : state.kind === 'success'
+        ? 'Got a reply.'
+        : state.kind === 'error'
+          ? 'No good.'
+          : 'Ready.'
   return (
     <div
       className="relative flex min-h-[380px] flex-col overflow-hidden rounded-[28px] p-8"
@@ -93,13 +217,13 @@ function CallSurface() {
               color: 'rgba(244,237,231,0.55)',
             }}
           >
-            Live call
+            Smoke test
           </p>
           <p
             className="mt-3 text-[1.8rem] leading-[1.1]"
             style={{ fontFamily: 'var(--font-serif)' }}
           >
-            Listening…
+            {headline}
           </p>
         </div>
         <span
@@ -113,9 +237,17 @@ function CallSurface() {
         >
           <span
             className="h-[6px] w-[6px] rounded-full"
-            style={{ backgroundColor: 'var(--accent)', boxShadow: '0 0 8px var(--accent)' }}
+            style={{
+              backgroundColor:
+                state.kind === 'success'
+                  ? '#7fb15c'
+                  : state.kind === 'error'
+                    ? 'var(--accent)'
+                    : 'var(--accent)',
+              boxShadow: '0 0 8px var(--accent)',
+            }}
           />
-          rec
+          {state.kind === 'success' ? 'ok' : state.kind === 'error' ? 'err' : 'wait'}
         </span>
       </div>
 
@@ -132,6 +264,8 @@ function CallSurface() {
                   height: `${height}%`,
                   backgroundColor: isAccent ? 'var(--accent)' : 'rgba(244,237,231,0.88)',
                   animationDelay: `${delay}s`,
+                  animationPlayState: state.kind === 'running' ? 'running' : 'paused',
+                  opacity: state.kind === 'running' ? 1 : 0.55,
                 }}
               />
             )
@@ -139,7 +273,7 @@ function CallSurface() {
         </div>
 
         <div className="flex items-center justify-between">
-          <MicButton />
+          <RerunButton onClick={onRerun} disabled={state.kind === 'running'} />
           <div>
             <p
               className="text-[11px] uppercase"
@@ -149,10 +283,10 @@ function CallSurface() {
                 color: 'rgba(244,237,231,0.55)',
               }}
             >
-              Voice
+              Provider
             </p>
             <p className="mt-1 text-[15px]" style={{ color: '#f4ede7' }}>
-              Gemini · Zephyr
+              {providerLabel(providerId)}
             </p>
           </div>
           <div>
@@ -164,10 +298,10 @@ function CallSurface() {
                 color: 'rgba(244,237,231,0.55)',
               }}
             >
-              Mic
+              Mode
             </p>
             <p className="mt-1 text-[15px]" style={{ color: '#f4ede7' }}>
-              MacBook Pro
+              Text only · v0.1
             </p>
           </div>
         </div>
@@ -176,35 +310,47 @@ function CallSurface() {
   )
 }
 
-function MicButton() {
+function RerunButton({ onClick, disabled }: { onClick: () => void; disabled: boolean }) {
   return (
     <button
-      className="group relative flex h-16 w-16 items-center justify-center rounded-full transition-transform hover:scale-[1.04]"
+      onClick={onClick}
+      disabled={disabled}
+      className="group relative flex h-16 w-16 items-center justify-center rounded-full transition-transform hover:scale-[1.04] disabled:cursor-not-allowed disabled:opacity-50"
       style={{
         backgroundColor: 'var(--accent)',
         boxShadow: '0 0 0 8px rgba(180, 73, 47, 0.18), 0 12px 28px rgba(180,73,47,0.35)',
       }}
-      aria-label="Start call"
+      aria-label="Rerun smoke test"
     >
       <span
         aria-hidden
         className="absolute inset-0 rounded-full"
         style={{
           border: '1px solid rgba(244,237,231,0.22)',
-          animation: 'vc-pulse 1.6s ease-in-out infinite',
+          animation: disabled ? 'none' : 'vc-pulse 1.6s ease-in-out infinite',
         }}
       />
       <svg viewBox="0 0 24 24" className="h-6 w-6" fill="none" stroke="#f4ede7">
-        <rect x="9" y="3" width="6" height="11" rx="3" strokeWidth="1.8" />
-        <path d="M6 11v1a6 6 0 0 0 12 0v-1" strokeWidth="1.8" strokeLinecap="round" />
-        <path d="M12 18v3" strokeWidth="1.8" strokeLinecap="round" />
-        <path d="M9 21h6" strokeWidth="1.8" strokeLinecap="round" />
+        <path
+          d="M3 12a9 9 0 1 0 3-6.7"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+        />
+        <path d="M3 4v5h5" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
     </button>
   )
 }
 
-function Transcript() {
+function Transcript({
+  state,
+  reply,
+  prompt,
+}: {
+  state: TestState
+  reply: string
+  prompt: string
+}) {
   return (
     <div
       className="flex min-h-[380px] flex-col gap-4 rounded-[28px] border p-6"
@@ -233,23 +379,29 @@ function Transcript() {
             color: 'var(--muted)',
           }}
         >
-          live
+          smoke
         </p>
       </div>
 
       <div className="flex flex-1 flex-col gap-3">
         <Bubble from="you" delay="0.1s">
-          Hey VoiceClaw. Can you hear me alright?
+          {prompt}
         </Bubble>
-        <Bubble from="ai" delay="0.9s">
-          Loud and clear, Michael. Nice to meet you.
-        </Bubble>
-        <Bubble from="you" delay="1.8s">
-          Great. Quick sanity check — what time is it in Toronto right now?
-        </Bubble>
-        <Bubble from="ai" delay="2.6s" thinking>
-          Thinking through brain…
-        </Bubble>
+        {state.kind === 'success' ? (
+          <Bubble from="ai" delay="0.3s">
+            {reply}
+          </Bubble>
+        ) : null}
+        {state.kind === 'running' ? (
+          <Bubble from="ai" delay="0.3s" thinking>
+            Pinging provider…
+          </Bubble>
+        ) : null}
+        {state.kind === 'error' ? (
+          <Bubble from="ai" delay="0.3s">
+            {state.error}
+          </Bubble>
+        ) : null}
       </div>
 
       <div
@@ -271,7 +423,7 @@ function Transcript() {
             color: 'var(--muted)',
           }}
         >
-          On-device · never leaves this Mac
+          On-device · key never leaves this Mac
         </span>
       </div>
     </div>

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -82,6 +82,7 @@ export default defineConfig({
           items: [
             { slug: 'relay-server' },
             { slug: 'desktop-app' },
+            { slug: 'desktop/onboarding', label: 'Desktop: onboarding wizard' },
             { slug: 'desktop/releasing', label: 'Desktop: releasing' },
             { slug: 'mobile-app' },
           ],

--- a/docs/src/content/docs/desktop/onboarding.mdx
+++ b/docs/src/content/docs/desktop/onboarding.mdx
@@ -1,0 +1,97 @@
+---
+title: Desktop onboarding wizard
+description: How VoiceClaw's first-run wizard guides users through sign-in, permissions, provider keys, and brain selection — and how it persists progress so users can resume mid-flow.
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components'
+
+The first time you open VoiceClaw on a Mac, a six-step wizard runs before the main app appears. It captures the bare minimum the app needs to make a real call: a working API key, the right macOS permissions, and a chosen brain. Each step writes its result to SQLite as it advances, so quitting mid-flow drops you back exactly where you left off the next time you launch.
+
+## The six steps
+
+<Steps>
+
+1. **Welcome.** A short pitch and a "let's set up" button. No data captured.
+
+2. **Sign in (optional).** Click *Continue with Google* and we open `https://getvoiceclaw.com/api/auth/google/start?target=desktop` in your browser. Google sends you back to a `voiceclaw://auth/callback?ticket=…` deep link. The desktop app POSTs that ticket to `/api/auth/ticket/redeem`, gets a device token back, and stores it encrypted (see *What gets saved* below). Sign-in is fully skippable for v0.1 — keys still work without an account.
+
+3. **Permissions.** Three rows: microphone, screen recording, accessibility. The wizard reads current state via `systemPreferences.getMediaAccessStatus()` and `systemPreferences.isTrustedAccessibilityClient(false)`. Microphone can be requested in-app; the other two open the matching pane in System Settings (`x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture`, etc.). The wizard polls every second while you're on this step, so granting a permission in System Settings flips the row to a green check without you having to click anything else.
+
+4. **Provider key.** Pick Gemini, OpenAI, or Grok. Paste the key, tab out, and the main process fires a cheap read-only call (`GET /v1beta/models?key=…` for Gemini) to confirm it's alive. On 200, the key is encrypted with [`safeStorage.encryptString`](https://www.electronjs.org/docs/latest/api/safe-storage) (Keychain-backed on macOS) and stored in `provider_keys.key_enc`. On 401/403 we surface "That key doesn't look right." and block continuation.
+
+5. **Brain.** Four options: bundled OpenClaw, detected Claude CLI, detected Codex CLI, and a custom HTTP endpoint. Detection happens via `which claude` / `which codex` with homebrew paths injected into `PATH` so login-item launches still resolve.
+
+6. **Smoke test.** Auto-runs a single `generateContent` round trip against your saved Gemini key with the prompt `"Say 'Hi, I'm VoiceClaw' in five words."`. The reply renders in the transcript bubble; latency lands in the route footer. This step is intentionally text-only for v0.1 — full bidirectional Live audio ships in a follow-up.
+
+</Steps>
+
+<Aside type="note" title="Future: real voice on step 6">
+The text-only smoke call is a deliberate descope. The implementation lives in `desktop/src/main/provider-keys.ts:geminiSmokeCall` with a `TODO(voice-test-call)` marker pointing at the follow-up Linear ticket where the bidirectional audio path will land.
+</Aside>
+
+## What gets saved and where
+
+All wizard state lives in the same SQLite file as the rest of the app, at `~/Library/Application Support/VoiceClaw/voiceclaw.db`:
+
+```sql
+CREATE TABLE onboarding_state (
+  id INTEGER PRIMARY KEY CHECK (id = 1), -- single-row table
+  current_step TEXT NOT NULL DEFAULT 'welcome',
+  payload TEXT NOT NULL DEFAULT '{}', -- JSON blob of step results
+  completed_at TEXT -- ISO timestamp set by markOnboardingComplete()
+);
+
+CREATE TABLE provider_keys (
+  provider TEXT PRIMARY KEY, -- 'gemini' | 'openai' | 'xai'
+  key_enc BLOB NOT NULL, -- safeStorage.encryptString output (Keychain-backed)
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE devices (
+  id TEXT PRIMARY KEY, -- device id from /api/auth/ticket/redeem
+  user_id TEXT,
+  user_email TEXT,
+  user_name TEXT,
+  token_enc BLOB NOT NULL, -- safeStorage-encrypted device token
+  platform TEXT,
+  created_at INTEGER NOT NULL
+);
+```
+
+Plaintext API keys and device tokens **never** touch disk. Electron's `safeStorage` wraps them with the macOS Keychain before they reach SQLite, so a stolen `voiceclaw.db` file alone can't recover them.
+
+## Resetting onboarding for testing
+
+Three options, in increasing destructiveness:
+
+- **Top-bar button.** "Start over" in the wizard's top bar pops a confirmation, then resets `current_step` to `welcome` and clears the payload. **Saved keys and devices stay intact** — only the wizard cursor resets.
+- **Env var.** `VOICECLAW_RESET_ONBOARDING=1 yarn dev` does the same reset on launch, before the window paints. Useful for dev iteration.
+- **Nuke the DB.** `rm ~/Library/Application\ Support/VoiceClaw/voiceclaw.db` resets everything: onboarding cursor, saved keys, device tokens, conversation history. Equivalent to a fresh install.
+
+## Deep link scheme
+
+The desktop app registers `voiceclaw://` as a URL handler at startup via `app.setAsDefaultProtocolClient('voiceclaw')`. macOS routes URLs of that scheme to the running instance via the `open-url` event. We accept exactly one shape:
+
+```
+voiceclaw://auth/callback?ticket=<opaque>
+```
+
+The `ticket` query parameter is exchanged for a device token at `https://getvoiceclaw.com/api/auth/ticket/redeem`. If the redeem fails, the wizard surfaces the error inline on the sign-in step instead of silently advancing.
+
+To override the auth host (useful for testing against a Vercel preview deploy), set `VOICECLAW_AUTH_BASE_URL=https://my-preview.vercel.app` before launching. The default is `https://getvoiceclaw.com`.
+
+## IPC surface
+
+The wizard's renderer talks to the main process exclusively through `window.electronAPI.onboarding`, defined in `desktop/src/preload/index.ts`:
+
+| Method | Returns | Notes |
+| --- | --- | --- |
+| `getState()` | `{ currentStep, payload, completedAt }` | Read on App mount; null `completedAt` means "show wizard." |
+| `updateStep(step, patch)` | merged state | Called on every step transition. Patch merges into existing payload JSON. |
+| `complete()` | merged state | Sets `completed_at = now()`. Called once on the final "Take me in" click. |
+| `reset()` | `{ ok, state? }` | Pops a `dialog.showMessageBox` confirmation; only resets if user confirms. |
+| `startSignIn()` | `{ ok }` | Opens the OAuth URL in the user's browser via `shell.openExternal`. |
+| `onAuthCallback(handler)` | unsubscribe fn | Subscribes to the deep-link event from main. |
+
+Each method is registered via `ipcMain.handle` in `desktop/src/main/ipc-handlers.ts`. The schema is created lazily in `ensureOnboardingSchema()` at app startup, so existing installs upgrade without manual migration.


### PR DESCRIPTION
## Summary

Replaces the wizard's mock state with real persistence and real step behavior. App now reads onboarding state on mount and shows the wizard iff `completed_at IS NULL`; quitting mid-flow resumes on the last step the user actually saw.

Branch: \`michael/nan-onboarding-wizard-wiring\` off latest \`origin/main\`.

### What changed

- **First-run gating.** \`App.tsx\` calls \`window.electronAPI.onboarding.getState()\` on mount and renders \`<OnboardingWizard initialState={…} />\` until \`complete()\` is invoked. No reload between wizard and main app.
- **SQLite schema.** Three new tables, lazily migrated:
  - \`onboarding_state\` — single-row (\`id=1\`) table with \`current_step\`, \`payload\` (JSON), \`completed_at\`.
  - \`provider_keys\` — encrypted key blobs (\`safeStorage.encryptString\`, Keychain-backed) keyed by provider.
  - \`devices\` — device tokens from the desktop OAuth ticket exchange, also encrypted.
- **IPC surface.** \`window.electronAPI.onboarding.{getState, updateStep, complete, reset, startSignIn, onAuthCallback}\` plus \`permissions\`, \`provider\`, and \`brain\` namespaces. Registered the matching \`ipcMain.handle\` blocks in \`ipc-handlers.ts\`.
- **Step 2 — Sign in.** Opens \`getvoiceclaw.com/api/auth/google/start?target=desktop\` via \`shell.openExternal\`. Registers \`voiceclaw://\` as the URL handler, listens for \`voiceclaw://auth/callback?ticket=…\` via \`open-url\`, redeems against \`/api/auth/ticket/redeem\`, stores the encrypted device token. Skippable.
- **Step 3 — Permissions.** Real \`systemPreferences.getMediaAccessStatus\` reads + \`askForMediaAccess\` for mic. Screen + accessibility get the matching \`x-apple.systempreferences:com.apple.preference.security?Privacy_*\` deeplink. 1Hz poll while on the step so grants made in Settings flip to a green check without extra clicks.
- **Step 4 — Provider key.** Validates against the provider's models endpoint (Gemini, OpenAI, xAI), encrypts with \`safeStorage\`, persists. 401/403 surfaces "That key doesn't look right." inline.
- **Step 5 — Brain.** \`which claude\` / \`which codex\` with homebrew paths injected. Custom URL must parse as http(s)://.
- **Step 6 — Smoke test.** Auto-runs a single \`generateContent\` round trip against the saved Gemini key with \`"Say 'Hi, I'm VoiceClaw' in five words."\`. Reply renders in the transcript bubble. \`TODO(voice-test-call)\` marker at the top of \`StepTestCall.tsx\` flags the follow-up for full Live audio.
- **"Start over."** Top-bar button pops a \`dialog.showMessageBox\` confirmation, then resets only the wizard cursor (saved keys + devices stay intact). \`VOICECLAW_RESET_ONBOARDING=1 yarn dev\` does the same on launch.
- **Docs.** \`docs/src/content/docs/desktop/onboarding.mdx\` covers the flow, schema, IPC surface, deep-link scheme, and reset paths. Sidebar entry added.

### Out of scope (intentionally)

- Full bidirectional Gemini Live realtime audio on step 6 — would double the size of this PR. Text-only smoke test confirms the key works end-to-end.
- \`src/main/logger.ts\` and PostHog/analytics surfaces — parallel agent owns those (\`voiceclaw-posthog\` worktree).

### Blockers / notes for reviewer

- Sign-in won't actually complete on a build that doesn't have Vercel env vars set on \`getvoiceclaw.com\` — \`/api/auth/google/start\` returns \`501\` if Google isn't configured. Step 2 is gracefully skippable for exactly this reason; the \"Continue without signing in\" button works regardless of upstream state.
- The wizard appears on every fresh install (no migration of existing users — there are no existing users yet). Users with an existing \`voiceclaw.db\` will see the wizard on first launch of this build because \`completed_at\` is null on the freshly-inserted row; that's the intended onboarding ramp for v0.1.

## Test plan

- [ ] \`yarn install\` in worktree, \`yarn typecheck\` in \`desktop/\` — passes (verified locally)
- [ ] \`yarn build\` in \`desktop/\` — passes (verified locally)
- [ ] \`yarn dev\` — wizard appears on first launch when DB is fresh
- [ ] Walk all 6 steps, click "Take me in" on step 6 — main app loads
- [ ] Quit the app, relaunch — main app loads (no wizard)
- [ ] \`VOICECLAW_RESET_ONBOARDING=1 yarn dev\` — wizard reappears at step 1
- [ ] Step 3: deny mic in System Settings before launch, verify "Open System Settings" button shows
- [ ] Step 4: paste a clearly bogus Gemini key, confirm red "That key doesn't look right." appears; paste a real one, confirm green check
- [ ] Step 4: real Gemini key gets encrypted into \`provider_keys.key_enc\` (verify with \`sqlite3\` that the blob is non-readable bytes, not the raw key)
- [ ] Step 6: with a valid Gemini key, smoke call returns a 5-word reply; with a bogus key, error message renders in the transcript bubble
- [ ] Top-bar "Start over" pops the confirmation dialog; cancel preserves state, confirm resets to step 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)