### PR TITLE
feat(NAN-644): increase desktop screen-share resolution and JPEG quality

### DIFF
--- a/desktop/src/renderer/src/lib/screen-capture.ts
+++ b/desktop/src/renderer/src/lib/screen-capture.ts
@@ -1,5 +1,5 @@
 // Screen capture utility for Electron's desktopCapturer.
-// Captures frames at 1 FPS, resizes to ~768px, and emits JPEG base64.
+// Captures frames at 1 FPS, resizes to ~1536px, and emits JPEG base64.
 
 export type ScreenSource = {
   id: string
@@ -17,9 +17,22 @@ declare global {
   }
 }
 
-const MAX_DIMENSION = 768
+// 1536 keeps small terminal text legible on Retina captures while staying within
+// Gemini's HIGH-resolution video tokenizer envelope. 768 was too aggressive —
+// 11pt monospace fonts blurred to the point Gemini misread "warp" as "warn",
+// command output as garbled glyphs, etc.
+const MAX_DIMENSION = 1536
 const CAPTURE_INTERVAL_MS = 1000 // 1 FPS
-const JPEG_QUALITY = 0.7
+// 0.85 preserves anti-aliased text edges through chroma subsampling. 0.7 was
+// dropping enough high-frequency luma detail that ligatures and thin glyph
+// strokes (i, l, |, /) became unreadable after JPEG.
+const JPEG_QUALITY = 0.85
+// Upper bound for the source stream so Chromium doesn't silently cap the
+// desktop capture at its 1280x720 default. We downscale to MAX_DIMENSION
+// after the fact — this just prevents pre-canvas downsampling. 4K covers
+// nearly every Retina/HiDPI display we care about.
+const SOURCE_MAX_WIDTH = 3840
+const SOURCE_MAX_HEIGHT = 2160
 
 export class ScreenCapture {
   private stream: MediaStream | null = null
@@ -30,7 +43,10 @@ export class ScreenCapture {
   private sourceName = ''
 
   async start(sourceId: string, onFrame: (base64Jpeg: string) => void) {
-    // Request screen capture stream using Electron's chromeMediaSource
+    // Request screen capture stream using Electron's chromeMediaSource.
+    // The legacy `mandatory` constraint shape is required when combining
+    // chromeMediaSource: 'desktop' with size hints — modern width/height
+    // constraints are ignored on this path in Chromium.
     this.stream = await navigator.mediaDevices.getUserMedia({
       audio: false,
       video: {
@@ -38,6 +54,8 @@ export class ScreenCapture {
         mandatory: {
           chromeMediaSource: 'desktop',
           chromeMediaSourceId: sourceId,
+          maxWidth: SOURCE_MAX_WIDTH,
+          maxHeight: SOURCE_MAX_HEIGHT,
         },
       } as any,
     })

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -398,6 +398,12 @@ export class GeminiAdapter implements ProviderAdapter {
             },
           },
         },
+        // Default LOW collapses every video frame to ~64 tokens, which loses
+        // the detail Gemini needs to read terminal text and code. HIGH bumps
+        // it to ~280 tokens/frame on Gemini 3 (~256 on 2.5) so small fonts
+        // stay legible during screen sharing. ~4x more video tokens per
+        // frame, negligible cost vs the continuous audio stream.
+        mediaResolution: "MEDIA_RESOLUTION_HIGH",
       },
       outputAudioTranscription: {},
       inputAudioTranscription: {},


### PR DESCRIPTION
## Why

Screen sharing with terminal apps (Warp, etc.) was unusable: Gemini routinely misread on-screen text — `warp` came back as `warn`, command output as garbled glyphs. Three independent downsamples were stacking before the model ever saw the frame:

1. **Chromium** silently capped `getUserMedia` at 1280x720 because we passed no size constraints to the desktop capturer.
2. **Our canvas** downscaled to 768px (`MAX_DIMENSION`) before encoding to JPEG.
3. **Gemini Live** re-tiled every video frame to a single 768x768 token because `mediaResolution` defaulted to LOW.

Plus `JPEG_QUALITY=0.7` was aggressive enough that chroma subsampling dropped the high-frequency luma detail needed to read thin glyph strokes (`i`, `l`, `|`, `/`).

## Changes

- **`desktop/src/renderer/src/lib/screen-capture.ts`**
  - `MAX_DIMENSION`: 768 → 1536
  - `JPEG_QUALITY`: 0.7 → 0.85
  - Pin `getUserMedia` `mandatory.maxWidth/maxHeight` to 4K so the source stream captures Retina pixels instead of being silently capped at 720p. (Legacy `mandatory` shape is required when combining `chromeMediaSource: 'desktop'` with size hints — modern `width`/`height` constraints are ignored on this path.)
- **`relay-server/src/adapters/gemini.ts`**
  - Set `generationConfig.mediaResolution = "MEDIA_RESOLUTION_HIGH"` so Gemini Live tiles each frame into multiple tokens.

## Tradeoff

~3x more video tokens per frame (roughly 256 → 768). At 1 FPS this is negligible compared to the continuous audio stream, and the readability win is the whole point of screen sharing.

## Linear

[NAN-644](https://linear.app/nano3labs/issue/NAN-644)

## Test plan

- [x] `cd desktop && yarn typecheck` — passes
- [x] `cd relay-server && yarn tsc --noEmit` — passes
- [ ] Manual: start desktop app, share Warp window, ask Gemini to read on-screen text, confirm it transcribes correctly