### PR TITLE
fix(NAN-642): de-dupe streaming words in desktop conversation renderer

### DIFF
--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -171,12 +171,14 @@ export function ChatPage() {
       setIsCallActive(false)
       setIsThinking(false)
       setStreamingText('')
+      streamingRoleRef.current = 'assistant'
     },
     onDisconnect: () => {
       setIsCallActive(false)
       setIsConnecting(false)
       setIsThinking(false)
       setStreamingText('')
+      streamingRoleRef.current = 'assistant'
     },
     onError: (message) => {
       console.error('[ChatPage] Relay error:', message)

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -35,6 +35,11 @@ export function ChatPage() {
   const [isThinking, setIsThinking] = useState(false)
   const [streamingText, setStreamingText] = useState('')
   const [streamingRole, setStreamingRole] = useState<'user' | 'assistant'>('assistant')
+  // Mirror of streamingRole readable synchronously in event callbacks. Used by
+  // onTranscriptDelta so we can decide "reset vs append" without putting an
+  // impure side effect inside a setState updater (which StrictMode would
+  // double-invoke and cause word duplication).
+  const streamingRoleRef = useRef<'user' | 'assistant'>('assistant')
   const [showLatency, setShowLatency] = useState(false)
   const [connectionError, setConnectionError] = useState('')
   const [activeRealtimeModel, setActiveRealtimeModel] = useState('')
@@ -106,15 +111,18 @@ export function ChatPage() {
       setIsCallActive(true)
     },
     onTranscriptDelta: (text, role) => {
-      setStreamingRole((prevRole) => {
-        if (prevRole !== role) {
-          // Role switched (user→assistant or vice versa) — reset the buffer
-          setStreamingText(text)
-        } else {
-          setStreamingText((prev) => prev + text)
-        }
-        return role
-      })
+      // Role/buffer reconciliation must NOT happen inside a setState updater —
+      // React StrictMode runs updaters twice (in dev) to surface impure ones,
+      // which double-fires the side-effect setStreamingText(...) and produced
+      // the doubled-words bug (NAN-642). The current role lives in a ref so
+      // we can read it synchronously here without conjuring an updater.
+      if (streamingRoleRef.current !== role) {
+        streamingRoleRef.current = role
+        setStreamingRole(role)
+        setStreamingText(text)
+      } else {
+        setStreamingText((prev) => prev + text)
+      }
       if (role === 'assistant') setIsThinking(false)
     },
     onTranscriptDone: async (text, role) => {
@@ -135,6 +143,7 @@ export function ChatPage() {
     onTurnStarted: () => {
       setIsThinking(false)
       setStreamingText('')
+      streamingRoleRef.current = 'user'
       setStreamingRole('user')
     },
     onTurnEnded: () => {
@@ -154,6 +163,7 @@ export function ChatPage() {
       }
     },
     onToolProgress: (_callId, summary) => {
+      streamingRoleRef.current = 'assistant'
       setStreamingRole('assistant')
       setStreamingText(summary)
     },


### PR DESCRIPTION
## Summary
- Fixes [NAN-642](https://linear.app/nano3labs/issue/NAN-642): desktop conversation renderer duplicates every streaming word/phrase (`here. here.`, `Just Just`, `waiting waiting`, `what what`, `thinking thinking`).

## Root cause
`ChatPage.onTranscriptDelta` passed an **impure** updater to `setStreamingRole`. The updater performed a side effect — it called `setStreamingText(...)` from inside itself. React 19 `<StrictMode>` (enabled in `desktop/src/renderer/src/main.tsx`) intentionally double-invokes state updaters in development to surface impurity, so the inner `setStreamingText((prev) => prev + text)` was queued twice per delta. Net effect: every transcript delta was appended to the streaming bubble twice → doubled words.

```ts
// before — impure: side-effect inside updater, doubled by StrictMode in dev
setStreamingRole((prevRole) => {
  if (prevRole !== role) setStreamingText(text)
  else                   setStreamingText((prev) => prev + text)  // queued twice
  return role
})
```

This is dev-build-only behavior (StrictMode is a no-op in production), but `yarn dev` is the typical desktop loop, hence the report.

## Fix
Mirror `streamingRole` in a ref (`streamingRoleRef`) so the "reset vs append" decision happens synchronously in the event callback, outside any setState updater. All `setStreamingText` / `setStreamingRole` calls are now pure (constant or `prev -> next`), so StrictMode's double-invocation has no observable effect. Other `setStreamingRole` call sites (`onTurnStarted`, `onToolProgress`) keep the ref in sync.

## Files changed
- `desktop/src/renderer/src/pages/ChatPage.tsx`

## Relation to NAN-637
**Separate bug.** NAN-637 is about timestamp/segment metadata (e.g. `[1m19s70ms]`) appearing inline in transcript text — that's an upstream relay/adapter content issue. NAN-642 is purely a renderer-side React StrictMode/impure-updater issue and is unrelated.

## Test plan
- [x] `yarn typecheck` (desktop) — clean
- [x] `yarn build` (desktop) — clean
- [ ] Live test: `yarn dev` desktop + dev relay, run a real Gemini call, confirm no doubled words during or after streaming.
- [ ] Verify `transcript.done` final commit still renders once (no race with the streaming bubble) — manual.

I have not exercised a live conversation against a relay from this worktree; the fix is verified via static analysis + StrictMode semantics + typecheck/build. Recommend a quick smoke before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)