### PR TITLE
feat(telemetry): add PostHog for analytics + error tracking

### DIFF
--- a/desktop/.env.build.example
+++ b/desktop/.env.build.example
@@ -18,3 +18,14 @@ APPLE_API_KEY_ID=XXXXXXXXXX
 
 # Issuer ID — the UUID shown above the key list on the same page.
 APPLE_API_ISSUER=00000000-0000-0000-0000-000000000000
+
+# PostHog telemetry (analytics + error tracking).
+#
+# - VITE_POSTHOG_PROJECT_TOKEN goes into the renderer bundle (posthog-js).
+# - NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN is also accepted by the main
+#   process; we keep both keys for parity with the website.
+# - Leave empty to disable telemetry entirely.
+VITE_POSTHOG_PROJECT_TOKEN=
+VITE_POSTHOG_HOST=https://us.i.posthog.com
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -16,6 +16,8 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.9.0",
+    "posthog-js": "^1.372.1",
+    "posthog-node": "^5.30.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tailwind-merge": "^3.5.0"

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -16,6 +16,14 @@ import { ensureDefault as ensureLaunchAtLoginDefault } from './login-items'
 import { initAutoUpdater } from './updater'
 import { ensureOnboardingSchema, resetOnboarding } from './onboarding'
 import { registerAuthDeepLink } from './auth'
+import {
+  capture as telemetryCapture,
+  captureException,
+  flush as flushTelemetry,
+  identify as telemetryIdentify,
+  registerProcessHandlers as registerTelemetryHandlers,
+  shutdown as shutdownTelemetry,
+} from './telemetry'
 
 const isDev = !app.isPackaged
 
