### PR TITLE
chore(deps): ignore tailwindcss major bumps in /mobile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,9 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
+      # nativewind 4.x targets tailwind v3 only; revisit when nativewind ships v4 support.
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
 
   # Relay server (Node)
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary
- Adds \`tailwindcss\` to the major-version ignore list for the \`/mobile\` workspace in \`.github/dependabot.yml\`.
- nativewind 4.x targets Tailwind v3 only — \`react-native-css-interop\` pins \`tailwindcss\` to \`>3.3.0 <4.0.0-0\`, so v4 can't land without a nativewind update.
- Closing dependabot PR #207 alongside this; the ignore prevents it from re-opening weekly.

## Test plan
- [ ] Confirm dependabot does not re-open a tailwindcss-major PR for /mobile next cycle
- [ ] Revisit when nativewind ships v4 support and remove this ignore