### PR TITLE
fix(desktop): use boolean notarize flag for electron-builder 26

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -48,8 +48,7 @@ mac:
     NSCameraUsageDescription: "VoiceClaw only uses your camera when you explicitly start a video-enabled session. It is otherwise idle."
     NSScreenCaptureUsageDescription: "VoiceClaw can share your screen with the AI on demand, so it can see what you're looking at when you ask it to. Sharing is off until you start it."
 
-  notarize:
-    teamId: HN6T5KD4ND
+  notarize: true
 
 dmg:
   title: "VoiceClaw ${version}"


### PR DESCRIPTION
## Why

\`release-desktop.yml\` ran for the first time on \`desktop-v0.2.0\` and failed schema validation in electron-builder:

\`\`\`
ValidationError: Invalid configuration object. electron-builder 26.8.1 has been initialized using a configuration object that does not match the API schema.
 - configuration.mac.notarize should be a boolean.
\`\`\`

The \`{ teamId: ... }\` object syntax was valid in older majors but electron-builder 26.x dropped it. Team ID is now inferred from the signing cert; the env var \`APPLE_TEAM_ID\` is the override knob if it's ever needed.

## Change

\`\`\`diff
-  notarize:
-    teamId: HN6T5KD4ND
+  notarize: true
\`\`\`

## Test plan

- [ ] Merge.
- [ ] Re-run the failed \`Release desktop\` job: \`gh run rerun 24944289705 --repo yagudaev/voiceclaw\` (or push a fresh tag if rerun is no longer available).
- [ ] Confirm \`Build, sign, notarize, and publish\` step completes.
- [ ] Confirm DMG + blockmap + latest-mac.yml appear as assets on the \`desktop-v0.2.0\` GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)