### PR TITLE
fix(ci): hand Developer ID cert to electron-builder via CSC_LINK

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -82,18 +82,19 @@ jobs:
           printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > ~/.appstore/AuthKey_${APPLE_API_KEY_ID}.p8
           chmod 600 ~/.appstore/AuthKey_${APPLE_API_KEY_ID}.p8
 
-      - name: Import Developer ID certificate
-        uses: apple-actions/import-codesign-certs@v7
-        with:
-          p12-file-base64: ${{ secrets.DEVELOPER_ID_CERT_P12 }}
-          p12-password: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
-
       - name: Build, sign, notarize, and publish
         working-directory: desktop
         env:
-          # electron-builder reads these from the environment to sign +
-          # notarize. APPLE_API_KEY points at the .p8 written above; the
-          # id/issuer pair lets notarytool auth without username/password.
+          # CSC_LINK + CSC_KEY_PASSWORD let electron-builder import the
+          # Developer ID cert into its own temporary keychain. More
+          # reliable than apple-actions/import-codesign-certs on macos-14,
+          # which sometimes leaves the imported identity invisible to
+          # electron-builder's `security find-identity` lookup, causing
+          # an ad-hoc-signed app that Apple notarytool then rejects.
+          CSC_LINK: ${{ secrets.DEVELOPER_ID_CERT_P12 }}
+          CSC_KEY_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+          # APPLE_API_KEY points at the .p8 written above; the id/issuer
+          # pair lets notarytool auth without username/password.
           APPLE_API_KEY: ${{ format('/Users/runner/.appstore/AuthKey_{0}.p8', secrets.APPLE_API_KEY_ID) }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}


### PR DESCRIPTION
## Why

Run #5 of the desktop release got all the way to \`Build, sign, notarize, and publish\` and then failed with:

\`\`\`
falling back to ad-hoc signature for macOS application code signing
...
⨯ Failed to notarize via notarytool
{\"status\":\"Invalid\", \"id\":\"...\", \"message\":\"Processing complete\"}
\`\`\`

Apple's notarytool rejected the build with the same message on every embedded binary, both x86_64 and arm64:

\`\`\`
The binary is not signed with a valid Developer ID certificate.
The signature does not include a secure timestamp.
\`\`\`

Root cause: \`apple-actions/import-codesign-certs@v7\` imported the .p12 successfully (the step reported ✓), but the identity wasn't visible to electron-builder's signing pass, so electron-builder fell back to ad-hoc signing. This is a known fragility of the two-step \"import then build\" pattern on macos-14 runners.

## Change

Drop the import-codesign-certs step. Pass the cert directly to electron-builder via \`CSC_LINK\` (base64 of .p12) + \`CSC_KEY_PASSWORD\`. electron-builder creates and unlocks its own temporary keychain, which guarantees the identity is in scope at sign time.

## Test plan

- [ ] Merge.
- [ ] Force-move \`desktop-v0.2.1\` tag to new main HEAD.
- [ ] Confirm logs no longer say \"falling back to ad-hoc signature\".
- [ ] Confirm notarytool returns \`status: Accepted\`.
- [ ] Confirm the DMG, blockmap, and latest-mac.yml attach to the \`desktop-v0.2.1\` GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)