### PR TITLE
fix(desktop): pin electron-builder publish to desktop-v tags

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -68,3 +68,7 @@ publish:
   owner: yagudaev
   repo: voiceclaw
   releaseType: release
+  # Match the release-please tag scheme so electron-builder publishes to
+  # the existing `desktop-v<version>` release instead of creating a new
+  # `v<version>` one (the default).
+  tagNamePrefix: desktop-v


### PR DESCRIPTION
## Why

Codex sanity-checked my plan to revert the desktop tag scheme back to bare \`v*.*.*\` and called out a cleaner option: electron-builder 26.x already exposes \`publish.tagNamePrefix\` for exactly this case. Setting it to \`desktop-v\` makes the GitHub publisher target the release-please-created \`desktop-v0.2.1\` release instead of trying to create a parallel \`v0.2.1\` one.

The previous run got past Apple signing + notarization and then died at the publish step:

\`\`\`
HttpError: 422 Unprocessable Entity
{\"message\":\"Validation Failed\", \"errors\":[{\"resource\":\"Release\",\"message\":\"Published releases must have a valid tag\"}]}
\`\`\`

electron-builder had created a parallel \`v0.2.1\` release with only the .blockmap asset, then errored on the rest of the upload.

## Change

\`\`\`diff
 publish:
   provider: github
   owner: yagudaev
   repo: voiceclaw
   releaseType: release
+  tagNamePrefix: desktop-v
\`\`\`

\`tagNamePrefix\` overrides the (now-deprecated) \`vPrefixedTagName\` and tells electron-builder to construct \`desktop-v0.2.1\` instead of \`v0.2.1\`.

## Cleanup

The orphaned \`v0.2.1\` git tag + GitHub Release that the previous run created will be deleted as part of merging this — they were never valid (DMG never uploaded successfully) and shouldn't appear in the public release history.

## Follow-up (not in this PR)

Per Codex's other note: in a monorepo, GitHub's \"latest release\" is repo-wide, so a future \`mobile-v*\` release could become \"latest\" and break the desktop electron-updater feed. Mitigation options for later: mark mobile releases with \`make_latest=false\`, or move desktop auto-updates to a generic provider with an explicit feed URL.

## Test plan

- [ ] Merge.
- [ ] Re-run desktop release on \`desktop-v0.2.1\` (force-move tag if needed).
- [ ] Confirm DMG, blockmap, and latest-mac.yml all attach to the existing \`desktop-v0.2.1\` GitHub Release (not a parallel \`v0.2.1\`).
- [ ] Confirm no new \`v0.2.1\` git tag/release gets created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)