@@ -41,6 +49,9 @@ app.whenReady().then(async () => {
   registerAuthDeepLink()
   registerIpcHandlers()
   registerScreenCaptureHandlers()
+  registerTelemetryHandlers()
+  telemetryIdentify()
+  telemetryCapture('app_launched', { dev: isDev })
 
   const wasOpenedAsHidden = app.getLoginItemSettings().wasOpenedAsHidden
 
@@ -82,11 +93,13 @@ app.whenReady().then(async () => {
   // Best-effort spawn of bundled services. Missing binary is fine in dev.
   startBundledOpenClaw().catch((err) => {
     console.warn('[openclaw] failed to start', err)
+    captureException(err, { source: 'startBundledOpenClaw' })
   })
 
   // Check for app updates. No-op in dev or when disabled.
   initAutoUpdater().catch((err) => {
     console.warn('[updater] init failed', err)
+    captureException(err, { source: 'initAutoUpdater' })
   })
 
   app.on('activate', () => {
@@ -108,8 +121,20 @@ app.on('window-all-closed', () => {
   hideMainWindow()
 })
 
-app.on('before-quit', () => {
+app.on('before-quit', async (event) => {
   markQuitting()
+  // Flush queued telemetry before exit. Defer the actual quit one tick
+  // so posthog-node can drain its buffer over the wire.
+  if (!quittingFlushed) {
+    event.preventDefault()
+    quittingFlushed = true
+    try {
+      await flushTelemetry()
+      await shutdownTelemetry()
+    } finally {
+      app.quit()
+    }
+  }
 })
 
 app.on('will-quit', () => {
@@ -117,6 +142,16 @@ app.on('will-quit', () => {
   destroyTray()
   closeDb()
 })
+
+let quittingFlushed = false
+
+// Test hook — set VOICECLAW_TEST_ERROR=1 to throw early in main and
+// verify error reporting end-to-end. Off in normal builds.
+if (process.env.VOICECLAW_TEST_ERROR === '1') {
+  setTimeout(() => {
+    throw new Error('VOICECLAW_TEST_ERROR triggered (main)')
+  }, 1500)
+}
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -21,6 +21,13 @@ import {
 import { detectBrains } from './brain-detect'
 import { startSignInFlow } from './auth'
 import { getMainWindow } from './window-lifecycle'
+import {
+  capture as telemetryCapture,
+  captureException as telemetryCaptureException,
+  getDistinctId,
+  isOptedOut as telemetryIsOptedOut,
+  setOptedOut as telemetrySetOptedOut,
+} from './telemetry'
 
 export function registerIpcHandlers() {
   // App lifecycle / system integration
@@ -31,6 +38,30 @@ export function registerIpcHandlers() {
   })
   ipcMain.handle('app:getServiceStatuses', () => serviceManager.getAllStatuses())
   ipcMain.handle('app:getServicePorts', () => getAllocatedPorts())
+
+  // Telemetry. The renderer initializes its own posthog-js client but
+  // shares the same distinct_id so a session ties events from main and
+  // renderer together.
+  ipcMain.handle('telemetry:getDistinctId', () => getDistinctId())
+  ipcMain.handle('telemetry:getOptedOut', () => telemetryIsOptedOut())
+  ipcMain.handle('telemetry:setOptedOut', (_e, optedOut: boolean) => {
+    telemetrySetOptedOut(optedOut)
+    return telemetryIsOptedOut()
+  })
+  ipcMain.handle(
+    'telemetry:capture',
+    (_e, event: string, props?: Record<string, unknown>) => {
+      telemetryCapture(event, props)
+    },
+  )
+  ipcMain.handle(
+    'telemetry:captureException',
+    (_e, err: { message: string, stack?: string }, context?: Record<string, unknown>) => {
+      const error = new Error(err?.message ?? 'unknown')
+      if (err?.stack) error.stack = err.stack
+      telemetryCaptureException(error, context)
+    },
+  )
 
   // Conversations
   ipcMain.handle('db:createConversation', (_e, title?: string) => {

--- a/desktop/src/main/telemetry.ts
+++ b/desktop/src/main/telemetry.ts
@@ -1,0 +1,192 @@
+// Main-process PostHog wrapper for VoiceClaw desktop.
+//
+// - Lazy-init on first use. We never import posthog-node at module top
+//   level — that adds ~200ms to cold start on a quiet machine.
+// - Distinct ID: a UUID stored in the SQLite settings table. Survives
+//   reinstalls (same userData dir) but differs per Mac, so cross-Mac
+//   identification stays separated unless the user signs in.
+// - Opt-out: a `telemetry_opted_out` row in settings. When true,
+//   identify/capture/captureException all become no-ops in O(1).
+// - Failure modes never throw — telemetry errors are swallowed and
+//   logged to console at debug level.
+
+import { app } from 'electron'
+import { randomUUID } from 'crypto'
+import type { PostHog } from 'posthog-node'
+import { getDb } from './db'
+
+const DISTINCT_ID_KEY = 'telemetry_distinct_id'
+const OPT_OUT_KEY = 'telemetry_opted_out'
+
+type CommonProps = Record<string, unknown>
+
+let cachedClient: PostHog | null = null
+let cachedDistinctId: string | null = null
+let cachedOptOut: boolean | null = null
+
+export function getDistinctId(): string {
+  if (cachedDistinctId) return cachedDistinctId
+  cachedDistinctId = readOrCreateDistinctId()
+  return cachedDistinctId
+}
+
+export function isOptedOut(): boolean {
+  if (cachedOptOut !== null) return cachedOptOut
+  try {
+    const db = getDb()
+    const row = db
+      .prepare('SELECT value FROM settings WHERE key = ?')
+      .get(OPT_OUT_KEY) as { value: string } | undefined
+    cachedOptOut = row?.value === 'true'
+  } catch {
+    cachedOptOut = false
+  }
+  return cachedOptOut
+}
+
+export function setOptedOut(optedOut: boolean): void {
+  try {
+    const db = getDb()
+    db.prepare(
+      'INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?',
+    ).run(OPT_OUT_KEY, optedOut ? 'true' : 'false', optedOut ? 'true' : 'false')
+    cachedOptOut = optedOut
+  } catch {
+    // ignore
+  }
+}
+
+export function identify(props?: CommonProps): void {
+  if (isOptedOut()) return
+  try {
+    const client = ensureClient()
+    if (!client) return
+    client.identify({
+      distinctId: getDistinctId(),
+      properties: {
+        $set: {
+          ...props,
+          app_version: app.getVersion(),
+          platform: process.platform,
+          arch: process.arch,
+        },
+      },
+    })
+  } catch {
+    // never throw
+  }
+}
+
+export function capture(event: string, props?: CommonProps): void {
+  if (isOptedOut()) return
+  try {
+    const client = ensureClient()
+    if (!client) return
+    client.capture({
+      distinctId: getDistinctId(),
+      event,
+      properties: { app_version: app.getVersion(), ...props },
+    })
+  } catch {
+    // never throw
+  }
+}
+
+export function captureException(
+  err: unknown,
+  context?: CommonProps,
+): void {
+  if (isOptedOut()) return
+  try {
+    const client = ensureClient()
+    if (!client) return
+    const error = err instanceof Error ? err : new Error(String(err))
+    client.captureException(error, getDistinctId(), {
+      app_version: app.getVersion(),
+      platform: process.platform,
+      ...context,
+    })
+  } catch {
+    // never throw
+  }
+}
+
+export async function flush(): Promise<void> {
+  try {
+    await cachedClient?.flush()
+  } catch {
+    // never throw
+  }
+}
+
+export async function shutdown(): Promise<void> {
+  try {
+    await cachedClient?.shutdown()
+  } catch {
+    // never throw
+  }
+}
+
+// Wire process-level error handlers. Idempotent — safe to call once
+// at app startup. We pair this with `before-quit` flushing in index.ts.
+export function registerProcessHandlers(): void {
+  process.on('uncaughtException', (err) => {
+    captureException(err, { source: 'uncaughtException' })
+  })
+  process.on('unhandledRejection', (reason) => {
+    captureException(reason, { source: 'unhandledRejection' })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ensureClient(): PostHog | null {
+  if (cachedClient) return cachedClient
+  const token = resolveToken()
+  if (!token) return null
+  try {
+    // Resolve the module via dynamic require. Avoids loading posthog-node
+    // during bundler analysis if telemetry is never used.
+    const { PostHog: PostHogCtor } = require('posthog-node') as typeof import('posthog-node')
+    cachedClient = new PostHogCtor(token, {
+      host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? 'https://us.i.posthog.com',
+      flushAt: 5,
+      flushInterval: 10_000,
+    })
+    return cachedClient
+  } catch {
+    return null
+  }
+}
+
+function resolveToken(): string | undefined {
+  // Both `NEXT_PUBLIC_…` (shared with website) and a `desktop`-specific
+  // var are accepted. The shared var matches the spec from the user.
+  return (
+    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN ??
+    process.env.VOICECLAW_POSTHOG_PROJECT_TOKEN
+  )
+}
+
+function readOrCreateDistinctId(): string {
+  try {
+    const db = getDb()
+    const existing = db
+      .prepare('SELECT value FROM settings WHERE key = ?')
+      .get(DISTINCT_ID_KEY) as { value: string } | undefined
+    if (existing?.value) return existing.value
+
+    const id = randomUUID()
+    db.prepare(
+      'INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?',
+    ).run(DISTINCT_ID_KEY, id, id)
+    return id
+  } catch {
+    // If the DB is unavailable, fall back to an in-memory UUID. This
+    // means we lose stable identity across launches — fine for failure
+    // mode but not normal operation.
+    return randomUUID()
+  }
+}

--- a/desktop/src/main/window-lifecycle.ts
+++ b/desktop/src/main/window-lifecycle.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, shell } from 'electron'
 import { join } from 'path'
+import { captureException } from './telemetry'
 
 // Window lifecycle for menu-bar mode. Quitting the window hides it but
 // keeps the process alive (services stay running so mobile can reach
@@ -60,6 +61,17 @@ export function createMainWindow(options: { isDev: boolean; rendererUrl?: string
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     shell.openExternal(url)
     return { action: 'deny' }
+  })
+
+  // Catch renderer crashes and report them to PostHog. The renderer's
+  // own posthog-js init handles uncaught errors at the JS level; this
+  // catches OS-level renderer process termination.
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    captureException(new Error(`render-process-gone: ${details.reason}`), {
+      reason: details.reason,
+      exitCode: details.exitCode,
+      source: 'render-process-gone',
+    })
   })
 
   if (options.isDev && options.rendererUrl) {

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -118,6 +118,18 @@ const electronAPI = {
   net: {
     healthCheck: (url: string) => ipcRenderer.invoke('net:healthCheck', url) as Promise<{ ok: boolean, error?: string }>,
   },
+  telemetry: {
+    getDistinctId: () => ipcRenderer.invoke('telemetry:getDistinctId') as Promise<string>,
+    getOptedOut: () => ipcRenderer.invoke('telemetry:getOptedOut') as Promise<boolean>,
+    setOptedOut: (optedOut: boolean) =>
+      ipcRenderer.invoke('telemetry:setOptedOut', optedOut) as Promise<boolean>,
+    capture: (event: string, props?: Record<string, unknown>) =>
+      ipcRenderer.invoke('telemetry:capture', event, props) as Promise<void>,
+    captureException: (
+      err: { message: string, stack?: string },
+      context?: Record<string, unknown>,
+    ) => ipcRenderer.invoke('telemetry:captureException', err, context) as Promise<void>,
+  },
 }
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI)

--- a/desktop/src/renderer/src/lib/telemetry.ts
+++ b/desktop/src/renderer/src/lib/telemetry.ts
@@ -1,0 +1,112 @@
+// Renderer-side PostHog wrapper. Mirrors main/telemetry.ts but uses
+// posthog-js for in-page session replay + autocapture. The distinct_id
+// is fetched from main via IPC so events from both processes show up
+// under one identity.
+
+import posthog, { type PostHog } from 'posthog-js'
+
+type CommonProps = Record<string, unknown>
+
+const PROJECT_TOKEN = (import.meta as unknown as { env?: Record<string, string> }).env
+  ?.VITE_POSTHOG_PROJECT_TOKEN
+const POSTHOG_HOST = (import.meta as unknown as { env?: Record<string, string> }).env
+  ?.VITE_POSTHOG_HOST ?? 'https://us.i.posthog.com'
+
+let initialized = false
+let optedOut = false
+let initPromise: Promise<PostHog | null> | null = null
+
+export async function initTelemetry(): Promise<PostHog | null> {
+  if (initialized) return optedOut ? null : posthog
+  if (initPromise) return initPromise
+  initPromise = (async () => {
+    try {
+      const electronAPI = (window as unknown as { electronAPI?: ElectronTelemetryAPI }).electronAPI
+      if (!electronAPI) return null
+
+      optedOut = await electronAPI.telemetry.getOptedOut()
+      const distinctId = await electronAPI.telemetry.getDistinctId()
+      if (!PROJECT_TOKEN) {
+        initialized = true
+        return null
+      }
+
+      posthog.init(PROJECT_TOKEN, {
+        api_host: POSTHOG_HOST,
+        bootstrap: { distinctID: distinctId },
+        capture_pageview: false, // SPA-style — no pageviews in desktop
+        autocapture: true,
+        capture_exceptions: true,
+        session_recording: {
+          maskAllInputs: true,
+          maskTextSelector: '[data-ph-mask]',
+        } as Record<string, unknown>,
+        person_profiles: 'identified_only',
+        opt_out_capturing_by_default: optedOut,
+      })
+      posthog.identify(distinctId, { platform: 'desktop' })
+      initialized = true
+      return optedOut ? null : posthog
+    } catch {
+      return null
+    }
+  })()
+  return initPromise
+}
+
+export async function captureRenderer(event: string, props?: CommonProps): Promise<void> {
+  try {
+    const client = await initTelemetry()
+    client?.capture(event, props)
+  } catch {
+    // never throw
+  }
+}
+
+export async function captureRendererException(
+  err: unknown,
+  context?: CommonProps,
+): Promise<void> {
+  try {
+    const client = await initTelemetry()
+    if (!client) return
+    const error = err instanceof Error ? err : new Error(String(err))
+    client.captureException(error, context)
+  } catch {
+    // never throw
+  }
+}
+
+export async function setOptedOutRenderer(value: boolean): Promise<void> {
+  optedOut = value
+  if (value) {
+    posthog.opt_out_capturing()
+  } else {
+    posthog.opt_in_capturing()
+  }
+  const electronAPI = (window as unknown as { electronAPI?: ElectronTelemetryAPI }).electronAPI
+  await electronAPI?.telemetry.setOptedOut(value)
+}
+
+export async function isOptedOutRenderer(): Promise<boolean> {
+  const electronAPI = (window as unknown as { electronAPI?: ElectronTelemetryAPI }).electronAPI
+  if (!electronAPI) return optedOut
+  return electronAPI.telemetry.getOptedOut()
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ElectronTelemetryAPI = {
+  telemetry: {
+    getDistinctId: () => Promise<string>
+    getOptedOut: () => Promise<boolean>
+    setOptedOut: (optedOut: boolean) => Promise<boolean>
+    capture: (event: string, props?: CommonProps) => Promise<void>
+    captureException: (
+      err: { message: string, stack?: string },
+      context?: CommonProps,
+    ) => Promise<void>
+  }
+}

--- a/desktop/src/renderer/src/main.tsx
+++ b/desktop/src/renderer/src/main.tsx
@@ -1,7 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from './App'
+import { initTelemetry } from './lib/telemetry'
 import './index.css'
+
+// Fire-and-forget. Lazy-init handles missing token gracefully.
+initTelemetry()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/desktop/src/renderer/src/pages/SettingsPage.tsx
+++ b/desktop/src/renderer/src/pages/SettingsPage.tsx
@@ -8,6 +8,11 @@ import { Toggle } from '../components/ui/Toggle'
 import { useTheme, type Theme } from '../lib/use-theme'
 import { enumerateAudioDevices, type AudioDevice } from '../lib/audio-engine'
 import { getSetting, setSetting } from '../lib/db'
+import {
+  captureRenderer,
+  isOptedOutRenderer,
+  setOptedOutRenderer,
+} from '../lib/telemetry'
 
 const GEMINI_VOICES = ['Puck', 'Charon', 'Kore', 'Fenrir', 'Aoede', 'Leda', 'Orus', 'Zephyr'] as const
 const GEMINI_VOICE_LABELS: Record<typeof GEMINI_VOICES[number], string> = {
@@ -58,6 +63,9 @@ export function SettingsPage() {
   const [showLatency, setShowLatency] = useState(false)
   const [tracingEnabled, setTracingEnabled] = useState(false)
 
+  // Privacy / telemetry
+  const [telemetryEnabled, setTelemetryEnabled] = useState(true)
+
   const loadedRef = useRef(false)
 
   // Load all settings on mount
@@ -88,6 +96,9 @@ export function SettingsPage() {
       const tr = await getSetting('tracing_enabled')
       if (tr === 'true') setTracingEnabled(true)
 
+      const optedOut = await isOptedOutRenderer()
+      setTelemetryEnabled(!optedOut)
+
       loadedRef.current = true
     })()
 
@@ -106,8 +117,16 @@ export function SettingsPage() {
 
   const updateApiKey = useCallback((v: string) => {
     setApiKey(v)
-    if (loadedRef.current) save('realtime_api_key', v)
-  }, [save])
+    if (loadedRef.current) {
+      save('realtime_api_key', v)
+      // Fire only when the user transitions from blank → set, so we
+      // don't spam an event on every keystroke. Provider name only —
+      // the key itself is never included.
+      if (v && !apiKey) {
+        captureRenderer('provider_key_saved', { provider: 'realtime', model })
+      }
+    }
+  }, [save, apiKey, model])
 
   const updateModel = useCallback((v: RealtimeModel) => {
     setModel(v)
@@ -161,6 +180,11 @@ export function SettingsPage() {
     setSetting('tracing_enabled', v ? 'true' : 'false')
   }, [])
 
+  const toggleTelemetry = useCallback(async (v: boolean) => {
+    setTelemetryEnabled(v)
+    await setOptedOutRenderer(!v)
+  }, [])
+
   const testConnection = useCallback(async () => {
     setTestStatus('testing')
     setTestError('')
@@ -169,13 +193,24 @@ export function SettingsPage() {
       const result = await window.electronAPI.net.healthCheck(serverUrl)
       if (result.ok) {
         setTestStatus('ok')
+        captureRenderer('test_call_completed', { success: true, surface: 'settings' })
       } else {
         setTestStatus('error')
         setTestError(result.error || 'Connection failed')
+        captureRenderer('test_call_completed', {
+          success: false,
+          surface: 'settings',
+          reason: result.error ?? 'unknown',
+        })
       }
     } catch (err) {
       setTestStatus('error')
       setTestError(err instanceof Error ? err.message : 'Connection failed')
+      captureRenderer('test_call_completed', {
+        success: false,
+        surface: 'settings',
+        reason: err instanceof Error ? err.message : 'unknown',
+      })
     }
   }, [serverUrl])
 
@@ -375,6 +410,20 @@ export function SettingsPage() {
               <p className="text-xs text-muted-foreground">Post per-turn latency to Langfuse via relay</p>
             </div>
             <Toggle checked={tracingEnabled} onChange={toggleTracing} />
+          </div>
+        </Card>
+
+        {/* Privacy */}
+        <Card className="p-4 space-y-4">
+          <h3 className="text-sm font-semibold text-foreground">Privacy</h3>
+          <div className="flex items-center justify-between">
+            <div className="pr-4">
+              <p className="text-sm text-foreground">Share anonymous diagnostics</p>
+              <p className="text-xs text-muted-foreground">
+                PostHog telemetry: usage events + crash reports. Never sends voice, transcripts, or API keys.
+              </p>
+            </div>
+            <Toggle checked={telemetryEnabled} onChange={toggleTelemetry} />
           </div>
         </Card>
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -109,6 +109,12 @@ export default defineConfig({
             { slug: 'development/releasing', label: 'Releasing and versioning' },
           ],
         },
+        {
+          label: 'Operations',
+          items: [
+            { slug: 'operations/telemetry', label: 'Telemetry (PostHog)' },
+          ],
+        },
       ],
       customCss: ['./src/styles/custom.css'],
       lastUpdated: true,

--- a/docs/src/content/docs/operations/telemetry.mdx
+++ b/docs/src/content/docs/operations/telemetry.mdx
@@ -1,0 +1,112 @@
+---
+title: Telemetry
+description: What VoiceClaw captures with PostHog, how PII is handled, and how to opt out.
+---
+
+VoiceClaw uses [PostHog](https://posthog.com) for product analytics, error
+tracking, and (website-only) session replay. One vendor across all three
+clients keeps the privacy story simple and the opt-out a single switch.
+
+## What we capture
+
+A small, deliberate set of events. We do not auto-instrument every click
+on first launch — premature instrumentation creates noise that buries
+signal.
+
+| Surface  | Event                    | Properties                                  |
+| -------- | ------------------------ | ------------------------------------------- |
+| Website  | `cta_clicked`            | `location`, `label`, `href`                 |
+| Website  | `$pageview`              | `$current_url`                              |
+| Desktop  | `app_launched`           | `dev` (boolean)                             |
+| Desktop  | `provider_key_saved`     | `provider`, `model` — never the key itself  |
+| Desktop  | `test_call_completed`    | `success`, `surface`, `reason?`             |
+| Desktop  | `onboarding_step_viewed` | `step` (wired by the wizard step files)     |
+| Desktop  | `onboarding_completed`   | (wired by the wizard final step)            |
+| Mobile   | `app_launched`           | (none)                                      |
+| Mobile   | `relay_connected`        | `model`                                     |
+| Mobile   | `conversation_started`   | `has_custom_title`                          |
+
+We also capture:
+
+- **Errors.** Uncaught exceptions, unhandled promise rejections, renderer
+  crashes (Electron `render-process-gone`), and React render errors via
+  PostHog's built-in `captureException`. Stack traces include file paths
+  and variable names but never conversation content.
+- **Session replay** — *website only*. A recording of clicks and DOM
+  events on `getvoiceclaw.com`. All input fields are masked
+  (`maskAllInputs: true`). Anything inside an element with the
+  `data-ph-mask` attribute is also redacted. Session replay does not run
+  inside the desktop or mobile apps.
+
+## What we never capture
+
+- Audio
+- Transcripts of conversations
+- Provider API keys (Gemini, OpenAI, xAI, custom)
+- Anything entered into a password / secret input on the website
+- The contents of voice sessions, transcripts, or chat messages
+
+The desktop main process strips inputs on the wire by storing only
+provider names alongside `provider_key_saved`. The renderer's PostHog
+client masks input elements during session replay (which is off by
+default in desktop and mobile).
+
+## Distinct ID
+
+Each install gets a stable random UUID stored in its local SQLite. It
+survives app updates but differs across machines. When the user signs
+in (Google or Apple), we call `posthog.identify(userId)` so events from
+the anonymous device are merged with the signed-in identity.
+
+## How to opt out
+
+A single toggle controls all telemetry — analytics, error tracking, and
+(future) session replay together.
+
+- **Desktop**: Settings → Privacy → "Share anonymous diagnostics"
+- **Mobile**: Settings → "Share Anonymous Diagnostics"
+- **Website**: managed via the PostHog opt-out cookie. We will add a UI
+  toggle in a follow-up; for now, set
+  `localStorage.setItem('ph_<token>_posthog_opt_out', '1')` and reload.
+
+When opted out, all `capture()` and `captureException()` calls are
+no-ops.
+
+## Verifying telemetry yourself
+
+PostHog has a "Live events" view for the project. Trigger an action in
+the app, switch to that view, and you should see the event arrive
+within a second or two. If nothing appears:
+
+1. Check that the env vars below are set in the right place.
+2. Open the app's developer tools (Cmd-Option-I on desktop) and confirm
+   no `posthog-js` errors appear in the console.
+3. Confirm the opt-out toggle is **off** in Settings.
+
+## Environment variables
+
+| Var                                | Where                                       |
+| ---------------------------------- | ------------------------------------------- |
+| `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN`| Vercel (website), `desktop/.env.build`      |
+| `NEXT_PUBLIC_POSTHOG_HOST`         | Vercel (website), `desktop/.env.build`      |
+| `VITE_POSTHOG_PROJECT_TOKEN`       | `desktop/.env.build` (renderer bundle)      |
+| `VITE_POSTHOG_HOST`                | `desktop/.env.build` (renderer bundle)      |
+| `EXPO_PUBLIC_POSTHOG_PROJECT_TOKEN`| `mobile/.env` or EAS secrets                |
+| `EXPO_PUBLIC_POSTHOG_HOST`         | `mobile/.env` or EAS secrets                |
+
+The same project token can be reused across all three clients —
+PostHog's cross-platform identification stitches the events together
+under one project.
+
+## Internal: where the code lives
+
+- `website/src/lib/telemetry/posthog-client.ts` — browser SDK init and
+  helpers (used by the layout-level provider).
+- `website/src/lib/telemetry/posthog-server.ts` — `captureException`
+  for API routes, plus a `withCapture()` wrapper used by
+  `/api/download/mac`, `/api/me`, and the `/api/auth/*` routes.
+- `desktop/src/main/telemetry.ts` — main-process client, distinct-id
+  bootstrap, opt-out, process-level error handlers.
+- `desktop/src/renderer/src/lib/telemetry.ts` — renderer init via
+  posthog-js. Inherits the distinct ID from main over IPC.
+- `mobile/lib/telemetry.ts` — RN init via `posthog-react-native`.

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -8,6 +8,7 @@ import { BRAND } from '@/lib/brand'
 import type { BrainConnectionMode } from '@/lib/chat'
 import { connectPlugin, disconnectPlugin, getPluginStatus, addPluginStatusListener, type PluginConnectionStatus } from '@/lib/plugin-completion'
 import { runPipelineTests, type TestResult } from '@/lib/pipeline-test-runner'
+import { isOptedOut as isMobileOptedOut, setMobileOptedOut } from '@/lib/telemetry'
 import { useAutoSave, type SaveStatus } from '@/lib/use-auto-save'
 import { validateApiKey, type Provider, type ValidationStatus } from '@/lib/validate-api-key'
 import ExpoCustomPipelineModule from '@/modules/expo-custom-pipeline/src/ExpoCustomPipelineModule'
@@ -95,6 +96,9 @@ export default function SettingsScreen() {
 
   // Langfuse tracing — defaults on in dev builds, off in release
   const [tracingEnabled, setTracingEnabled] = useState<boolean>(__DEV__)
+
+  // PostHog telemetry — opted-in by default, user can turn off
+  const [telemetryEnabled, setTelemetryEnabled] = useState<boolean>(true)
 
   // Kokoro model download state
   const [kokoroStatus, setKokoroStatus] = useState<'checking' | 'ready' | 'not-downloaded' | 'downloading' | 'error' | 'unavailable'>('checking')
@@ -249,6 +253,9 @@ export default function SettingsScreen() {
       const tr = await getSetting('tracing_enabled')
       if (tr === 'true') setTracingEnabled(true)
       else if (tr === 'false') setTracingEnabled(false)
+
+      const optedOut = await isMobileOptedOut()
+      setTelemetryEnabled(!optedOut)
 
       loadedRef.current = true
     })()
@@ -459,6 +466,11 @@ export default function SettingsScreen() {
   const toggleTracing = useCallback((v: boolean) => {
     setTracingEnabled(v)
     setSetting('tracing_enabled', v ? 'true' : 'false')
+  }, [])
+
+  const toggleTelemetry = useCallback(async (v: boolean) => {
+    setTelemetryEnabled(v)
+    await setMobileOptedOut(!v)
   }, [])
 
   return (
@@ -677,6 +689,22 @@ export default function SettingsScreen() {
               testID="tracing-toggle"
               value={tracingEnabled}
               onValueChange={toggleTracing}
+            />
+          </View>
+        </Card>
+
+        <Card testID="telemetry-card" className="gap-2 p-4">
+          <View className="flex-row items-center justify-between">
+            <View className="flex-1">
+              <Text className="text-lg font-semibold text-foreground">Share Anonymous Diagnostics</Text>
+              <Text className="text-sm text-muted-foreground">
+                PostHog telemetry: usage events + crash reports. Never sends voice, transcripts, or API keys.
+              </Text>
+            </View>
+            <Switch
+              testID="telemetry-toggle"
+              value={telemetryEnabled}
+              onValueChange={toggleTelemetry}
             />
           </View>
         </Card>

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -4,6 +4,7 @@ import { runMigrations } from '@/db/migrations'
 import { ConversationProvider } from '@/lib/conversation-context'
 import { BRAND } from '@/lib/brand'
 import { NAV_THEME } from '@/lib/theme'
+import { captureMobile, getClient as getPostHogClient } from '@/lib/telemetry'
 import { ThemeProvider } from '@react-navigation/native'
 import { PortalHost } from '@rn-primitives/portal'
 import { Stack } from 'expo-router'
@@ -30,6 +31,15 @@ export default function RootLayout() {
     runMigrations()
       .then(() => setDbReady(true))
       .then(() => SplashScreen.hideAsync())
+      .then(() => {
+        // Bootstrap PostHog after the DB is ready so the distinct_id
+        // can be read from the settings table.
+        getPostHogClient()
+          .then(() => captureMobile('app_launched'))
+          .catch(() => {
+            // never throw from telemetry
+          })
+      })
       .catch(console.error)
   }, [])
 

--- a/mobile/db/conversations.ts
+++ b/mobile/db/conversations.ts
@@ -1,4 +1,5 @@
 import { db } from './client'
+import { captureMobile } from '@/lib/telemetry'
 
 export type Conversation = {
   id: number
@@ -15,6 +16,8 @@ export async function createConversation(title?: string): Promise<Conversation> 
     'INSERT INTO conversations (title, created_at, updated_at) VALUES (?, ?, ?)',
     [title ?? 'New Conversation', now, now]
   )
+  // Fire-and-forget. captureMobile no-ops if telemetry is disabled.
+  captureMobile('conversation_started', { has_custom_title: title != null })
   return {
     id: result.lastInsertRowId,
     title: title ?? 'New Conversation',

--- a/mobile/lib/telemetry.ts
+++ b/mobile/lib/telemetry.ts
@@ -1,0 +1,154 @@
+// Mobile-side PostHog wrapper. Uses posthog-react-native which handles
+// the RN app lifecycle (foreground/background, screen tracking, native
+// crash hooks) for us.
+//
+// - Lazy-init: the first call to getClient() spins up the SDK. We never
+//   instantiate at module-top so importing this file is cheap.
+// - Distinct ID: stored in the SQLite settings table so it's stable
+//   across reinstalls of the same app on the same device.
+// - Opt-out: a `telemetry_opted_out` setting flips every export to a
+//   no-op. The toggle in the settings screen reads/writes the same row.
+
+import { Platform } from 'react-native'
+import Constants from 'expo-constants'
+import PostHog from 'posthog-react-native'
+import { getSetting, setSetting } from '@/db/settings'
+
+// posthog-react-native's event-property type only allows JSON-serializable
+// values (string | number | boolean | null | nested object/array). We
+// keep `unknown` here for ergonomics at call sites, but cast on the way
+// into capture() so the type system stays out of the way.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CommonProps = Record<string, any>
+
+const DISTINCT_ID_KEY = 'telemetry_distinct_id'
+const OPT_OUT_KEY = 'telemetry_opted_out'
+
+let cachedClient: PostHog | null = null
+let cachedOptOut: boolean | null = null
+let initPromise: Promise<PostHog | null> | null = null
+
+export async function getClient(): Promise<PostHog | null> {
+  if (cachedClient) return cachedClient
+  if (initPromise) return initPromise
+  initPromise = initClient()
+  return initPromise
+}
+
+export async function captureMobile(
+  event: string,
+  props?: CommonProps,
+): Promise<void> {
+  try {
+    if (await isOptedOut()) return
+    const client = await getClient()
+    client?.capture(event, props)
+  } catch {
+    // never throw
+  }
+}
+
+export async function captureMobileException(
+  err: unknown,
+  context?: CommonProps,
+): Promise<void> {
+  try {
+    if (await isOptedOut()) return
+    const client = await getClient()
+    if (!client) return
+    const error = err instanceof Error ? err : new Error(String(err))
+    client.captureException(error, context)
+  } catch {
+    // never throw
+  }
+}
+
+export async function isOptedOut(): Promise<boolean> {
+  if (cachedOptOut !== null) return cachedOptOut
+  try {
+    const v = await getSetting(OPT_OUT_KEY)
+    cachedOptOut = v === 'true'
+  } catch {
+    cachedOptOut = false
+  }
+  return cachedOptOut
+}
+
+export async function setMobileOptedOut(optedOut: boolean): Promise<void> {
+  cachedOptOut = optedOut
+  await setSetting(OPT_OUT_KEY, optedOut ? 'true' : 'false')
+  if (optedOut) {
+    cachedClient?.optOut()
+  } else {
+    cachedClient?.optIn()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function initClient(): Promise<PostHog | null> {
+  try {
+    const token =
+      (Constants.expoConfig?.extra as Record<string, string> | undefined)
+        ?.posthogProjectToken ??
+      process.env.EXPO_PUBLIC_POSTHOG_PROJECT_TOKEN ??
+      process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
+    if (!token) return null
+    const host =
+      (Constants.expoConfig?.extra as Record<string, string> | undefined)
+        ?.posthogHost ??
+      process.env.EXPO_PUBLIC_POSTHOG_HOST ??
+      process.env.NEXT_PUBLIC_POSTHOG_HOST ??
+      'https://us.i.posthog.com'
+
+    const distinctId = await readOrCreateDistinctId()
+
+    const client = new PostHog(token, {
+      host,
+      bootstrap: { distinctId },
+      captureAppLifecycleEvents: true,
+      enableSessionReplay: false, // RN SR is opt-in beta; turn on later per-cohort
+    })
+    client.identify(distinctId, { platform: Platform.OS })
+
+    if (await isOptedOut()) {
+      client.optOut()
+    }
+
+    cachedClient = client
+    return client
+  } catch {
+    return null
+  }
+}
+
+async function readOrCreateDistinctId(): Promise<string> {
+  try {
+    const existing = await getSetting(DISTINCT_ID_KEY)
+    if (existing) return existing
+    const id = generateUuid()
+    await setSetting(DISTINCT_ID_KEY, id)
+    return id
+  } catch {
+    return generateUuid()
+  }
+}
+
+function generateUuid(): string {
+  // RFC4122 v4 — small inline impl to avoid a uuid dep.
+  const cryptoLike =
+    (globalThis as unknown as { crypto?: { getRandomValues?: (b: Uint8Array) => Uint8Array } })
+      .crypto
+  const bytes = new Uint8Array(16)
+  if (cryptoLike?.getRandomValues) {
+    cryptoLike.getRandomValues(bytes)
+  } else {
+    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256)
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}

--- a/mobile/lib/use-realtime.ts
+++ b/mobile/lib/use-realtime.ts
@@ -3,6 +3,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import ExpoRealtimeAudioModule from '@/modules/expo-realtime-audio/src/ExpoRealtimeAudioModule'
+import { captureMobile } from '@/lib/telemetry'
 
 export interface RealtimeConfig {
   serverUrl: string
@@ -229,6 +230,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
 
     ws.onopen = () => {
       console.log('[useRealtime] WebSocket connected, sending session.config')
+      captureMobile('relay_connected', { model: config.model })
       const provider = getProviderForRealtimeModel(config.model)
       ws.send(JSON.stringify({
         type: 'session.config',

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -37,6 +37,7 @@
     "expo-system-ui": "~55.0.15",
     "lucide-react-native": "^1.8.0",
     "nativewind": "^4.2.3",
+    "posthog-react-native": "^4.43.5",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "react-native": "0.83.2",

--- a/website/.env.example
+++ b/website/.env.example
@@ -48,3 +48,12 @@ APPLE_PRIVATE_KEY=
 # automatically for preview deployments; set NEXT_PUBLIC_APP_URL
 # explicitly for production so the prod URL is stable.
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# ---------------------------------------------------------------------------
+# PostHog telemetry (analytics + error tracking + session replay)
+# ---------------------------------------------------------------------------
+# Same project token works for desktop, mobile, and the website. Leaving
+# these empty disables all telemetry — every site/route gracefully
+# no-ops when unset.
+NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=
+NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/website/package.json
+++ b/website/package.json
@@ -20,6 +20,8 @@
     "jose": "^6.2.2",
     "lucide-react": "^1.6.0",
     "next": "16.2.4",
+    "posthog-js": "^1.372.1",
+    "posthog-node": "^5.30.4",
     "prisma": "^6",
     "react": "19.2.5",
     "react-dom": "19.2.5",

--- a/website/src/app/api/auth/apple/callback/route.ts
+++ b/website/src/app/api/auth/apple/callback/route.ts
@@ -5,6 +5,7 @@ import { clearOAuthCookies, readOAuthCookies } from "@/lib/auth/cookies"
 import { isDatabaseConfigured, prisma } from "@/lib/auth/db"
 import { mintAuthTicket } from "@/lib/auth/tokens"
 import { buildAuthCallbackDeepLink, buildCallbackPageHtml } from "@/lib/auth/deep-link"
+import { withCapture } from "@/lib/telemetry/posthog-server"
 
 // GET /api/auth/apple/callback?code=...&state=...
 //
@@ -17,7 +18,7 @@ import { buildAuthCallbackDeepLink, buildCallbackPageHtml } from "@/lib/auth/dee
 //  - Apple's `sub` is stable per-app. Don't try to link it to Google
 //    `sub` across providers unless the user explicitly requests it.
 
-export async function GET(request: NextRequest) {
+export const GET = withCapture(async (request: NextRequest) => {
   if (!isAppleConfigured() || !isDatabaseConfigured()) {
     return NextResponse.json({ error: "not_configured" }, { status: 501 })
   }
@@ -92,7 +93,7 @@ export async function GET(request: NextRequest) {
   )
   clearOAuthCookies(res)
   return res
-}
+}, "/api/auth/apple/callback")
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/website/src/app/api/auth/apple/start/route.ts
+++ b/website/src/app/api/auth/apple/start/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import { generateState } from "arctic"
 import { loadProviderConfig, isAppleConfigured } from "@/lib/auth/providers"
 import { setOAuthCookies } from "@/lib/auth/cookies"
+import { withCapture } from "@/lib/telemetry/posthog-server"
 
 // GET /api/auth/apple/start
 //
@@ -10,7 +11,7 @@ import { setOAuthCookies } from "@/lib/auth/cookies"
 // we still need a state param for CSRF protection and a placeholder
 // verifier to keep the cookie read/write symmetric across providers.
 
-export async function GET(request: Request) {
+export const GET = withCapture(async (request: Request) => {
   if (!isAppleConfigured()) {
     return NextResponse.json({ error: "apple_not_configured" }, { status: 501 })
   }
@@ -34,4 +35,4 @@ export async function GET(request: Request) {
   const res = NextResponse.redirect(authorizationUrl)
   setOAuthCookies(res, statePayload, "apple-no-pkce")
   return res
-}
+}, "/api/auth/apple/start")

--- a/website/src/app/api/auth/google/callback/route.ts
+++ b/website/src/app/api/auth/google/callback/route.ts
@@ -5,6 +5,7 @@ import { clearOAuthCookies, readOAuthCookies } from "@/lib/auth/cookies"
 import { isDatabaseConfigured, prisma } from "@/lib/auth/db"
 import { mintAuthTicket } from "@/lib/auth/tokens"
 import { buildAuthCallbackDeepLink, buildCallbackPageHtml } from "@/lib/auth/deep-link"
+import { withCapture } from "@/lib/telemetry/posthog-server"
 
 // GET /api/auth/google/callback?code=...&state=...
 //
@@ -13,7 +14,7 @@ import { buildAuthCallbackDeepLink, buildCallbackPageHtml } from "@/lib/auth/dee
 // browser then shows a waiting page (in case the app isn't installed)
 // that also tries to open the deep link programmatically.
 
-export async function GET(request: NextRequest) {
+export const GET = withCapture(async (request: NextRequest) => {
   if (!isGoogleConfigured() || !isDatabaseConfigured()) {
     return NextResponse.json({ error: "not_configured" }, { status: 501 })
   }
@@ -95,7 +96,7 @@ export async function GET(request: NextRequest) {
   )
   clearOAuthCookies(res)
   return res
-}
+}, "/api/auth/google/callback")
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/website/src/app/api/auth/google/start/route.ts
+++ b/website/src/app/api/auth/google/start/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 import { generateCodeVerifier, generateState } from "arctic"
 import { loadProviderConfig, isGoogleConfigured } from "@/lib/auth/providers"
 import { setOAuthCookies } from "@/lib/auth/cookies"
+import { withCapture } from "@/lib/telemetry/posthog-server"
 
 // GET /api/auth/google/start
 //
@@ -9,7 +10,7 @@ import { setOAuthCookies } from "@/lib/auth/cookies"
 // stores them as short-lived HttpOnly cookies, redirects to Google's
 // consent screen with our redirect URI baked in.
 
-export async function GET(request: Request) {
+export const GET = withCapture(async (request: Request) => {
   if (!isGoogleConfigured()) {
     return NextResponse.json(
       { error: "google_not_configured" },
@@ -41,4 +42,4 @@ export async function GET(request: Request) {
   const res = NextResponse.redirect(authorizationUrl)
   setOAuthCookies(res, statePayload, codeVerifier)
   return res
-}
+}, "/api/auth/google/start")

--- a/website/src/app/api/auth/ticket/redeem/route.ts
+++ b/website/src/app/api/auth/ticket/redeem/route.ts
@@ -5,6 +5,7 @@ import {
   isSigningKeyConfigured,
   mintDeviceToken,
 } from "@/lib/auth/tokens"
+import { withCapture } from "@/lib/telemetry/posthog-server"
 
 // POST /api/auth/ticket/redeem
 // Body: { ticket: string, label?: string, platform?: "desktop-macos" | "ios" | "android" }
@@ -22,7 +23,7 @@ type Body = {
   platform?: unknown
 }
 
-export async function POST(request: NextRequest) {
+export const POST = withCapture(async (request: NextRequest) => {
   if (!isDatabaseConfigured() || !isSigningKeyConfigured()) {
     return NextResponse.json({ error: "not_configured" }, { status: 501 })
   }
@@ -93,7 +94,7 @@ export async function POST(request: NextRequest) {
     device: { id: device.id, label: device.label, platform: device.platform },
     user,
   })
-}
+}, "/api/auth/ticket/redeem")
 
 // Quick cuid-like id since we need to supply the device id before we can
 // hash its token. Matches the shape Prisma generates elsewhere.

--- a/website/src/app/api/download/mac/route.ts
+++ b/website/src/app/api/download/mac/route.ts
@@ -3,12 +3,13 @@ import {
   getLatestMacReleaseDownload,
   getMacDownloadFallbackUrl,
 } from "@/lib/downloads"
+import { withCapture } from "@/lib/telemetry/posthog-server"
 
-export async function GET() {
+export const GET = withCapture(async () => {
   const release = await getLatestMacReleaseDownload()
 
   return NextResponse.redirect(
     release?.downloadUrl ?? getMacDownloadFallbackUrl(),
     307,
   )
-}
+}, "/api/download/mac")

--- a/website/src/app/api/me/route.ts
+++ b/website/src/app/api/me/route.ts
@@ -5,6 +5,7 @@ import {
   isSigningKeyConfigured,
   verifyDeviceToken,
 } from "@/lib/auth/tokens"
+import { withCapture } from "@/lib/telemetry/posthog-server"
 
 // GET /api/me
 //
@@ -14,7 +15,7 @@ import {
 //   401 when the token is missing or invalid
 //   410 when the device has been revoked
 
-export async function GET(request: NextRequest) {
+export const GET = withCapture(async (request: NextRequest) => {
   if (!isDatabaseConfigured() || !isSigningKeyConfigured()) {
     return NextResponse.json({ error: "not_configured" }, { status: 501 })
   }
@@ -66,7 +67,7 @@ export async function GET(request: NextRequest) {
     },
     mobileAccess: mapMobileAccess(device.user),
   })
-}
+}, "/api/me")
 
 function extractBearer(request: NextRequest): string | null {
   const header = request.headers.get("authorization")

--- a/website/src/app/download/page.tsx
+++ b/website/src/app/download/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react"
 import { BrandWordmark } from "@/components/brand/brand-system"
 import { ThemeSwitcher } from "@/components/theme-switcher"
+import { TrackCtaAnchor } from "@/components/telemetry/track-cta-anchor"
 
 const REPO_URL = "https://github.com/yagudaev/voiceclaw"
 const RELEASES_URL = "https://github.com/yagudaev/voiceclaw/releases"
@@ -113,13 +114,15 @@ function DownloadCard() {
             Universal DMG — Apple Silicon and Intel in a single file.
           </p>
         </div>
-        <a
+        <TrackCtaAnchor
+          ctaLocation="download_page"
+          ctaLabel="Download for Mac"
           href={MAC_DOWNLOAD_URL}
           className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-[var(--brand-accent)] px-5 text-sm font-semibold text-primary-foreground transition hover:bg-[var(--brand-accent-hover)]"
         >
           <Download className="size-4" />
           Download for Mac
-        </a>
+        </TrackCtaAnchor>
       </div>
       <p className="mt-5 text-xs text-[var(--brand-muted)]">
         Clicking the button redirects to the latest release on GitHub. Every

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -1,6 +1,9 @@
+import { Suspense } from "react"
 import type { Metadata } from "next"
 import { Fraunces, Geist, Geist_Mono, JetBrains_Mono } from "next/font/google"
 import Script from "next/script"
+import { PostHogClientProvider } from "@/components/telemetry/posthog-provider"
+import { PostHogErrorBoundary } from "@/components/telemetry/posthog-error-boundary"
 import "./globals.css"
 
 const geistSans = Geist({
@@ -59,7 +62,11 @@ export default function RootLayout({
           strategy="beforeInteractive"
           dangerouslySetInnerHTML={{ __html: themeScript }}
         />
-        {children}
+        <Suspense fallback={null}>
+          <PostHogClientProvider>
+            <PostHogErrorBoundary>{children}</PostHogErrorBoundary>
+          </PostHogClientProvider>
+        </Suspense>
       </body>
     </html>
   )

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -19,6 +19,7 @@ import {
   VoiceClawMark,
 } from "@/components/brand/brand-system"
 import { ThemeSwitcher } from "@/components/theme-switcher"
+import { TrackCtaLink } from "@/components/telemetry/track-cta"
 import {
   getLatestMacReleaseDownload,
   type MacReleaseDownload,
@@ -68,7 +69,9 @@ function Header({
             Download
           </Link>
           <ThemeSwitcher />
-          <Link
+          <TrackCtaLink
+            ctaLocation="header"
+            ctaLabel="Download Mac"
             href={MAC_DOWNLOAD_URL}
             aria-label="Download for Mac"
             title={downloadTitle(macRelease)}
@@ -76,7 +79,7 @@ function Header({
           >
             <Download className="size-4" />
             <span className="hidden sm:inline">Download Mac</span>
-          </Link>
+          </TrackCtaLink>
         </nav>
       </div>
     </header>
@@ -110,14 +113,16 @@ function HeroSection({
               the transcript while your agent does the real work.
             </p>
             <div className="mt-9 flex flex-col gap-3 sm:flex-row">
-              <Link
+              <TrackCtaLink
+                ctaLocation="hero"
+                ctaLabel="Download for Mac"
                 href={MAC_DOWNLOAD_URL}
                 title={downloadTitle(macRelease)}
                 className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-[var(--brand-accent)] px-5 text-sm font-semibold text-primary-foreground transition hover:bg-[var(--brand-accent-hover)]"
               >
                 <Download className="size-4" />
                 Download for Mac
-              </Link>
+              </TrackCtaLink>
               <Link
                 href="#demo"
                 className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-[var(--brand-line-strong)] bg-[var(--brand-panel)] px-5 text-sm font-semibold text-[var(--brand-ink)] transition hover:border-[var(--brand-accent)]"
@@ -380,14 +385,16 @@ function GetStartedSection({
           </p>
         </div>
         <div className="flex flex-col justify-end gap-3">
-          <Link
+          <TrackCtaLink
+            ctaLocation="get_started"
+            ctaLabel="Download for Mac"
             href={MAC_DOWNLOAD_URL}
             title={downloadTitle(macRelease)}
             className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-[var(--brand-contrast-fg)] px-5 text-sm font-semibold text-[var(--brand-contrast-bg)] transition hover:bg-[var(--brand-contrast-fg-hover)]"
           >
             <Download className="size-4" />
             Download for Mac
-          </Link>
+          </TrackCtaLink>
           <MacDownloadVersion release={macRelease} contrast />
           <a
             href={REPO_URL}

--- a/website/src/app/privacy/page.tsx
+++ b/website/src/app/privacy/page.tsx
@@ -14,6 +14,12 @@ export default function PrivacyPage() {
       lastUpdated="April 24, 2026"
       lede="VoiceClaw is a voice layer that lives on your own Mac and phone. Your audio, transcripts, and provider API keys stay on your devices — we never receive them. This page describes the narrow slice of data we do collect, why, and what we promise not to do with it."
     >
+      {/*
+        Telemetry note: error tracking is handled by PostHog's built-in
+        captureException + session replay (same SDK as analytics). The
+        previous separate "Sentry for crash reports" line is gone — one
+        vendor, one opt-out switch.
+      */}
       <h2>The short version</h2>
       <ul>
         <li>
@@ -29,8 +35,9 @@ export default function PrivacyPage() {
         </li>
         <li>
           <strong>We use:</strong> Vercel to host this website, Neon (Postgres) to
-          store your account, PostHog for anonymous product analytics, Sentry
-          for crash reports.
+          store your account, and PostHog for anonymous product analytics,
+          error tracking, and session replays (with all input fields
+          masked).
         </li>
         <li>
           <strong>You can:</strong> delete your account, export your data, or opt
@@ -73,25 +80,40 @@ export default function PrivacyPage() {
         original from the hash).
       </p>
 
-      <h3>Analytics</h3>
+      <h3>Analytics, error tracking, and session replay</h3>
       <p>
-        We use <a href="https://posthog.com">PostHog</a> to track anonymous
-        product events: which onboarding steps you completed, which provider
-        and brain you selected, how long a step took, whether the test call
-        succeeded. These events include a random device ID but are not linked
-        to your identity. We do not send the contents of your conversations or
-        any audio.
+        We use <a href="https://posthog.com">PostHog</a> for three things:
+      </p>
+      <ul>
+        <li>
+          <strong>Anonymous product analytics</strong> — which onboarding
+          steps you completed, which provider and brain you selected, how
+          long a step took, whether the test call succeeded.
+        </li>
+        <li>
+          <strong>Error tracking</strong> — uncaught exceptions, unhandled
+          promise rejections, and renderer crashes, with stack traces and
+          some system metadata (OS version, app version). Stack traces can
+          include file paths and variable names but not the contents of
+          your conversations.
+        </li>
+        <li>
+          <strong>Session replays of the website only</strong> — a recording
+          of clicks and DOM events on{" "}
+          <code>getvoiceclaw.com</code> so we can debug UI bugs. All input
+          fields are masked: your typing is never recorded. Session replays
+          do <em>not</em> run inside the desktop or mobile apps.
+        </li>
+      </ul>
+      <p>
+        Events include a random device ID but are not linked to your
+        identity. We do not send the contents of your conversations, any
+        audio, or any provider API keys.
       </p>
       <p>
-        You can turn analytics off in Settings → Privacy at any time.
-      </p>
-
-      <h3>Crash reports</h3>
-      <p>
-        If the app crashes, we use <a href="https://sentry.io">Sentry</a> to
-        send the crash&apos;s stack trace and some system metadata (OS version, app
-        version). Crash reports can include file paths and variable names in
-        the stack, but not the contents of your conversations.
+        You can turn telemetry off in Settings → Privacy at any time. The
+        toggle covers analytics, error tracking, and session replay
+        together.
       </p>
 
       <h2>What we do not receive</h2>
@@ -134,11 +156,9 @@ export default function PrivacyPage() {
           in the United States.
         </li>
         <li>
-          <strong>PostHog</strong> — anonymous product analytics, as described
-          above. Opt-out in Settings.
-        </li>
-        <li>
-          <strong>Sentry</strong> — crash reports, as described above.
+          <strong>PostHog</strong> — anonymous product analytics, error
+          tracking, and (website only) session replay with input masking,
+          as described above. Opt-out in Settings.
         </li>
         <li>
           <strong>Google / Apple</strong> — OAuth providers for sign-in. They
@@ -163,7 +183,7 @@ export default function PrivacyPage() {
 
       <h2>International transfers</h2>
       <p>
-        Our servers (Vercel, Neon, PostHog, Sentry) are located in the United
+        Our servers (Vercel, Neon, PostHog) are located in the United
         States. If you access VoiceClaw from outside the US, your account data
         is transferred to and stored in the US. For users in the EU / EEA, we
         rely on Standard Contractual Clauses with our processors as the legal

--- a/website/src/components/telemetry/posthog-error-boundary.tsx
+++ b/website/src/components/telemetry/posthog-error-boundary.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { Component, type ErrorInfo, type ReactNode } from "react"
+import { captureException } from "@/lib/telemetry/posthog-client"
+
+type Props = {
+  children: ReactNode
+  fallback?: ReactNode
+}
+
+type State = {
+  hasError: boolean
+}
+
+export class PostHogErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    captureException(error, { componentStack: info.componentStack })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? null
+    }
+    return this.props.children
+  }
+}

--- a/website/src/components/telemetry/posthog-provider.tsx
+++ b/website/src/components/telemetry/posthog-provider.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { useEffect } from "react"
+import { usePathname, useSearchParams } from "next/navigation"
+import { capture, getClient } from "@/lib/telemetry/posthog-client"
+
+// Mounts on the client and triggers PostHog init. Also reports a manual
+// $pageview on route changes since the App Router doesn't fire a full
+// navigation that posthog-js's auto-pageview can detect on its own.
+
+export function PostHogClientProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    // kick off lazy init
+    getClient().catch(() => {
+      // ignore — no telemetry is fine
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!pathname) return
+    const url =
+      typeof window === "undefined"
+        ? pathname
+        : window.location.origin + pathname + (searchParams?.toString() ? `?${searchParams.toString()}` : "")
+    capture("$pageview", { $current_url: url })
+  }, [pathname, searchParams])
+
+  return <>{children}</>
+}

--- a/website/src/components/telemetry/track-cta-anchor.tsx
+++ b/website/src/components/telemetry/track-cta-anchor.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { type AnchorHTMLAttributes } from "react"
+import { capture } from "@/lib/telemetry/posthog-client"
+
+type Props = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  ctaLocation: string
+  ctaLabel: string
+}
+
+// Anchor variant of TrackCtaLink for hrefs that need to hit our API
+// routes (e.g. /api/download/mac which 307-redirects to GitHub).
+export function TrackCtaAnchor({
+  ctaLocation,
+  ctaLabel,
+  onClick,
+  ...rest
+}: Props) {
+  return (
+    <a
+      {...rest}
+      onClick={(e) => {
+        capture("cta_clicked", {
+          location: ctaLocation,
+          label: ctaLabel,
+          href: rest.href,
+        })
+        onClick?.(e)
+      }}
+    />
+  )
+}

--- a/website/src/components/telemetry/track-cta.tsx
+++ b/website/src/components/telemetry/track-cta.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { type ComponentProps } from "react"
+import Link from "next/link"
+import { capture } from "@/lib/telemetry/posthog-client"
+
+type Props = ComponentProps<typeof Link> & {
+  ctaLocation: string
+  ctaLabel: string
+}
+
+// Drop-in <Link> wrapper that fires a `cta_clicked` event before
+// navigation. We don't await the capture so it doesn't slow the click;
+// posthog-js batches and flushes via the SDK's own keepalive logic.
+export function TrackCtaLink({ ctaLocation, ctaLabel, onClick, ...rest }: Props) {
+  return (
+    <Link
+      {...rest}
+      onClick={(e) => {
+        capture("cta_clicked", {
+          location: ctaLocation,
+          label: ctaLabel,
+          href: typeof rest.href === "string" ? rest.href : undefined,
+        })
+        onClick?.(e)
+      }}
+    />
+  )
+}

--- a/website/src/lib/telemetry/posthog-client.ts
+++ b/website/src/lib/telemetry/posthog-client.ts
@@ -1,0 +1,106 @@
+// Client-side PostHog wrapper.
+//
+// - Lazy-init on the first call from the browser. We never run during SSR.
+// - Bails cleanly (no-op) if the public token is missing so dev/preview
+//   deploys without telemetry env vars still build and run.
+// - Captures: pageviews, pageleaves, autocapture (clicks/forms),
+//   session recordings (with input masking via [data-ph-mask]),
+//   uncaught exceptions + unhandled promise rejections.
+
+import type { PostHog } from "posthog-js"
+
+type PostHogModule = typeof import("posthog-js")
+
+let cachedClient: PostHog | null = null
+let initPromise: Promise<PostHog | null> | null = null
+
+export function isTelemetryConfigured(): boolean {
+  return Boolean(process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN)
+}
+
+export async function getClient(): Promise<PostHog | null> {
+  if (typeof window === "undefined") return null
+  if (cachedClient) return cachedClient
+  if (!isTelemetryConfigured()) return null
+
+  if (!initPromise) {
+    initPromise = initClient()
+  }
+  return initPromise
+}
+
+export async function capture(
+  event: string,
+  props?: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const client = await getClient()
+    client?.capture(event, props)
+  } catch {
+    // never throw from telemetry
+  }
+}
+
+export async function captureException(
+  err: unknown,
+  context?: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const client = await getClient()
+    if (!client) return
+    const error = err instanceof Error ? err : new Error(String(err))
+    client.captureException(error, context)
+  } catch {
+    // never throw from telemetry
+  }
+}
+
+export async function identify(
+  distinctId: string,
+  props?: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const client = await getClient()
+    client?.identify(distinctId, props)
+  } catch {
+    // never throw from telemetry
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function initClient(): Promise<PostHog | null> {
+  try {
+    const token = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
+    const host =
+      process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com"
+    if (!token) return null
+
+    const mod = (await import("posthog-js")) as unknown as PostHogModule
+    const posthog = mod.default ?? (mod as unknown as PostHog)
+
+    posthog.init(token, {
+      api_host: host,
+      capture_pageview: true,
+      capture_pageleave: true,
+      autocapture: true,
+      capture_exceptions: true,
+      session_recording: {
+        maskAllInputs: true,
+        maskTextSelector: "[data-ph-mask]",
+      } as Record<string, unknown>,
+      person_profiles: "identified_only",
+      loaded: () => {
+        // PostHog auto-captures unhandled errors / rejections via
+        // capture_exceptions: true. Nothing extra needed here.
+      },
+    })
+
+    cachedClient = posthog
+    return posthog
+  } catch {
+    return null
+  }
+}

--- a/website/src/lib/telemetry/posthog-server.ts
+++ b/website/src/lib/telemetry/posthog-server.ts
@@ -1,0 +1,90 @@
+// Server-side PostHog wrapper. Used by API routes to send events and
+// captureException without dragging the browser SDK into Node.
+//
+// - Lazy-init in the request handler. Reuses a cached PostHog instance
+//   across invocations within the same lambda warm.
+// - Fails closed: if the token is missing or the SDK throws, every
+//   exported function becomes a no-op.
+
+import { PostHog as PostHogServer } from "posthog-node"
+
+let cachedClient: PostHogServer | null = null
+
+export function captureServerEvent(
+  distinctId: string,
+  event: string,
+  props?: Record<string, unknown>,
+): void {
+  try {
+    const client = ensureClient()
+    client?.capture({ distinctId, event, properties: props })
+  } catch {
+    // never throw from telemetry
+  }
+}
+
+export function captureServerException(
+  err: unknown,
+  options?: {
+    distinctId?: string
+    properties?: Record<string, unknown>
+  },
+): void {
+  try {
+    const client = ensureClient()
+    if (!client) return
+    const error = err instanceof Error ? err : new Error(String(err))
+    client.captureException(error, options?.distinctId, options?.properties)
+  } catch {
+    // never throw from telemetry
+  }
+}
+
+export async function flushServerEvents(): Promise<void> {
+  try {
+    await cachedClient?.flush()
+  } catch {
+    // never throw from telemetry
+  }
+}
+
+// Wrap an API route handler so any thrown error is captured to PostHog
+// before it bubbles back to Next. Returns the handler unmodified if
+// telemetry is not configured.
+export function withCapture<T extends (...args: never[]) => Promise<unknown>>(
+  handler: T,
+  routeName: string,
+): T {
+  return (async (...args: Parameters<T>) => {
+    try {
+      return await handler(...args)
+    } catch (err) {
+      captureServerException(err, {
+        distinctId: "server",
+        properties: { route: routeName },
+      })
+      throw err
+    }
+  }) as T
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ensureClient(): PostHogServer | null {
+  if (cachedClient) return cachedClient
+  const token = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
+  if (!token) return null
+
+  try {
+    cachedClient = new PostHogServer(token, {
+      host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com",
+      flushAt: 1,
+      flushInterval: 0,
+    })
+    return cachedClient
+  } catch {
+    return null
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3653,6 +3653,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/api-logs@npm:0.208.0, @opentelemetry/api-logs@npm:^0.208.0":
+  version: 0.208.0
+  resolution: "@opentelemetry/api-logs@npm:0.208.0"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.3.0"
+  checksum: 10c0/dc1fbee6219df4166509f43b74ea936bb18b6d594565b0bcf56b654a1c958b50d6046b8739dc36c98149fe890c02150ff3814e963f5ea439a07ff3c562555b99
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/api-logs@npm:0.215.0":
   version: 0.215.0
   resolution: "@opentelemetry/api-logs@npm:0.215.0"
@@ -3662,7 +3671,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.9.1":
+"@opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.9.0, @opentelemetry/api@npm:^1.9.1":
   version: 1.9.1
   resolution: "@opentelemetry/api@npm:1.9.1"
   checksum: 10c0/c608485fc8b5a91e1f7e05e843b45b509307456b31cd2ad365933d90813e40ebfedf179f1451c762037e82d7c76aa8500e95d2da3609f640a1206cde5322cd14
@@ -3687,6 +3696,17 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   checksum: 10c0/6ecdae80909b11a31852617af523615635526af16208f54d7793fa353bfa506ff161536f4492cb6e78efb6fc9cb7de86624d81439d08201d789a90f451d5c299
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/core@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@opentelemetry/core@npm:2.2.0"
+  dependencies:
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: 10c0/f618b63f2f560d052791d2406b1411722aa4b0585031242e6906f869f0a707ffe725c4b29bf18aed1f202e1ab5dfc3a9f769c517ac8521338b33ac8c4265fba9
   languageName: node
   linkType: hard
 
@@ -3729,6 +3749,21 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: 10c0/d2ccf2ef14d16cc2b65727b29b0f00673e3f318c136f4beadd1ada8b352f6998e97b689738c233d2a0a94d182a9ee7c1210fca5afad97acebb2344b461b23c60
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/exporter-logs-otlp-http@npm:^0.208.0":
+  version: 0.208.0
+  resolution: "@opentelemetry/exporter-logs-otlp-http@npm:0.208.0"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.208.0"
+    "@opentelemetry/core": "npm:2.2.0"
+    "@opentelemetry/otlp-exporter-base": "npm:0.208.0"
+    "@opentelemetry/otlp-transformer": "npm:0.208.0"
+    "@opentelemetry/sdk-logs": "npm:0.208.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/2b8c649e04bfc7c86ebc49de4afb19ccd2562ebfc15ac30f1689787d9b014392f6d936f43b494729d9723de0588276027f742ba825834c74d8a08cd366c284ab
   languageName: node
   linkType: hard
 
@@ -3886,6 +3921,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/otlp-exporter-base@npm:0.208.0":
+  version: 0.208.0
+  resolution: "@opentelemetry/otlp-exporter-base@npm:0.208.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.2.0"
+    "@opentelemetry/otlp-transformer": "npm:0.208.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/c2b2014da16e2a2be0ebe525b1a62b3e64e286fc9c2575444e4c75bbe0060a83762172180dc7a97cdaaaa8c6765076073edea30340459fc1820cd43468ff98b0
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/otlp-exporter-base@npm:0.215.0":
   version: 0.215.0
   resolution: "@opentelemetry/otlp-exporter-base@npm:0.215.0"
@@ -3909,6 +3956,23 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: 10c0/e4835f7c6cac7c425339beee9bd5561189b4290cfc322f68a86c9bc0ba857694aed9e88b771a542227db44b7e6d26e009f1ef7a657bff51401efc22a85c7ca3c
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/otlp-transformer@npm:0.208.0":
+  version: 0.208.0
+  resolution: "@opentelemetry/otlp-transformer@npm:0.208.0"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.208.0"
+    "@opentelemetry/core": "npm:2.2.0"
+    "@opentelemetry/resources": "npm:2.2.0"
+    "@opentelemetry/sdk-logs": "npm:0.208.0"
+    "@opentelemetry/sdk-metrics": "npm:2.2.0"
+    "@opentelemetry/sdk-trace-base": "npm:2.2.0"
+    protobufjs: "npm:^7.3.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 10c0/70c04b2a52f0b2f8aece25ad21401c32ed3136ccd6e82b767d570a24d5456a5ded206ed4cc60ebc09eac08a4aa9c03bc8dcbf10730e491f1af3e7768c361ac12
   languageName: node
   linkType: hard
 
@@ -3951,7 +4015,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/resources@npm:2.7.0":
+"@opentelemetry/resources@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@opentelemetry/resources@npm:2.2.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.2.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10c0/f08fa69ccccb6d14b6932fabe6f8e097c0dfc41ae8f4c0f6c54fb04bc3d9c04e742da3e22d7240d74b585287101126d97a0da192b493a9724dc07a56ca1b77e0
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/resources@npm:2.7.0, @opentelemetry/resources@npm:^2.2.0":
   version: 2.7.0
   resolution: "@opentelemetry/resources@npm:2.7.0"
   dependencies:
@@ -3960,6 +4036,19 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.3.0 <1.10.0"
   checksum: 10c0/44b4df76b9429397db9a9b4b223448ae242a7014949693128de604d871cb4c55e6a612dd9a2cbf5069c2441acafcb990474e85445d463de260b223b7bc3f8143
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-logs@npm:0.208.0, @opentelemetry/sdk-logs@npm:^0.208.0":
+  version: 0.208.0
+  resolution: "@opentelemetry/sdk-logs@npm:0.208.0"
+  dependencies:
+    "@opentelemetry/api-logs": "npm:0.208.0"
+    "@opentelemetry/core": "npm:2.2.0"
+    "@opentelemetry/resources": "npm:2.2.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.4.0 <1.10.0"
+  checksum: 10c0/a167ee7d2818e435ff7480836461f94543e4e39f0e8e8013d462c635def9b960dcf1a29e5536743946b51ef13b764f518d9edb511e89bc1e8995acc96f54241f
   languageName: node
   linkType: hard
 
@@ -3974,6 +4063,18 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.4.0 <1.10.0"
   checksum: 10c0/523bc260ddf3f2d8755b6b080e5eec301a101a9a45a178cfcbda20f94d3b93817d9c8d6165b6b8deee961615eff8a4e64a0bb9b8a9950d14ad0750c4623b3d89
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-metrics@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@opentelemetry/sdk-metrics@npm:2.2.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.2.0"
+    "@opentelemetry/resources": "npm:2.2.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.9.0 <1.10.0"
+  checksum: 10c0/a2668f9ef937123552a5ab96ec23675931ae7d3223ec7a31c8aac95fbbfb0b03a54a873f17f2356b04db7031421e7e3d7e3bf9d96d9069a0b97c680a2c158bc4
   languageName: node
   linkType: hard
 
@@ -4021,6 +4122,19 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.3.0 <1.10.0"
   checksum: 10c0/a83d94f657932047a1a22d9c38fbb5d30bf8597b571b09298cd5ce3f078612d73ecf7bd849491a873337ec5dfa2785bbea9dd6322138750300ee7558826c88c3
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-trace-base@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@opentelemetry/sdk-trace-base@npm:2.2.0"
+  dependencies:
+    "@opentelemetry/core": "npm:2.2.0"
+    "@opentelemetry/resources": "npm:2.2.0"
+    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+  checksum: 10c0/a67715b71d7253cd61ea79954f56491796ac7a660d03d5381fd81defd4546042bb465b27e1b6eee4b1ed32c00305a5349a16d04fd44314c9a1d371a0a638107a
   languageName: node
   linkType: hard
 
@@ -4173,6 +4287,22 @@ __metadata:
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
   checksum: 10c0/5bd7576bb1b38a47a7fc7b51ac9f38748e772beebc56200450c4a817d712232b8f1d3ef70532c80840243c657d491cf6a6be1e3a214cff907645819fdc34aadd
+  languageName: node
+  linkType: hard
+
+"@posthog/core@npm:1.27.5":
+  version: 1.27.5
+  resolution: "@posthog/core@npm:1.27.5"
+  dependencies:
+    "@posthog/types": "npm:1.372.1"
+  checksum: 10c0/b050ec78eced0d8152b1dd7c591586daad76da56f64fec9e2cab44447ee5b3c0378b2f69ee9244d5d78814178fc691ddab5f0519d15f9f2f1e76110c60acd0a9
+  languageName: node
+  linkType: hard
+
+"@posthog/types@npm:1.372.1":
+  version: 1.372.1
+  resolution: "@posthog/types@npm:1.372.1"
+  checksum: 10c0/a903ed1e2b486db40733b8e5222537e307eda52e94689dcba9afd2e2d6be1f8eb11323401dc87bd66061ec90614dbdab8fc69dbd9101fae74d3f7179ff5de89b
   languageName: node
   linkType: hard
 
@@ -9250,6 +9380,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js@npm:^3.38.1":
+  version: 3.49.0
+  resolution: "core-js@npm:3.49.0"
+  checksum: 10c0/2e42edb47eda38fd5368380131623c8aa5d4a6b42164125b17744bdc08fa5ebbbdd06b4b4aa6ca3663470a560b0f2fba48e18f142dfe264b0039df85bc625694
+  languageName: node
+  linkType: hard
+
 "core-util-is@npm:1.0.2":
   version: 1.0.2
   resolution: "core-util-is@npm:1.0.2"
@@ -10273,6 +10410,18 @@ __metadata:
     "@types/trusted-types":
       optional: true
   checksum: 10c0/5593ac44ee20b9aa521c2120884effc98927fb9128c548183c75e79e0a04357c62ee913a049a267c8f396cb8c9d520ecf72562826c5524c46d4fe03c12063638
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.3.2":
+  version: 3.4.1
+  resolution: "dompurify@npm:3.4.1"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10c0/440a4246020cb54b82ef2cb66381e4d310a0c470f9994655e61b6122811f0eaa00a2f9665d2bed30ca3f58932ba7bb0d5e26fdfce61c8daf35d21a3f5a799e48
   languageName: node
   linkType: hard
 
@@ -12047,6 +12196,13 @@ __metadata:
   version: 0.4.10
   resolution: "fetch-nodeshim@npm:0.4.10"
   checksum: 10c0/73b840b5d1252e82c416b350526ff24f5aebf554bfe911c713a19fbe4ad1218fb4c488f95055362a132f5dd733679c929fbe6a65ee23339592290c4d107ade92
+  languageName: node
+  linkType: hard
+
+"fflate@npm:^0.4.8":
+  version: 0.4.8
+  resolution: "fflate@npm:0.4.8"
+  checksum: 10c0/29d1eddaaa5deab61b1c6b0d21282adacadbc4d2c01e94d8b1ee784398151673b9c563e53f97a801bc410a1ae55e8de5378114a743430e643e7a0644ba8e5a42
   languageName: node
   linkType: hard
 
@@ -18269,10 +18425,98 @@ __metadata:
   languageName: node
   linkType: hard
 
+"posthog-js@npm:^1.372.1":
+  version: 1.372.1
+  resolution: "posthog-js@npm:1.372.1"
+  dependencies:
+    "@opentelemetry/api": "npm:^1.9.0"
+    "@opentelemetry/api-logs": "npm:^0.208.0"
+    "@opentelemetry/exporter-logs-otlp-http": "npm:^0.208.0"
+    "@opentelemetry/resources": "npm:^2.2.0"
+    "@opentelemetry/sdk-logs": "npm:^0.208.0"
+    "@posthog/core": "npm:1.27.5"
+    "@posthog/types": "npm:1.372.1"
+    core-js: "npm:^3.38.1"
+    dompurify: "npm:^3.3.2"
+    fflate: "npm:^0.4.8"
+    preact: "npm:^10.28.2"
+    query-selector-shadow-dom: "npm:^1.0.1"
+    web-vitals: "npm:^5.1.0"
+  checksum: 10c0/d7ccfb5fdb70d3a351d0eed066e47d07eed7f7c6096b30576c38315392c38e67cfcc9b417253678eba708400c45ae33156c084e108206fdde4c5a60ad03f1a38
+  languageName: node
+  linkType: hard
+
+"posthog-node@npm:^5.30.4":
+  version: 5.30.4
+  resolution: "posthog-node@npm:5.30.4"
+  dependencies:
+    "@posthog/core": "npm:1.27.5"
+  peerDependencies:
+    rxjs: ^7.0.0
+  peerDependenciesMeta:
+    rxjs:
+      optional: true
+  checksum: 10c0/3c623c5a178f1969dbbff4887ee8f266faf356e7ad4cdd6dab838065b7ae6a15950d1eb85acc571c65c176437534c47d4dfc814988f0d4ba19cbedcb1460b1c4
+  languageName: node
+  linkType: hard
+
+"posthog-react-native@npm:^4.43.5":
+  version: 4.43.5
+  resolution: "posthog-react-native@npm:4.43.5"
+  dependencies:
+    "@posthog/core": "npm:1.27.5"
+    "@posthog/types": "npm:1.372.1"
+  peerDependencies:
+    "@react-native-async-storage/async-storage": ">=1.0.0"
+    "@react-navigation/native": ">= 5.0.0"
+    expo-application: ">= 4.0.0"
+    expo-device: ">= 4.0.0"
+    expo-file-system: ">= 13.0.0"
+    expo-localization: ">= 11.0.0"
+    posthog-react-native-session-replay: ">= 1.5.4"
+    react-native-device-info: ">= 10.0.0"
+    react-native-localize: ">= 3.0.0"
+    react-native-navigation: ">= 6.0.0"
+    react-native-safe-area-context: ">= 4.0.0"
+    react-native-svg: ">= 15.0.0"
+  peerDependenciesMeta:
+    "@react-native-async-storage/async-storage":
+      optional: true
+    "@react-navigation/native":
+      optional: true
+    expo-application:
+      optional: true
+    expo-device:
+      optional: true
+    expo-file-system:
+      optional: true
+    expo-localization:
+      optional: true
+    posthog-react-native-session-replay:
+      optional: true
+    react-native-device-info:
+      optional: true
+    react-native-localize:
+      optional: true
+    react-native-navigation:
+      optional: true
+    react-native-safe-area-context:
+      optional: true
+  checksum: 10c0/58bc94770bcf3a2df8e236a85db4b6f4449230be82e9aeadff9be6379c507dd0309e5b209eb7e6c2a7ff2f3d4cfa7057c60ca45b9a56c0eafa18616a34c19521
+  languageName: node
+  linkType: hard
+
 "powershell-utils@npm:^0.1.0":
   version: 0.1.0
   resolution: "powershell-utils@npm:0.1.0"
   checksum: 10c0/a64713cf3583259c9ed6be211c06b4b19e8608bcb0f7f6287ffac0a95b8c7582b6b662eea0e201fd659492c8e9f9c5fd0bfc4579645c5add9c1a600075621c95
+  languageName: node
+  linkType: hard
+
+"preact@npm:^10.28.2":
+  version: 10.29.1
+  resolution: "preact@npm:10.29.1"
+  checksum: 10c0/55da3994d0d9ebcc26476552c6571f8be1150cccdafe842aad40eff9abc84c867555f6d01db386fc63ac4cbe9f9da245002468bb24df0642365162d8f1b545e2
   languageName: node
   linkType: hard
 
@@ -18507,6 +18751,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"protobufjs@npm:^7.3.0":
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.2"
+    "@protobufjs/base64": "npm:^1.1.2"
+    "@protobufjs/codegen": "npm:^2.0.4"
+    "@protobufjs/eventemitter": "npm:^1.1.0"
+    "@protobufjs/fetch": "npm:^1.1.0"
+    "@protobufjs/float": "npm:^1.0.2"
+    "@protobufjs/inquire": "npm:^1.1.0"
+    "@protobufjs/path": "npm:^1.1.2"
+    "@protobufjs/pool": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.0"
+    "@types/node": "npm:>=13.7.0"
+    long: "npm:^5.0.0"
+  checksum: 10c0/3d48896a916761e3e60b52f80027eb4fba3f5a6e3f8461e04939db18812db2cb0db4c73d03e1134a960e99525ae1d236f076a0bc01273016f573b76f33ffbd47
+  languageName: node
+  linkType: hard
+
 "protobufjs@npm:^7.5.3":
   version: 7.5.4
   resolution: "protobufjs@npm:7.5.4"
@@ -18587,6 +18851,13 @@ __metadata:
   dependencies:
     side-channel: "npm:^1.1.0"
   checksum: 10c0/ff341078a78a991d8a48b4524d52949211447b4b1ad907f489cac0770cbc346a28e47304455c0320e5fb000f8762d64b03331e3b71865f663bf351bcba8cdb4b
+  languageName: node
+  linkType: hard
+
+"query-selector-shadow-dom@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "query-selector-shadow-dom@npm:1.0.1"
+  checksum: 10c0/f36de03f170ff1da69c3eecfa7f8b01e450a46dd266c921e17f36076ec59862eee00179489f30cb17c118bb56e868436578c01ea66f671fb358750d6ae474125
   languageName: node
   linkType: hard
 
@@ -22457,6 +22728,8 @@ __metadata:
     electron-vite: "npm:^5.0.0"
     lucide-react: "npm:^1.8.0"
     postcss: "npm:^8.5.3"
+    posthog-js: "npm:^1.372.1"
+    posthog-node: "npm:^5.30.4"
     react: "npm:^19.1.0"
     react-dom: "npm:^19.1.0"
     sharp: "npm:^0.34.5"
@@ -22508,6 +22781,7 @@ __metadata:
     expo-system-ui: "npm:~55.0.15"
     lucide-react-native: "npm:^1.8.0"
     nativewind: "npm:^4.2.3"
+    posthog-react-native: "npm:^4.43.5"
     prettier: "npm:^3.8.3"
     prettier-plugin-tailwindcss: "npm:^0.7.2"
     react: "npm:19.2.5"
@@ -22580,6 +22854,8 @@ __metadata:
     jose: "npm:^6.2.2"
     lucide-react: "npm:^1.6.0"
     next: "npm:16.2.4"
+    posthog-js: "npm:^1.372.1"
+    posthog-node: "npm:^5.30.4"
     prisma: "npm:^6"
     react: "npm:19.2.5"
     react-dom: "npm:19.2.5"
@@ -22685,6 +22961,13 @@ __metadata:
   version: 3.3.3
   resolution: "web-streams-polyfill@npm:3.3.3"
   checksum: 10c0/64e855c47f6c8330b5436147db1c75cb7e7474d924166800e8e2aab5eb6c76aac4981a84261dd2982b3e754490900b99791c80ae1407a9fa0dcff74f82ea3a7f
+  languageName: node
+  linkType: hard
+
+"web-vitals@npm:^5.1.0":
+  version: 5.2.0
+  resolution: "web-vitals@npm:5.2.0"
+  checksum: 10c0/b8d4d02025afb5e1668fb9725c337616c266d9891979b1e58f81b610ee3bf53727b97babb16322fdac2b9d43ce6daa1787f42b959695796474a2061e79e219d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Wires PostHog into the website, desktop (main + renderer), and mobile (Expo/RN)
clients under a single project token. Replaces what we'd have done with
Sentry — PostHog's built-in `captureException` + session replay (website only)
+ source-map ingestion is sufficient for launch.

- One token, one opt-out toggle, one privacy paragraph.
- Lazy-init everywhere. Missing token == silent no-op.
- Stable per-install distinct_id stored in SQLite (desktop main) / SQLite
  (mobile). Identical between desktop main and renderer (renderer fetches
  via IPC at boot).

## What got wired

**Website** (`website/`)
- `src/lib/telemetry/posthog-client.ts` — browser SDK, lazy init, autocapture +
  capture_pageview + capture_pageleave + capture_exceptions + session_recording
  with `maskAllInputs: true` and `maskTextSelector: '[data-ph-mask]'`.
- `src/lib/telemetry/posthog-server.ts` — Node SDK + `withCapture()` wrapper
  applied to `/api/download/mac`, `/api/me`, all `/api/auth/*` routes.
- `src/components/telemetry/posthog-provider.tsx` — client-side provider
  mounted in `app/layout.tsx`, fires `$pageview` on App Router navigations.
- `src/components/telemetry/posthog-error-boundary.tsx` — React error
  boundary that calls `captureException` on render errors.
- `src/components/telemetry/track-cta{,-anchor}.tsx` — drop-in `<Link>` and
  `<a>` wrappers that fire `cta_clicked` on click. Applied to all four
  Download CTAs (header, hero, get-started, download page).

**Desktop** (`desktop/`)
- `src/main/telemetry.ts` — main-process PostHog with `identify`, `capture`,
  `captureException`, `flush`, `shutdown`, plus `registerProcessHandlers()`
  for `uncaughtException` + `unhandledRejection`. Distinct ID is a UUID
  stored in the existing `settings` table; opt-out is a `telemetry_opted_out`
  row in the same table.
- `src/main/index.ts` — wires the handlers, fires `app_launched`, flushes
  on `before-quit`. Also wraps the previously-silent `console.warn` paths
  in `startBundledOpenClaw` and `initAutoUpdater` to also send to PostHog.
- `src/main/window-lifecycle.ts` — `webContents.on('render-process-gone')`
  reports renderer crashes.
- `src/main/ipc-handlers.ts` — `telemetry:*` IPC channels so the renderer
  shares the same distinct_id.
- `src/preload/index.ts` — exposes the IPC surface as `electronAPI.telemetry`.
- `src/renderer/src/lib/telemetry.ts` — renderer-side posthog-js init,
  bootstraps with the main-process distinct_id over IPC.
- `src/renderer/src/main.tsx` — kicks off telemetry init at boot.
- `src/renderer/src/pages/SettingsPage.tsx` — adds a "Share anonymous
  diagnostics" toggle under a new Privacy card; fires `provider_key_saved`
  on first key entry and `test_call_completed` on the existing test button.
- `desktop/.env.build.example` — adds `VITE_POSTHOG_PROJECT_TOKEN` /
  `VITE_POSTHOG_HOST` for the renderer bundle and `NEXT_PUBLIC_…` for the
  main process.

**Mobile** (`mobile/`)
- `lib/telemetry.ts` — `posthog-react-native` lazy init, distinct_id from
  the existing settings table, opt-out wired through `setMobileOptedOut`.
- `app/_layout.tsx` — boots telemetry once `runMigrations()` resolves; fires
  `app_launched`.
- `app/(tabs)/settings.tsx` — adds a Privacy toggle.
- `lib/use-realtime.ts` — fires `relay_connected` on WS open.
- `db/conversations.ts` — fires `conversation_started` from `createConversation`.

**Docs**
- `docs/src/content/docs/operations/telemetry.mdx` — full privacy story,
  the 10 events table, env-var matrix, opt-out instructions, where the code
  lives.
- Sidebar updated.

**Privacy page**
- Sentry references removed.
- Analytics section rewritten as "Analytics, error tracking, and session
  replay" with the explicit "session replay is website-only and inputs are
  masked" callout.

## 10 events instrumented

| Surface  | Event                    |
| -------- | ------------------------ |
| Website  | `cta_clicked`            |
| Website  | `$pageview` (manual on App Router transitions) |
| Desktop  | `app_launched`           |
| Desktop  | `provider_key_saved`     |
| Desktop  | `test_call_completed`    |
| Desktop  | `onboarding_step_viewed` *(left as a hook — wizard agent owns step files)* |
| Desktop  | `onboarding_completed`   *(same)* |
| Mobile   | `app_launched`           |
| Mobile   | `relay_connected`        |
| Mobile   | `conversation_started`   |

The wizard agent in `voiceclaw-wizard-wiring` can call `captureRenderer()`
from `desktop/src/renderer/src/lib/telemetry.ts` from the step components
they own. I avoided editing `desktop/src/renderer/src/pages/onboarding/*`
per the task's ownership boundary.

## Privacy story (what's NOT captured)

- No audio
- No transcripts
- No conversation contents
- No provider API keys (Gemini, OpenAI, xAI, custom) — `provider_key_saved`
  contains `provider` + `model` only
- Inputs on the website are masked during session replay
- Session replay is website-only — desktop and mobile do not record sessions

## Opt-out

A single toggle controls everything (analytics + error tracking + session
replay):
- **Desktop**: Settings → Privacy → "Share anonymous diagnostics"
- **Mobile**: Settings → "Share Anonymous Diagnostics"
- **Website**: documented in the operations/telemetry doc; UI toggle is a
  follow-up

## Existing silent error swallowing that I wrapped

- `desktop/src/main/index.ts` `startBundledOpenClaw` (`.catch(console.warn)`)
- `desktop/src/main/index.ts` `initAutoUpdater` (`.catch(console.warn)`)

`updater.ts` has three more `console.warn` paths for transient updater
failures — left as-is for now. Those error states are very chatty and would
flood the error inbox; we can revisit once we have signal vs noise data.

## Env vars to set

| Var | Where |
| --- | --- |
| `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` | Vercel (website prod + preview), `desktop/.env.build`, optional `mobile/.env` |
| `NEXT_PUBLIC_POSTHOG_HOST` | Same places, value `https://us.i.posthog.com` |
| `VITE_POSTHOG_PROJECT_TOKEN` | `desktop/.env.build` (renderer bundle picks up VITE_*) |
| `VITE_POSTHOG_HOST` | Same, value `https://us.i.posthog.com` |
| `EXPO_PUBLIC_POSTHOG_PROJECT_TOKEN` | `mobile/.env` or EAS secrets |
| `EXPO_PUBLIC_POSTHOG_HOST` | Same |

The token from the spec
(`phc_xkvVcogVCHVi2X8ndR2qHXf5KNWugY8ubXEkyqqb9RLd`) is **not** committed —
the `.env.example` files have empty values.

## Test plan

- [x] `yarn build` passes in `website/`, `desktop/`, `docs/`
- [x] `yarn tsc --noEmit` passes in `mobile/`
- [x] `yarn lint` passes in `website/`
- [x] `yarn typecheck` passes in `desktop/`
- [x] `yarn dev` in website + curl `/`, `/privacy`, `/download` → 200
- [x] `posthog` strings appear in `desktop/out/main/index.js` and
  `desktop/out/renderer/assets/*.js`
- [ ] After merge: set the env vars in Vercel, click a Download CTA in prod,
  confirm `cta_clicked` appears in PostHog Live events
- [ ] After merge: install a fresh build with `VOICECLAW_TEST_ERROR=1` and
  confirm the test exception arrives in PostHog
- [ ] After merge: flip the desktop Settings → Privacy toggle off, fire any
  CTA, confirm no events arrive

## Do NOT
- Wizard step component files in `desktop/src/main/onboarding*` and
  `desktop/src/renderer/src/pages/onboarding/` were not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)