### PR TITLE
feat(NAN-636): add minimal volume control for agent audio output

### DIFF
--- a/desktop/src/renderer/src/components/VolumeControl.tsx
+++ b/desktop/src/renderer/src/components/VolumeControl.tsx
@@ -70,7 +70,8 @@ export function VolumeControl({
       if (disabled) return
       e.preventDefault()
       draggingRef.current = true
-      ;(e.target as Element).setPointerCapture?.(e.pointerId)
+      const target = e.currentTarget
+      target.setPointerCapture?.(e.pointerId)
       updateFromClientY(e.clientY)
     },
     [disabled, updateFromClientY],
@@ -86,33 +87,36 @@ export function VolumeControl({
 
   const handlePointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     draggingRef.current = false
-    ;(e.target as Element).releasePointerCapture?.(e.pointerId)
+    const target = e.currentTarget
+    target.releasePointerCapture?.(e.pointerId)
   }, [])
 
   const handleSliderKey = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (disabled) return
       const step = e.shiftKey ? 0.1 : 0.05
+      const adjust = (next: number) => {
+        onVolumeChange(next)
+        if (muted) onMutedChange(false)
+      }
       switch (e.key) {
         case 'ArrowUp':
         case 'ArrowRight':
           e.preventDefault()
-          onVolumeChange(Math.min(1, volume + step))
-          if (muted) onMutedChange(false)
+          adjust(Math.min(1, volume + step))
           break
         case 'ArrowDown':
         case 'ArrowLeft':
           e.preventDefault()
-          onVolumeChange(Math.max(0, volume - step))
+          adjust(Math.max(0, volume - step))
           break
         case 'Home':
           e.preventDefault()
-          onVolumeChange(0)
+          adjust(0)
           break
         case 'End':
           e.preventDefault()
-          onVolumeChange(1)
-          if (muted) onMutedChange(false)
+          adjust(1)
           break
       }
     },
