### PR TITLE
fix(desktop): make signing fail loudly + diagnose cert

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -82,17 +82,35 @@ jobs:
           printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > ~/.appstore/AuthKey_${APPLE_API_KEY_ID}.p8
           chmod 600 ~/.appstore/AuthKey_${APPLE_API_KEY_ID}.p8
 
+      - name: Inspect Developer ID p12 (subject + private-key check)
+        env:
+          CSC_LINK: ${{ secrets.DEVELOPER_ID_CERT_P12 }}
+          CSC_KEY_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+        run: |
+          set +x
+          cert="$(mktemp)"
+          printf '%s' "$CSC_LINK" | base64 --decode > "$cert"
+          openssl pkcs12 -in "$cert" -nokeys -passin pass:"$CSC_KEY_PASSWORD" 2>/dev/null \
+            | openssl x509 -noout -subject -issuer -dates
+          openssl pkcs12 -in "$cert" -nocerts -nodes -passin pass:"$CSC_KEY_PASSWORD" 2>/dev/null \
+            | openssl pkey -noout -check >/dev/null 2>&1 \
+            && echo "p12 contains a valid private key" \
+            || { echo "FAIL: p12 has no private key (or wrong password / corrupted base64)"; exit 1; }
+          rm -f "$cert"
+
       - name: Build, sign, notarize, and publish
         working-directory: desktop
         env:
           # CSC_LINK + CSC_KEY_PASSWORD let electron-builder import the
-          # Developer ID cert into its own temporary keychain. More
-          # reliable than apple-actions/import-codesign-certs on macos-14,
-          # which sometimes leaves the imported identity invisible to
-          # electron-builder's `security find-identity` lookup, causing
-          # an ad-hoc-signed app that Apple notarytool then rejects.
+          # Developer ID cert into its own temporary keychain.
           CSC_LINK: ${{ secrets.DEVELOPER_ID_CERT_P12 }}
           CSC_KEY_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+          # Fail loudly instead of silently falling back to an ad-hoc
+          # signature that Apple notarytool will then reject.
+          CSC_FOR_PULL_REQUEST: "true"
+          # Verbose electron-builder logs while we are still debugging
+          # the macos-14 signing path.
+          DEBUG: electron-builder
           # APPLE_API_KEY points at the .p8 written above; the id/issuer
           # pair lets notarytool auth without username/password.
           APPLE_API_KEY: ${{ format('/Users/runner/.appstore/AuthKey_{0}.p8', secrets.APPLE_API_KEY_ID) }}
@@ -101,7 +119,7 @@ jobs:
           # GH_TOKEN scopes the GitHub Releases upload done by
           # electron-builder's `--publish always`.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: yarn dist:mac --publish always
+        run: yarn dist:mac --publish always -c.forceCodeSigning=true
 
       - name: Upload DMG as workflow artifact
         if: always()

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -30,12 +30,6 @@ mac:
       arch:
         - universal
 
-  # electron-builder takes the CN suffix only — "Nano 3 Labs Ltd (HN6T5KD4ND)"
-  # — and infers the "Developer ID Application: " prefix itself. Including the
-  # prefix here makes it reject every cert with "identity not found", which
-  # silently breaks signing (the build finishes but the .app is unsigned).
-  identity: "Nano 3 Labs Ltd (HN6T5KD4ND)"
-
   # Hardened Runtime + entitlements are required for notarization.
   hardenedRuntime: true
   gatekeeperAssess: false

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -8,7 +8,7 @@
     "build": "electron-vite build",
     "typecheck": "tsc --noEmit",
     "postinstall": "electron-rebuild -f -w better-sqlite3 --module-dir .",
-    "dist:mac": "electron-vite build && node scripts/with-build-env.mjs electron-builder --mac --publish never",
+    "dist:mac": "electron-vite build && node scripts/with-build-env.mjs electron-builder --mac",
     "build:icon": "tsx scripts/build-mac-icon.ts ../mobile/assets/images/ios/icon-1024x1024.png build/icon-master.png build/icon.iconset && iconutil -c icns build/icon.iconset -o build/icon.icns && cp build/icon.iconset/icon_512x512.png resources/dock/icon.png",
     "build:tray-icon": "tsx scripts/build-tray-icon.ts",
     "build:assets": "yarn build:icon && yarn build:tray-icon"


### PR DESCRIPTION
## Why

Got a sanity check from Codex on 5 failed desktop release runs in a row. Both attempt #5 (with apple-actions/import-codesign-certs) and #6 (with CSC_LINK) failed at the same place:

\`\`\`
falling back to ad-hoc signature for macOS application code signing
signing file=dist/mac-universal/VoiceClaw.app identityName=- identityHash=none
\`\`\`

Apple notarytool then rejected: \"The binary is not signed with a valid Developer ID certificate.\"

\`identityName=-\` is electron-builder's way of saying \"I imported a cert but couldn't match the pinned identity, so I gave up and ad-hoc signed.\" Three plausible causes per Codex:

1. **The pinned \`identity:\` in electron-builder.yml doesn't match the cert's actual CN.** Most likely.
2. The .p12 is missing the private key (export-from-Keychain footgun).
3. CSC_KEY_PASSWORD is wrong (would normally error loudly but worth verifying).

## Change

1. **Drop the pinned identity.** \`desktop/electron-builder.yml\` had \`identity: \"Nano 3 Labs Ltd (HN6T5KD4ND)\"\`. If the actual cert's CN suffix differs by even one character (whitespace, encoding, missing/extra parens), electron-builder silently skips it. Auto-detect from the keychain is more robust for a single-cert setup.

2. **Add a pre-build cert inspection step** that decodes the .p12, prints subject/issuer/dates, and verifies the private key exists. If the .p12 is broken, this fails the job with a clear error in seconds instead of after a 4-minute build.

3. **Force signing to fail loudly** on the build step:
   - \`-c.forceCodeSigning=true\` — error instead of silent ad-hoc fallback.
   - \`DEBUG=electron-builder\` — verbose logs to see exactly what's happening.

4. **Fix \`--publish\` conflict.** \`desktop/package.json\` had \`dist:mac\` hardcoded with \`--publish never\`, which the workflow's \`--publish always\` then can't override cleanly. Remove the pin from the script.

## Test plan

- [ ] Merge.
- [ ] Force-move \`desktop-v0.2.1\` tag to new main HEAD.
- [ ] If cert is missing private key → diagnostic step fails with that exact message; user re-exports.
- [ ] If cert is fine but identity-pin was the issue → build now signs successfully with the auto-detected identity, notarization passes, DMG attaches to release.
- [ ] If something else is wrong → \`DEBUG=electron-builder\` + the \`forceCodeSigning\` error give us the real reason instead of the ad-hoc smokescreen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)