### PR TITLE
fix(NAN-674): suppress empty placeholder bubble in chat UI

### DIFF
--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -35,10 +35,9 @@ export function ChatPage() {
   const [isThinking, setIsThinking] = useState(false)
   const [streamingText, setStreamingText] = useState('')
   const [streamingRole, setStreamingRole] = useState<'user' | 'assistant'>('assistant')
-  // Mirror of streamingRole readable synchronously in event callbacks. Used by
-  // onTranscriptDelta so we can decide "reset vs append" without putting an
-  // impure side effect inside a setState updater (which StrictMode would
-  // double-invoke and cause word duplication).
+  // Synchronously-readable mirror of streamingRole. Event callbacks must
+  // decide reset-vs-append without a setState updater — StrictMode invokes
+  // updaters twice in dev, so any side effect inside one runs twice.
   const streamingRoleRef = useRef<'user' | 'assistant'>('assistant')
   const [showLatency, setShowLatency] = useState(false)
   const [connectionError, setConnectionError] = useState('')
@@ -111,11 +110,9 @@ export function ChatPage() {
       setIsCallActive(true)
     },
     onTranscriptDelta: (text, role) => {
-      // Role/buffer reconciliation must NOT happen inside a setState updater —
-      // React StrictMode runs updaters twice (in dev) to surface impure ones,
-      // which double-fires the side-effect setStreamingText(...) and produced
-      // the doubled-words bug (NAN-642). The current role lives in a ref so
-      // we can read it synchronously here without conjuring an updater.
+      // Read the current role from the ref so reset-vs-append stays out of
+      // a setState updater. StrictMode double-invokes updaters in dev, so
+      // any side effect (setStreamingText) inside one would fire twice.
       if (streamingRoleRef.current !== role) {
         streamingRoleRef.current = role
         setStreamingRole(role)

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -147,7 +147,7 @@ export function ChatPage() {
       setStreamingRole('user')
     },
     onTurnEnded: () => {
-      setIsThinking(true)
+      setIsThinking(false)
     },
     onToolCall: async (_callId, name, args) => {
       // Handle displayText tool call locally
@@ -376,7 +376,7 @@ export function ChatPage() {
           <MessageBubble key={msg.id} message={msg} showLatency={showLatency} />
         ))}
         {/* Streaming text */}
-        {streamingText && (
+        {streamingText.trim() && (
           <div className={`flex ${streamingRole === 'user' ? 'justify-end' : 'justify-start'} mb-3`}>
             <div
               className={`
@@ -393,7 +393,7 @@ export function ChatPage() {
           </div>
         )}
         {/* Thinking indicator */}
-        {isThinking && !streamingText && (
+        {isThinking && !streamingText.trim() && (
           <div className="flex justify-start mb-3">
             <div className="rounded-md border border-border bg-card px-4 py-2.5">
               <ThinkingDots />


### PR DESCRIPTION
## Why

After every assistant response, the desktop chat sometimes showed an empty bubble underneath the reply while the user was deciding what to say next. Looked like a stray pending placeholder. Linear: [NAN-674](https://linear.app/nano3labs/issue/NAN-674).

## Root cause

`ChatPage.onTurnEnded` was setting `isThinking = true`. Given the relay's `turn.ended` semantics (it fires after the assistant's `transcript.done` has already flushed), this turned the thinking-dots indicator on at the wrong moment — once the assistant had already finished, then left it on indefinitely until the next user `turn.started`. Result: a faint empty bubble visible during the inter-turn gap.

The mobile realtime path doesn't do this — it sets `isThinking = false` on turn-ended. Desktop now matches.

## Fix

- `onTurnEnded`: `setIsThinking(false)` (was `true`).
- Render guards on `streamingText` use `trim()` so a whitespace-only delta race can't sneak an empty bubble in either.

## Test plan

- [ ] `yarn typecheck` in `desktop/` passes
- [ ] Run a conversation in dev. After the assistant finishes a reply, no empty bubble appears underneath while waiting for the next user turn.
- [ ] Streaming text still renders mid-response (PR #221 flow intact — `setStreamingText` from delta callbacks unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)