### PR TITLE
chore(yarn): track .yarnrc.yml and pin nodeLinker to node-modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,5 @@ desktop/build/icon-master.png
 .claude/scheduled_tasks.lock
 .claude/settings.local.json
 
-# Yarn local config
-.yarnrc.yml
-
 # Dev logs
 logs/

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,5 @@
+compressionLevel: mixed
+
+enableGlobalCache: false
+
+nodeLinker: node-modules


### PR DESCRIPTION
## Why

The desktop release CI failed at workspace postinstalls:

- **desktop**: \`electron-rebuild\` → \"Unable to find electron's version number\"
- **website**: \`prisma generate\` → \"Could not resolve @prisma/client\"

Both are the same symptom: workspace postinstall scripts can't see their dependencies. The root cause is that **\`.yarnrc.yml\` was gitignored**, so CI had no yarn config at all and Yarn 4 fell back to its **PnP linker**, which has no \`node_modules/\` directory for those tools to read from.

Locally, everyone happened to be running with \`nodeLinker: node-modules\` (yarn 4's default kicks in without a config, plus the existing .yarnrc.yml only set compressionLevel + enableGlobalCache), so CI and local diverged silently.

## Change

- Track \`.yarnrc.yml\` (remove from \`.gitignore\`).
- Add explicit \`nodeLinker: node-modules\` so the choice is loud and CI/local cannot drift again.
- Keep the existing \`compressionLevel: mixed\` and \`enableGlobalCache: false\` settings.

## Test plan

- [ ] Merge.
- [ ] Force-move \`desktop-v0.2.1\` tag to new main HEAD (no DMG was ever published, safe to retry).
- [ ] Confirm \`Install dependencies\` step completes without postinstall failures.
- [ ] Confirm \`Build, sign, notarize, and publish\` succeeds and DMG attaches to the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)