### PR TITLE
feat(NAN-671): remove OpenAI Realtime from onboarding provider picker

### DIFF
--- a/desktop/src/renderer/src/pages/onboarding/StepProvider.tsx
+++ b/desktop/src/renderer/src/pages/onboarding/StepProvider.tsx
@@ -31,17 +31,6 @@ const PROVIDERS: Provider[] = [
     freeTier: 'Free tier available',
   },
   {
-    id: 'openai',
-    name: 'OpenAI Realtime',
-    tagline: 'OpenAI',
-    detail: 'Sharp, precise, slightly cooler voice. Pay per minute.',
-    keyLink: 'https://platform.openai.com/api-keys',
-    keyLinkLabel: 'Get a key at platform.openai.com',
-    placeholder: 'sk-...',
-    prefix: 'sk-',
-    freeTier: 'Pay-as-you-go',
-  },
-  {
     id: 'xai',
     name: 'Grok Voice',
     tagline: 'xAI',
@@ -76,10 +65,12 @@ export function StepProvider({
   initialProvider = 'gemini',
   previewMode = false,
 }: Props) {
-  const [selected, setSelected] = useState<ProviderId>(initialProvider)
+  const [selected, setSelected] = useState<ProviderId>(
+    PROVIDERS.some((p) => p.id === initialProvider) ? initialProvider : 'gemini',
+  )
   const [apiKey, setApiKey] = useState('')
   const [validation, setValidation] = useState<ValidationState>({ kind: 'empty' })
-  const active = PROVIDERS.find((p) => p.id === selected)!
+  const active = PROVIDERS.find((p) => p.id === selected) ?? PROVIDERS[0]
 
   const handleKeyChange = (key: string) => {
     setApiKey(key)
@@ -147,7 +138,7 @@ export function StepProvider({
       secondaryAction={{ label: 'Back', onClick: onBack }}
       onStartOver={onStartOver}
     >
-      <div className="grid gap-3 md:grid-cols-3">
+      <div className="grid gap-3 md:grid-cols-2">
         {PROVIDERS.map((provider) => (
           <ProviderCard
             key={provider.id}


### PR DESCRIPTION
## Summary
- Remove the OpenAI Realtime card from the desktop onboarding voice-provider picker (`StepProvider.tsx`); only Gemini Live and Grok Voice remain visible.
- Switch the picker grid from `md:grid-cols-3` to `md:grid-cols-2` so the layout still feels intentional.
- Guard `initialProvider` so existing users whose persisted default is `'openai'` fall back to `'gemini'` in the picker instead of crashing on `active.name`.
- The `'openai'` `ProviderId`, IPC handlers, keychain logic, and relay-server adapter are untouched — this is purely a UX simplification and the provider can be re-introduced.

Linear: https://linear.app/nano3labs/issue/NAN-671

## Test plan
- [ ] `yarn typecheck` in `desktop/` (passes locally)
- [ ] Run desktop onboarding wizard, confirm step 04 shows only Gemini Live and Grok Voice cards
- [ ] Confirm an existing user with `payload.provider === 'openai'` still lands on the picker with Gemini selected, no runtime error

🤖 Generated with [Claude Code](https://claude.com/claude-code)