### PR TITLE
fix(NAN-670, NAN-675): thumbnail icon fallback + deterministic picker order

### DIFF
--- a/desktop/src/main/screen-capture.ts
+++ b/desktop/src/main/screen-capture.ts
@@ -1,7 +1,14 @@
 import { ipcMain, desktopCapturer, systemPreferences, shell, session } from 'electron'
 
+export type ScreenSourceIPC = {
+  id: string
+  name: string
+  thumbnailDataURL: string | null
+  appIconDataURL: string | null
+}
+
 export function registerScreenCaptureHandlers() {
-  ipcMain.handle('screen:getSources', async () => {
+  ipcMain.handle('screen:getSources', async (): Promise<ScreenSourceIPC[]> => {
     if (process.platform === 'darwin') {
       const status = systemPreferences.getMediaAccessStatus('screen')
       if (status !== 'granted') {
@@ -16,12 +23,23 @@ export function registerScreenCaptureHandlers() {
 
     const sources = await desktopCapturer.getSources({
       types: ['screen', 'window'],
-      thumbnailSize: { width: 320, height: 240 },
+      thumbnailSize: { width: 640, height: 480 },
+      fetchWindowIcons: true,
     })
-    return sources.map((s) => ({
+
+    const screens = sources
+      .filter((s) => s.id.startsWith('screen:'))
+      .sort((a, b) => a.id.localeCompare(b.id))
+    const windows = sources
+      .filter((s) => s.id.startsWith('window:'))
+      .sort((a, b) => a.name.localeCompare(b.name))
+
+    return [...screens, ...windows].map((s) => ({
       id: s.id,
       name: s.name,
-      thumbnailDataURL: s.thumbnail.toDataURL(),
+      thumbnailDataURL: s.thumbnail.isEmpty() ? null : s.thumbnail.toDataURL(),
+      appIconDataURL:
+        s.appIcon && !s.appIcon.isEmpty() ? s.appIcon.toDataURL() : null,
     }))
   })
 

--- a/desktop/src/main/screen-capture.ts
+++ b/desktop/src/main/screen-capture.ts
@@ -32,7 +32,10 @@ export function registerScreenCaptureHandlers() {
       .sort((a, b) => a.id.localeCompare(b.id))
     const windows = sources
       .filter((s) => s.id.startsWith('window:'))
-      .sort((a, b) => a.name.localeCompare(b.name))
+      .sort((a, b) => {
+        const byName = a.name.localeCompare(b.name)
+        return byName !== 0 ? byName : a.id.localeCompare(b.id)
+      })
 
     return [...screens, ...windows].map((s) => ({
       id: s.id,

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -154,7 +154,15 @@ const electronAPI = {
       }>,
   },
   screen: {
-    getSources: () => ipcRenderer.invoke('screen:getSources'),
+    getSources: () =>
+      ipcRenderer.invoke('screen:getSources') as Promise<
+        Array<{
+          id: string
+          name: string
+          thumbnailDataURL: string | null
+          appIconDataURL: string | null
+        }>
+      >,
   },
   net: {
     healthCheck: (url: string) => ipcRenderer.invoke('net:healthCheck', url) as Promise<{ ok: boolean, error?: string }>,

--- a/desktop/src/renderer/src/components/ScreenSharePicker.tsx
+++ b/desktop/src/renderer/src/components/ScreenSharePicker.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { X } from 'lucide-react'
+import { AppWindow, Monitor, X } from 'lucide-react'
 import { Button } from './ui/Button'
 import { getScreenSources, type ScreenSource } from '../lib/screen-capture'
 
@@ -44,11 +44,7 @@ export function ScreenSharePicker({ onSelect, onCancel }: ScreenSharePickerProps
                   onClick={() => onSelect(source)}
                   className="group rounded-md border border-border bg-background p-2 hover:border-primary/50 hover:bg-accent transition-colors text-left"
                 >
-                  <img
-                    src={source.thumbnailDataURL}
-                    alt={source.name}
-                    className="w-full h-32 object-contain rounded-md bg-muted mb-2"
-                  />
+                  <SourcePreview source={source} />
                   <p className="text-xs text-muted-foreground group-hover:text-foreground truncate px-1">
                     {source.name}
                   </p>
@@ -58,6 +54,38 @@ export function ScreenSharePicker({ onSelect, onCancel }: ScreenSharePickerProps
           )}
         </div>
       </div>
+    </div>
+  )
+}
+
+function SourcePreview({ source }: { source: ScreenSource }) {
+  const isScreen = source.id.startsWith('screen:')
+
+  if (source.thumbnailDataURL) {
+    return (
+      <img
+        src={source.thumbnailDataURL}
+        alt={source.name}
+        className="w-full h-32 object-contain rounded-md bg-muted mb-2"
+      />
+    )
+  }
+
+  if (source.appIconDataURL) {
+    return (
+      <div className="w-full h-32 flex items-center justify-center rounded-md bg-muted mb-2">
+        <img
+          src={source.appIconDataURL}
+          alt={source.name}
+          className="h-16 w-16 object-contain"
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="w-full h-32 flex items-center justify-center rounded-md bg-muted mb-2 text-muted-foreground">
+      {isScreen ? <Monitor size={40} /> : <AppWindow size={40} />}
     </div>
   )
 }

--- a/desktop/src/renderer/src/lib/screen-capture.ts
+++ b/desktop/src/renderer/src/lib/screen-capture.ts
@@ -4,7 +4,8 @@
 export type ScreenSource = {
   id: string
   name: string
-  thumbnailDataURL: string
+  thumbnailDataURL: string | null
+  appIconDataURL: string | null
 }
 
 declare global {


### PR DESCRIPTION
## Summary

Bundled fix for two screen-share picker bugs that share the same call site (`desktopCapturer.getSources` in `desktop/src/main/screen-capture.ts`).

### NAN-670 — Broken app thumbnails (Urgent)

On macOS, `CGWindowListCreateImage` returns an empty `NativeImage` for windows the WindowServer hasn't rendered recently (hidden, minimized, or menu-bar-only apps like Tailscale, 1Password mini, etc.). The old code called `thumbnail.toDataURL()` unconditionally, which on an empty image returns a *valid-but-blank* data URL — so the picker rendered a broken tile.

Fix:
- Main handler now returns `thumbnailDataURL: string | null` (null when `thumbnail.isEmpty()`) and `appIconDataURL: string | null` (null when empty / unavailable).
- Pass `fetchWindowIcons: true` to `getSources` so we can use the app icon as a fallback.
- Picker renders a fallback chain: **thumbnail → appIcon → Lucide icon** (`Monitor` for screens, `AppWindow` for windows). Stale apps stay selectable; user just sees an icon instead of a broken tile.

Also bumps `thumbnailSize` from 320×240 → 640×480 for sharper previews.

### NAN-675 — Non-deterministic picker order (High)

Sources are now sorted in the main handler before being returned to the renderer:
- **Screens first**, sorted by `id` ascending (Electron's id format is `screen:ZZ:0` where `ZZ` is the sequential screen number, so id-sort = screen-index sort).
- **Windows after**, sorted alphabetically by `name`.

### IPC contract

Updated `main` → `preload` → `renderer wrapper` → `picker` to propagate the nullable shape consistently.

## Tickets

- NAN-670 — https://linear.app/nano3labs/issue/NAN-670
- NAN-675 — https://linear.app/nano3labs/issue/NAN-675

## Test plan

- [x] `desktop/yarn typecheck` passes
- [ ] Run desktop dev, open the screen-share picker:
  - [ ] Tailscale (or any menu-bar-only / hidden app) shows a Lucide `AppWindow` icon (or its appIcon) instead of a broken tile
  - [ ] Picker order is deterministic across reopens — screens appear first (in display order), windows after sorted alphabetically
  - [ ] Selecting a fallback-icon source still successfully starts capture
- [ ] Verify on a multi-display setup that screens are listed in stable order

I have not run the desktop dev build on-device for this PR — agent worktree, no display attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)