@@ -126,11 +130,13 @@ export function VolumeControl({
       <button
         type="button"
         aria-label={
-          muted
-            ? 'Agent audio muted. Click to unmute or open volume slider.'
-            : open
-              ? 'Mute agent audio'
-              : 'Open volume slider'
+          open
+            ? muted
+              ? 'Unmute agent audio'
+              : 'Mute agent audio'
+            : muted
+              ? 'Agent audio muted. Open volume slider.'
+              : 'Open agent volume slider'
         }
         aria-pressed={muted}
         aria-expanded={open}

--- a/desktop/src/renderer/src/components/VolumeControl.tsx
+++ b/desktop/src/renderer/src/components/VolumeControl.tsx
@@ -95,6 +95,7 @@ export function VolumeControl({
     (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (disabled) return
       const step = e.shiftKey ? 0.1 : 0.05
+      const displayed = muted ? 0 : volume
       const adjust = (next: number) => {
         onVolumeChange(next)
         if (muted) onMutedChange(false)
@@ -103,12 +104,12 @@ export function VolumeControl({
         case 'ArrowUp':
         case 'ArrowRight':
           e.preventDefault()
-          adjust(Math.min(1, volume + step))
+          adjust(Math.min(1, displayed + step))
           break
         case 'ArrowDown':
         case 'ArrowLeft':
           e.preventDefault()
-          adjust(Math.max(0, volume - step))
+          adjust(Math.max(0, displayed - step))
           break
         case 'Home':
           e.preventDefault()

--- a/desktop/src/renderer/src/components/VolumeControl.tsx
+++ b/desktop/src/renderer/src/components/VolumeControl.tsx
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Volume2, VolumeX, Volume1, Volume } from 'lucide-react'
+import { cn } from '../lib/cn'
+
+interface VolumeControlProps {
+  volume: number
+  muted: boolean
+  onVolumeChange: (volume: number) => void
+  onMutedChange: (muted: boolean) => void
+  disabled?: boolean
+}
+
+const SLIDER_HEIGHT = 96
+
+export function VolumeControl({
+  volume,
+  muted,
+  onVolumeChange,
+  onMutedChange,
+  disabled,
+}: VolumeControlProps) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const trackRef = useRef<HTMLDivElement>(null)
+  const draggingRef = useRef(false)
+  const Icon = pickIcon(muted ? 0 : volume, muted)
+
+  useEffect(() => {
+    if (!open) return
+    const onDocPointerDown = (e: PointerEvent) => {
+      if (draggingRef.current) return
+      const root = containerRef.current
+      if (root && !root.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('pointerdown', onDocPointerDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('pointerdown', onDocPointerDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const handleIconClick = useCallback(() => {
+    if (disabled) return
+    if (open) {
+      onMutedChange(!muted)
+      return
+    }
+    setOpen(true)
+  }, [disabled, open, muted, onMutedChange])
+
+  const updateFromClientY = useCallback(
+    (clientY: number) => {
+      const track = trackRef.current
+      if (!track) return
+      const rect = track.getBoundingClientRect()
+      const ratio = 1 - (clientY - rect.top) / rect.height
+      const next = Math.max(0, Math.min(1, ratio))
+      onVolumeChange(next)
+      if (muted && next > 0) onMutedChange(false)
+    },
+    [muted, onMutedChange, onVolumeChange],
+  )
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (disabled) return
+      e.preventDefault()
+      draggingRef.current = true
+      ;(e.target as Element).setPointerCapture?.(e.pointerId)
+      updateFromClientY(e.clientY)
+    },
+    [disabled, updateFromClientY],
+  )
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!draggingRef.current) return
+      updateFromClientY(e.clientY)
+    },
+    [updateFromClientY],
+  )
+
+  const handlePointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    draggingRef.current = false
+    ;(e.target as Element).releasePointerCapture?.(e.pointerId)
+  }, [])
+
+  const handleSliderKey = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (disabled) return
+      const step = e.shiftKey ? 0.1 : 0.05
+      switch (e.key) {
+        case 'ArrowUp':
+        case 'ArrowRight':
+          e.preventDefault()
+          onVolumeChange(Math.min(1, volume + step))
+          if (muted) onMutedChange(false)
+          break
+        case 'ArrowDown':
+        case 'ArrowLeft':
+          e.preventDefault()
+          onVolumeChange(Math.max(0, volume - step))
+          break
+        case 'Home':
+          e.preventDefault()
+          onVolumeChange(0)
+          break
+        case 'End':
+          e.preventDefault()
+          onVolumeChange(1)
+          if (muted) onMutedChange(false)
+          break
+      }
+    },
+    [disabled, volume, muted, onMutedChange, onVolumeChange],
+  )
+
+  const fillPct = Math.round((muted ? 0 : volume) * 100)
+
+  return (
+    <div ref={containerRef} className="relative inline-flex">
+      <button
+        type="button"
+        aria-label={
+          muted
+            ? 'Agent audio muted. Click to unmute or open volume slider.'
+            : open
+              ? 'Mute agent audio'
+              : 'Open volume slider'
+        }
+        aria-pressed={muted}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        disabled={disabled}
+        onClick={handleIconClick}
+        className={cn(
+          'inline-flex h-10 w-10 items-center justify-center rounded-md transition-colors duration-150',
+          'hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
+          'disabled:opacity-50 disabled:pointer-events-none',
+          muted ? 'text-destructive' : 'text-foreground',
+        )}
+      >
+        <Icon size={20} />
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Agent output volume"
+          className={cn(
+            'absolute left-1/2 -translate-x-1/2 -translate-y-2 bottom-full z-50',
+            'flex flex-col items-center gap-2 rounded-md border border-border bg-card px-2 py-3',
+            'vc-panel-shadow',
+          )}
+        >
+          <div className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+            {muted ? 'mute' : `${fillPct}%`}
+          </div>
+          <div
+            ref={trackRef}
+            role="slider"
+            tabIndex={0}
+            aria-label="Agent output volume"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={fillPct}
+            aria-orientation="vertical"
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            onPointerCancel={handlePointerUp}
+            onKeyDown={handleSliderKey}
+            className={cn(
+              'relative w-2 cursor-pointer rounded-full bg-muted',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
+            )}
+            style={{ height: SLIDER_HEIGHT }}
+          >
+            <div
+              className="absolute bottom-0 left-0 right-0 rounded-full bg-primary"
+              style={{ height: `${fillPct}%` }}
+            />
+            <div
+              className="absolute left-1/2 size-3 -translate-x-1/2 rounded-full border border-border bg-background shadow-sm"
+              style={{ bottom: `calc(${fillPct}% - 6px)` }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function pickIcon(level: number, muted: boolean) {
+  if (muted || level <= 0) return VolumeX
+  if (level < 0.34) return Volume
+  if (level < 0.67) return Volume1
+  return Volume2
+}

--- a/desktop/src/renderer/src/components/VolumeControl.tsx
+++ b/desktop/src/renderer/src/components/VolumeControl.tsx
@@ -139,7 +139,7 @@ export function VolumeControl({
               ? 'Agent audio muted. Open volume slider.'
               : 'Open agent volume slider'
         }
-        aria-pressed={muted}
+        aria-pressed={open ? muted : undefined}
         aria-expanded={open}
         aria-haspopup="dialog"
         disabled={disabled}

--- a/desktop/src/renderer/src/lib/audio-engine.ts
+++ b/desktop/src/renderer/src/lib/audio-engine.ts
@@ -115,7 +115,7 @@ export class AudioEngine {
   }
 
   setVolume(volume: number) {
-    this.outputVolume = Math.max(0, Math.min(1, volume))
+    this.outputVolume = Math.max(0, volume)
     this.applyOutputGain()
   }
 

--- a/desktop/src/renderer/src/lib/audio-engine.ts
+++ b/desktop/src/renderer/src/lib/audio-engine.ts
@@ -21,6 +21,8 @@ export class AudioEngine {
   private isPlaying = false
   private muted = false
   private currentRms = 0
+  private outputVolume = 1
+  private outputMuted = false
 
   // Output (AI voice) level meter — an AnalyserNode tapped off the
   // playback gain. Cheap enough to keep always-on so the call bar can
@@ -44,6 +46,7 @@ export class AudioEngine {
     // Gain node for playback volume
     this.gainNode = this.audioCtx.createGain()
     this.gainNode.connect(this.audioCtx.destination)
+    this.applyOutputGain()
 
     // Tap the gain for an output level meter. The analyser lives on the
     // gain's post-volume signal so the reading reflects what the user
@@ -112,9 +115,21 @@ export class AudioEngine {
   }
 
   setVolume(volume: number) {
-    if (this.gainNode) {
-      this.gainNode.gain.value = Math.max(0, volume)
-    }
+    this.outputVolume = Math.max(0, Math.min(1, volume))
+    this.applyOutputGain()
+  }
+
+  setOutputMuted(muted: boolean) {
+    this.outputMuted = muted
+    this.applyOutputGain()
+  }
+
+  getOutputVolume(): number {
+    return this.outputVolume
+  }
+
+  isOutputMuted(): boolean {
+    return this.outputMuted
   }
 
   async setOutputDevice(deviceId: string) {
@@ -214,6 +229,11 @@ export class AudioEngine {
 
     this.source.connect(this.processor)
     this.processor.connect(this.audioCtx.destination)
+  }
+
+  private applyOutputGain() {
+    if (!this.gainNode) return
+    this.gainNode.gain.value = this.outputMuted ? 0 : this.outputVolume
   }
 
   private drainPlaybackQueue() {

--- a/desktop/src/renderer/src/lib/use-realtime.ts
+++ b/desktop/src/renderer/src/lib/use-realtime.ts
@@ -60,6 +60,8 @@ export interface RealtimeControls {
   start: (config: RealtimeConfig) => void
   stop: () => void
   setMuted: (muted: boolean) => void
+  setOutputVolume: (volume: number) => void
+  setOutputMuted: (muted: boolean) => void
   sendFrame: (base64Jpeg: string) => void
   getInputLevel: () => number
   getOutputLevel: () => number
@@ -349,6 +351,14 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
     engineRef.current?.setMuted(muted)
   }, [])
 
+  const setOutputVolume = useCallback((volume: number) => {
+    engineRef.current?.setVolume(volume)
+  }, [])
+
+  const setOutputMuted = useCallback((muted: boolean) => {
+    engineRef.current?.setOutputMuted(muted)
+  }, [])
+
   const sendFrame = useCallback((base64Jpeg: string) => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       wsRef.current.send(JSON.stringify({ type: 'frame.append', data: base64Jpeg }))
@@ -367,6 +377,8 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
     start,
     stop,
     setMuted,
+    setOutputVolume,
+    setOutputMuted,
     sendFrame,
     getInputLevel,
     getOutputLevel,

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -221,7 +221,11 @@ export function ChatPage() {
     const tavilyApiKey = tavilyEnabled
       ? ((await getSetting('tavily_api_key')) || undefined)
       : undefined
-    const volume = baseVolume * outputGain
+    const baseRaw = await getSetting('realtime_volume')
+    const baseParsed = parseFloat(baseRaw ?? '')
+    const freshBaseVolume = Number.isNaN(baseParsed) ? 1 : Math.max(0, baseParsed)
+    setBaseVolume(freshBaseVolume)
+    const volume = freshBaseVolume * outputGain
     const tracingEnabled = (await getSetting('tracing_enabled')) === 'true'
     const inputDeviceId = (await getSetting('input_device_id')) || undefined
     const outputDeviceId = (await getSetting('output_device_id')) || undefined
@@ -253,7 +257,7 @@ export function ChatPage() {
       conversationHistory: conversationHistory.length > 0 ? conversationHistory : undefined,
       tracingEnabled,
     })
-  }, [realtime, baseVolume, outputGain])
+  }, [realtime, outputGain])
 
   const endCall = useCallback(() => {
     realtime.stop()
@@ -262,6 +266,7 @@ export function ChatPage() {
     setIsThinking(false)
     setStreamingText('')
     setIsMuted(false)
+    setOutputMuted(false)
     setActiveRealtimeModel('')
   }, [realtime])
 

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -210,6 +210,7 @@ export function ChatPage() {
   const startCall = useCallback(async () => {
     setConnectionError('')
     setIsConnecting(true)
+    setOutputMuted(false)
     const serverUrl = (await getSetting('realtime_server_url')) || 'ws://localhost:8080/ws'
     const model = normalizeRealtimeModel(await getSetting('realtime_model'))
     const voice = normalizeRealtimeVoice(model, await getSetting('realtime_voice'))

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -33,15 +33,15 @@ export function ChatPage() {
   const titleGeneratedRef = useRef(false)
   const [isCallActive, setIsCallActive] = useState(false)
   const [isMuted, setIsMuted] = useState(false)
-  const [outputVolume, setOutputVolume] = useState(1)
+  const [outputGain, setOutputGain] = useState(1)
+  const [baseVolume, setBaseVolume] = useState(1)
   const [outputMuted, setOutputMuted] = useState(false)
   const [isConnecting, setIsConnecting] = useState(false)
   const [isThinking, setIsThinking] = useState(false)
   const [streamingText, setStreamingText] = useState('')
   const [streamingRole, setStreamingRole] = useState<'user' | 'assistant'>('assistant')
-  // Synchronously-readable mirror of streamingRole. Event callbacks must
-  // decide reset-vs-append without a setState updater — StrictMode invokes
-  // updaters twice in dev, so any side effect inside one runs twice.
+  // Synchronous mirror of streamingRole — IPC callbacks need to read the
+  // current role outside of a setState updater since updaters must stay pure.
   const streamingRoleRef = useRef<'user' | 'assistant'>('assistant')
   const [showLatency, setShowLatency] = useState(false)
   const [connectionError, setConnectionError] = useState('')
@@ -81,7 +81,11 @@ export function ChatPage() {
     getSetting('show_latency').then((v) => setShowLatency(v === 'true'))
     getSetting('realtime_volume').then((v) => {
       const parsed = parseFloat(v ?? '')
-      if (!Number.isNaN(parsed)) setOutputVolume(Math.max(0, Math.min(1, parsed)))
+      if (!Number.isNaN(parsed)) setBaseVolume(Math.max(0, parsed))
+    })
+    getSetting('realtime_output_gain').then((v) => {
+      const parsed = parseFloat(v ?? '')
+      if (!Number.isNaN(parsed)) setOutputGain(Math.max(0, Math.min(1, parsed)))
     })
   }, [])
 
@@ -118,9 +122,6 @@ export function ChatPage() {
       setIsCallActive(true)
     },
     onTranscriptDelta: (text, role) => {
-      // Read the current role from the ref so reset-vs-append stays out of
-      // a setState updater. StrictMode double-invokes updaters in dev, so
-      // any side effect (setStreamingText) inside one would fire twice.
       if (streamingRoleRef.current !== role) {
         streamingRoleRef.current = role
         setStreamingRole(role)
@@ -199,8 +200,8 @@ export function ChatPage() {
   realtimeRef.current = realtime
 
   useEffect(() => {
-    realtime.setOutputVolume(outputVolume)
-  }, [outputVolume, realtime])
+    realtime.setOutputVolume(baseVolume * outputGain)
+  }, [baseVolume, outputGain, realtime])
 
   useEffect(() => {
     realtime.setOutputMuted(outputMuted)
@@ -220,7 +221,7 @@ export function ChatPage() {
     const tavilyApiKey = tavilyEnabled
       ? ((await getSetting('tavily_api_key')) || undefined)
       : undefined
-    const volume = outputVolume
+    const volume = baseVolume * outputGain
     const tracingEnabled = (await getSetting('tracing_enabled')) === 'true'
     const inputDeviceId = (await getSetting('input_device_id')) || undefined
     const outputDeviceId = (await getSetting('output_device_id')) || undefined
@@ -252,7 +253,7 @@ export function ChatPage() {
       conversationHistory: conversationHistory.length > 0 ? conversationHistory : undefined,
       tracingEnabled,
     })
-  }, [realtime, outputVolume])
+  }, [realtime, baseVolume, outputGain])
 
   const endCall = useCallback(() => {
     realtime.stop()
@@ -270,9 +271,9 @@ export function ChatPage() {
     realtime.setMuted(next)
   }, [isMuted, realtime])
 
-  const handleOutputVolumeChange = useCallback((next: number) => {
-    setOutputVolume(next)
-    setSetting('realtime_volume', next.toString()).catch(() => {})
+  const handleOutputGainChange = useCallback((next: number) => {
+    setOutputGain(next)
+    setSetting('realtime_output_gain', next.toString()).catch(() => {})
   }, [])
 
   const handleOutputMutedChange = useCallback((next: boolean) => {
@@ -494,9 +495,9 @@ export function ChatPage() {
               </Button>
             </span>
             <VolumeControl
-              volume={outputVolume}
+              volume={outputGain}
               muted={outputMuted}
-              onVolumeChange={handleOutputVolumeChange}
+              onVolumeChange={handleOutputGainChange}
               onMutedChange={handleOutputMutedChange}
             />
 

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -6,6 +6,7 @@ import { ThinkingDots } from '../components/ThinkingDots'
 import { AudioLevelMeter } from '../components/AudioLevelMeter'
 import { VoiceClawMark } from '../components/brand/VoiceClawMark'
 import { ScreenSharePicker } from '../components/ScreenSharePicker'
+import { VolumeControl } from '../components/VolumeControl'
 import { ScreenCapture, type ScreenSource } from '../lib/screen-capture'
 import { useRealtime, type RealtimeCallbacks } from '../lib/use-realtime'
 import { useConversationContext } from '../lib/conversation-context'
@@ -15,6 +16,7 @@ import {
   getLatestConversation,
   getMessages,
   getSetting,
+  setSetting,
   updateConversationTitle,
   type Message,
 } from '../lib/db'
@@ -31,6 +33,8 @@ export function ChatPage() {
   const titleGeneratedRef = useRef(false)
   const [isCallActive, setIsCallActive] = useState(false)
   const [isMuted, setIsMuted] = useState(false)
+  const [outputVolume, setOutputVolume] = useState(1)
+  const [outputMuted, setOutputMuted] = useState(false)
   const [isConnecting, setIsConnecting] = useState(false)
   const [isThinking, setIsThinking] = useState(false)
   const [streamingText, setStreamingText] = useState('')
@@ -75,6 +79,10 @@ export function ChatPage() {
   useEffect(() => {
     loadLatestConversation()
     getSetting('show_latency').then((v) => setShowLatency(v === 'true'))
+    getSetting('realtime_volume').then((v) => {
+      const parsed = parseFloat(v ?? '')
+      if (!Number.isNaN(parsed)) setOutputVolume(Math.max(0, Math.min(1, parsed)))
+    })
   }, [])
 
   const loadLatestConversation = async () => {
@@ -190,6 +198,14 @@ export function ChatPage() {
   const realtimeRef = useRef(realtime)
   realtimeRef.current = realtime
 
+  useEffect(() => {
+    realtime.setOutputVolume(outputVolume)
+  }, [outputVolume, realtime])
+
+  useEffect(() => {
+    realtime.setOutputMuted(outputMuted)
+  }, [outputMuted, realtime])
+
   const startCall = useCallback(async () => {
     setConnectionError('')
     setIsConnecting(true)
@@ -204,7 +220,7 @@ export function ChatPage() {
     const tavilyApiKey = tavilyEnabled
       ? ((await getSetting('tavily_api_key')) || undefined)
       : undefined
-    const volume = parseFloat((await getSetting('realtime_volume')) || '1.0')
+    const volume = outputVolume
     const tracingEnabled = (await getSetting('tracing_enabled')) === 'true'
     const inputDeviceId = (await getSetting('input_device_id')) || undefined
     const outputDeviceId = (await getSetting('output_device_id')) || undefined
@@ -236,7 +252,7 @@ export function ChatPage() {
       conversationHistory: conversationHistory.length > 0 ? conversationHistory : undefined,
       tracingEnabled,
     })
-  }, [realtime])
+  }, [realtime, outputVolume])
 
   const endCall = useCallback(() => {
     realtime.stop()
@@ -253,6 +269,15 @@ export function ChatPage() {
     setIsMuted(next)
     realtime.setMuted(next)
   }, [isMuted, realtime])
+
+  const handleOutputVolumeChange = useCallback((next: number) => {
+    setOutputVolume(next)
+    setSetting('realtime_volume', next.toString()).catch(() => {})
+  }, [])
+
+  const handleOutputMutedChange = useCallback((next: boolean) => {
+    setOutputMuted(next)
+  }, [])
 
   // The floating call bar's context menu forwards mute / end-call
   // requests through main. Wire them to the chat UI's existing actions.
@@ -468,6 +493,13 @@ export function ChatPage() {
                 {isScreenSharing ? <MonitorOff size={20} /> : <Monitor size={20} />}
               </Button>
             </span>
+            <VolumeControl
+              volume={outputVolume}
+              muted={outputMuted}
+              onVolumeChange={handleOutputVolumeChange}
+              onMutedChange={handleOutputMutedChange}
+            />
+
             <Button
               variant="destructive"
               size="icon"

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -84,6 +84,7 @@ export default defineConfig({
             { slug: 'desktop-app' },
             { slug: 'desktop/onboarding', label: 'Desktop: onboarding wizard' },
             { slug: 'desktop/call-bar', label: 'Desktop: floating call bar' },
+            { slug: 'desktop/volume-control', label: 'Desktop: agent volume control' },
             { slug: 'desktop/releasing', label: 'Desktop: releasing' },
             { slug: 'mobile-app' },
           ],

--- a/docs/src/content/docs/desktop/volume-control.mdx
+++ b/docs/src/content/docs/desktop/volume-control.mdx
@@ -1,0 +1,40 @@
+---
+title: Agent volume control
+description: A small speaker icon in the active-call control row that opens a vertical slider for adjusting the agent's playback volume — and toggles mute when the slider is already open.
+---
+
+import { Aside } from '@astrojs/starlight/components'
+
+While you're on a call in the desktop app, the row of icon buttons under the transcript includes a small speaker icon next to the screen-share button. It controls only the agent's voice — your microphone mute and call-end controls live alongside it but are unrelated.
+
+## What it does
+
+- **Click the icon when nothing's open.** A small vertical slider pops up above the icon. Drag the thumb up to raise the agent's voice, down to lower it. The level meter below the transcript still reflects your mic input — this slider only affects what the agent sounds like to you.
+- **Click the icon again while the slider is open.** Mutes the agent. Click once more to unmute. The slider stays visible the whole time so the toggle feels deliberate, like a native volume picker.
+- **Drag while muted.** Touching the slider unmutes automatically and snaps the level to wherever you dragged.
+- **Click outside the slider.** Closes it. The icon goes back to its idle state until the next click.
+
+The icon glyph follows the level: `Volume2` at high levels, `Volume1` mid, `Volume` near silent, and `VolumeX` (with a red tint) when muted.
+
+## Where the volume actually applies
+
+The slider drives the gain stage in `AudioEngine` — the same `GainNode` that all assistant playback flows through. It does **not** touch the system output volume, the microphone, or any other desktop audio. Other apps on your machine stay at whatever level your OS has them at.
+
+## What persists
+
+- The **volume level** persists across reloads via the SQLite `settings` table (key: `realtime_volume`). Your last setting is restored when the chat window mounts.
+- The **mute state** does not persist. We assume mute is a deliberate, in-the-moment choice — every fresh call starts unmuted at your saved volume.
+
+## Keyboard
+
+The slider track is keyboard-focusable when open:
+
+- `ArrowUp` / `ArrowRight` — raise volume by 5% (10% with Shift)
+- `ArrowDown` / `ArrowLeft` — lower volume by 5% (10% with Shift)
+- `Home` — set to 0
+- `End` — set to 100
+- `Escape` — close the slider
+
+<Aside type="tip">
+  If you want to silence the agent without touching the slider, just click the icon twice while the slider is open: first click opens it, second click mutes. Click the icon a third time to unmute and keep going.
+</Aside>

--- a/docs/src/content/docs/desktop/volume-control.mdx
+++ b/docs/src/content/docs/desktop/volume-control.mdx
@@ -20,10 +20,13 @@ The icon glyph follows the level: `Volume2` at high levels, `Volume1` mid, `Volu
 
 The slider drives the gain stage in `AudioEngine` — the same `GainNode` that all assistant playback flows through. It does **not** touch the system output volume, the microphone, or any other desktop audio. Other apps on your machine stay at whatever level your OS has them at.
 
+The slider sits *on top of* the boost multiplier in **Settings → Speaker Volume**. Settings sets the base level (0.5x – 3.0x); the in-call slider then attenuates that base from 0% – 100%. So `Settings = 2.0x` and `slider = 50%` gives an effective playback gain of 1.0x.
+
 ## What persists
 
-- The **volume level** persists across reloads via the SQLite `settings` table (key: `realtime_volume`). Your last setting is restored when the chat window mounts.
-- The **mute state** does not persist. We assume mute is a deliberate, in-the-moment choice — every fresh call starts unmuted at your saved volume.
+- The **slider position** persists across reloads via the SQLite `settings` table (key: `realtime_output_gain`). Your last setting is restored when the chat window mounts.
+- The **base speaker volume** stays where you put it in Settings (key: `realtime_volume`).
+- The **mute state** does not persist. We assume mute is a deliberate, in-the-moment choice — every fresh call starts unmuted at your saved gain.
 
 ## Keyboard
 


### PR DESCRIPTION
## Summary
- Single speaker icon in the active-call control row opens a vertical popover slider that drives the AudioEngine playback gain.
- Click the icon while the slider is open to toggle mute (matches the native-volume-picker UX in the ticket); the slider stays visible. Click outside or press Escape to close.
- Volume persists across sessions via the existing \`realtime_volume\` setting; mute is per-call.
- Wires new \`setOutputMuted\` / \`getOutputVolume\` on \`AudioEngine\` and exposes \`setOutputVolume\` / \`setOutputMuted\` on \`useRealtime\` so the chat page can drive the playback gain independently of the existing mic-input \`setMuted\` path.
- Ships with a Starlight docs page (\`desktop/volume-control\`) explaining UX, keyboard shortcuts, and persistence.

## Test plan
- [ ] Start a call, click the speaker icon — vertical slider appears above it.
- [ ] Drag the slider — agent voice volume changes live.
- [ ] Click the icon while slider is open — agent audio mutes (icon turns red, shows VolumeX). Click again — unmutes at saved level.
- [ ] Drag while muted — auto-unmutes and snaps to dragged level.
- [ ] Click outside the popover — closes; re-opens on next click.
- [ ] Reload the desktop app — last volume level is restored; mute resets to off.
- [ ] Keyboard: focus slider, ArrowUp/Down adjust by 5%, Home/End jump to 0/100, Escape closes.
- [ ] Verify other apps' system audio is unaffected.

\U0001f916 Generated with [Claude Code](https://claude.com/claude-code)