### PR TITLE
fix(mobile): make deploy reproducible from any fresh checkout

### DIFF
--- a/mobile/scripts/build-ios.sh
+++ b/mobile/scripts/build-ios.sh
@@ -15,8 +15,12 @@ ASC_KEY_ID="${ASC_API_KEY_ID:-SG645CPQP8}"
 ASC_ISSUER_ID="${ASC_API_ISSUER_ID:-69a6de83-015f-47e3-e053-5b8c7c11a4d1}"
 
 echo "==> Building VoiceClaw ($VARIANT)"
-echo "==> Step 1: Prebuild with APP_VARIANT=$VARIANT"
 cd "$MOBILE_DIR"
+
+echo "==> Step 0: Download Daily.co iOS SDK (vendored, gitignored)"
+./scripts/download-daily-sdk.sh
+
+echo "==> Step 1: Prebuild with APP_VARIANT=$VARIANT"
 APP_VARIANT="$VARIANT" npx expo prebuild --clean
 
 echo "==> Step 2: Resolve SPM packages"

--- a/mobile/scripts/download-daily-sdk.sh
+++ b/mobile/scripts/download-daily-sdk.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Downloads the Daily.co iOS SDK framework needed by the Vapi module
 # Run this before building: ./scripts/download-daily-sdk.sh
+set -euo pipefail
 
 DAILY_VERSION="0.37.0"
 FRAMEWORKS_DIR="modules/expo-vapi/ios/Frameworks"
@@ -12,10 +13,17 @@ if [ -d "${FRAMEWORKS_DIR}/Daily.xcframework" ]; then
 fi
 
 echo "Downloading Daily.co iOS SDK v${DAILY_VERSION}..."
-curl -sL -o /tmp/daily-sdk.zip "${DOWNLOAD_URL}"
+curl -fsSL -o /tmp/daily-sdk.zip "${DOWNLOAD_URL}"
 
 echo "Extracting to ${FRAMEWORKS_DIR}..."
+mkdir -p "${FRAMEWORKS_DIR}"
 unzip -o /tmp/daily-sdk.zip -d "${FRAMEWORKS_DIR}" > /dev/null
 
 rm /tmp/daily-sdk.zip
+
+if [ ! -d "${FRAMEWORKS_DIR}/Daily.xcframework" ]; then
+  echo "!! Download/extract finished but ${FRAMEWORKS_DIR}/Daily.xcframework is missing" >&2
+  exit 1
+fi
+
 echo "Done — Daily.xcframework ready"


### PR DESCRIPTION
## Summary

A fresh-checkout `yarn ios:release:production` failed today because the vendored, gitignored `Daily.xcframework` was never downloaded. The repo has `mobile/scripts/download-daily-sdk.sh`, but the actual deploy entrypoint `mobile/scripts/build-ios.sh` never invoked it — so the build only worked on machines that happened to already have the framework on disk. Anyone on a fresh worktree, a new laptop, or CI hits the same cliff.

## What this PR cures

- Adds a `Step 0: Download Daily.co iOS SDK` to `mobile/scripts/build-ios.sh`, before `expo prebuild` and any `xcodebuild` step.
  - **Fresh-checkout failure cured:** the framework is now fetched on first deploy from any clone, no manual setup step.
  - **Idempotent:** `download-daily-sdk.sh` already short-circuits if `Daily.xcframework` exists, so existing checkouts pay nothing.
  - **Fails loudly:** `set -euo pipefail` is on; a non-zero exit halts the build immediately rather than continuing into a confusing `xcodebuild` failure later.
  - **Visible in deploy logs:** logged with the same `==> Step N:` prefix as the rest of the script.

## Deferred (not in this PR)

`mobile/eas.json`'s production submit profile is missing `ascAppId`. `mobile/CLAUDE.md` documents this exact failure mode: without it, `eas submit` can fall back to interactive Apple ID login and break non-interactive deploys. **Staging** has `6762490226`, but that is the App Store Connect ID for the `com.yagudaev.voiceclaw.staging` bundle — production (`com.yagudaev.voiceclaw`) is a separate ASC app with its own ID, and the production ID is not recorded anywhere in the repo or sibling docs.

Rather than guess and risk submitting to the wrong app, leaving this for a follow-up PR once the production value is read off App Store Connect (Apps → VoiceClaw → App Information → Apple ID).

## Test plan

- [x] `bash -n mobile/scripts/build-ios.sh` (syntax)
- [x] Ran `mobile/scripts/download-daily-sdk.sh` standalone in a fresh worktree — downloads `Daily.xcframework` correctly, populates `Info.plist`, `ios-arm64`, `ios-arm64_x86_64-simulator`.
- [x] Ran it a second time — short-circuits with `Daily.xcframework already exists, skipping download`. Confirms idempotency.
- [x] `python3 -c 'import json; json.load(open("mobile/eas.json"))'` (no eas.json change in this PR, but verified untouched).