### PR TITLE
fix(gemini): fold resume history into systemInstruction to dodge 1007

### DIFF
--- a/docs/src/content/docs/relay-server.mdx
+++ b/docs/src/content/docs/relay-server.mdx
@@ -100,7 +100,7 @@ When a client sends `conversationHistory` on `session.config`, the relay reconst
 How the recent turns are injected:
 
 - **OpenAI Realtime / xAI:** one `conversation.item.create` per turn (role `user` with content type `input_text`, or role `assistant` with content type `output_text`). No `response.create` is sent — the next user audio drives the first response.
-- **Gemini Live:** a single `clientContent` message with `turnComplete: true` containing all turns (roles mapped `assistant` → `model`, parts coalesced so roles strictly alternate). Sent immediately after `setupComplete`, before the audio stream begins. The setup message opts into this seeding path with `historyConfig.initialHistoryInClientContent: true` — required by `gemini-3.1-flash-live-preview`, which otherwise treats `sendClientContent` as unsupported. `turnComplete: true` marks this as the terminating message of the initial history seed; the next user audio drives the first model turn via `realtimeInput.audio`.
+- **Gemini Live:** the recent turns are folded into `systemInstruction.parts[0].text` under a `## Most recent turns (verbatim)` section, alongside the summary preamble. We do not use the documented `clientContent` + `historyConfig.initialHistoryInClientContent` seeding path: in production it closes the upstream WebSocket with `1007` ("invalid argument") on `gemini-3.1-flash-live-preview`, even when the payload matches the documented contract. Baking the transcript into the system prompt is less natural than first-class turns but is reliable and keeps continuity intact.
 
 History is injected only on the initial connect. Reconnects that use Gemini's resumption handle, and OpenAI's timer-based rotation, both have their own continuity paths and do not replay history.
 

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -5,7 +5,7 @@ import type { SessionConfigEvent } from "../types.js"
 import type { ProviderAdapter, SendToClient } from "./types.js"
 import { buildInstructions } from "../instructions.js"
 import { getGeminiTools } from "../tools/index.js"
-import { buildHistorySplit, formatSummaryPreamble } from "../history.js"
+import { buildHistorySplit, formatSummaryPreamble, formatRecentTurnsPreamble } from "../history.js"
 import { log, error as logError } from "../log.js"
 
 const GEMINI_WS_URL = "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
@@ -68,14 +68,12 @@ export class GeminiAdapter implements ProviderAdapter {
   private isReconnecting = false
   private disconnected = false
   private wsUrlOverride: string | null = null // for tests to point at a mock server
-  // Conversation history injected on the initial connect only. Reconnects rely
-  // on Gemini's resumption handle (or on the next initial connect) — replaying
-  // turns into a resumed session would duplicate context the model already has.
-  // Stored already in Gemini wire shape so the setup flag and the post-setupComplete
-  // clientContent stay consistent: setting historyConfig.initialHistoryInClientContent
-  // without a follow-up clientContent leaves the model waiting for the seed.
-  private resumeTurns: GeminiClientTurn[] = []
-  private resumeSummary: string | null = null
+  // Resume context (summary + recent turns) baked into systemInstruction at setup.
+  // Built once on initial connect; reconnects rely on Gemini's resumption handle.
+  // We avoid the post-setup clientContent + historyConfig.initialHistoryInClientContent
+  // path on gemini-3.1-flash-live-preview — it closes the WebSocket with 1007
+  // ("invalid argument") in production despite matching the documented contract.
+  private resumePreamble: string = ""
   // Bounded queues for messages written during the reconnect window.
   // Flushed on the resumed connection's setupComplete.
   private pendingAudio: string[] = []
@@ -101,10 +99,13 @@ export class GeminiAdapter implements ProviderAdapter {
     this.watchdogEnabled = config.watchdog === "enabled"
 
     const split = await buildHistorySplit(config.conversationHistory, "gemini")
-    this.resumeTurns = buildClientContentTurns(split.recent)
-    this.resumeSummary = split.summary
-    if (this.resumeTurns.length > 0 || split.summary) {
-      log(`[gemini] Resume context: recent=${this.resumeTurns.length} turns, summary=${split.summary ? `${split.summary.length} chars` : "none"}`)
+    const sections: string[] = []
+    if (split.summary) sections.push(formatSummaryPreamble(split.summary))
+    const recentPreamble = formatRecentTurnsPreamble(split.recent)
+    if (recentPreamble) sections.push(recentPreamble)
+    this.resumePreamble = sections.join("\n\n")
+    if (this.resumePreamble) {
+      log(`[gemini] Resume context folded into systemInstruction: recent=${split.recent.length} turns, summary=${split.summary ? `${split.summary.length} chars` : "none"} (${this.resumePreamble.length} chars)`)
     }
 
     await this.openUpstream()
@@ -146,7 +147,6 @@ export class GeminiAdapter implements ProviderAdapter {
             log("[gemini] Setup complete")
             this.resetWatchdog()
             finish()
-            this.injectResumeTurns()
             // Flush AFTER finish() so any waiters see a fully-established
             // connection before queued sends begin landing on the wire.
             this.flushPending()
@@ -396,8 +396,8 @@ export class GeminiAdapter implements ProviderAdapter {
 
   private sendSetup(config: SessionConfigEvent, model: string) {
     const baseInstructions = buildInstructions(config)
-    const instructions = this.resumeSummary
-      ? `${baseInstructions}\n\n${formatSummaryPreamble(this.resumeSummary)}`
+    const instructions = this.resumePreamble
+      ? `${baseInstructions}\n\n${this.resumePreamble}`
       : baseInstructions
     const tools = getGeminiTools(config)
     const voice = resolveVoice(config.voice)
@@ -448,15 +448,6 @@ export class GeminiAdapter implements ProviderAdapter {
 
     if (tools.length > 0) {
       setup.tools = [{ functionDeclarations: tools }]
-    }
-
-    // gemini-3.1-flash-live-preview only accepts a post-setup clientContent
-    // history seed when this flag is set; absent it, sendClientContent is
-    // unsupported on this model. Only set when we actually have wire-ready
-    // turns to inject — opting into the seeding path without sending the
-    // terminating clientContent leaves the model waiting for the seed.
-    if (this.resumeTurns.length > 0) {
-      setup.historyConfig = { initialHistoryInClientContent: true }
     }
 
     // Enable context window compression unconditionally. hasVideoInput is only
@@ -738,27 +729,6 @@ export class GeminiAdapter implements ProviderAdapter {
     }
   }
 
-  private injectResumeTurns() {
-    if (this.resumeTurns.length === 0) return
-    if (!this.upstream || this.upstream.readyState !== WebSocket.OPEN) return
-
-    // turnComplete: true marks this as the terminating message of the initial
-    // history seed. After this, the next user audio drives the first model turn
-    // via realtimeInput.audio — sendClientContent is no longer used on this model.
-    const payload = JSON.stringify({
-      clientContent: {
-        turns: this.resumeTurns,
-        turnComplete: true,
-      },
-    })
-
-    log(`[gemini] Injecting ${this.resumeTurns.length} recent turn(s) via clientContent (${payload.length} bytes)`)
-    this.upstream.send(payload)
-
-    this.resumeTurns = []
-    this.resumeSummary = null
-  }
-
   private flushPending() {
     if (!this.upstream || this.upstream.readyState !== WebSocket.OPEN) return
     // Control first so the model unblocks before we flood it with media.
@@ -988,33 +958,3 @@ function findModalityTokens(
   return details?.find((d) => d.modality === modality)?.tokenCount
 }
 
-type GeminiClientTurn = { role: "user" | "model", parts: { text: string }[] }
-
-// Map the relay's history shape onto Gemini's clientContent.turns. Drops
-// entries with unknown roles or empty text and coalesces consecutive same-role
-// turns so the wire payload always alternates user/model — Gemini Live
-// requires alternation.
-function buildClientContentTurns(
-  history: { role: "user" | "assistant", text: string }[],
-): GeminiClientTurn[] {
-  const out: GeminiClientTurn[] = []
-  for (const m of history) {
-    const role = mapRole(m.role)
-    if (!role) continue
-    const text = typeof m.text === "string" ? m.text.trim() : ""
-    if (!text) continue
-    const last = out[out.length - 1]
-    if (last && last.role === role) {
-      last.parts.push({ text })
-    } else {
-      out.push({ role, parts: [{ text }] })
-    }
-  }
-  return out
-}
-
-function mapRole(role: unknown): "user" | "model" | null {
-  if (role === "user") return "user"
-  if (role === "assistant") return "model"
-  return null
-}

--- a/relay-server/src/history.ts
+++ b/relay-server/src/history.ts
@@ -48,6 +48,24 @@ export function formatSummaryPreamble(summary: string): string {
   return `## Earlier in this conversation\n${summary.trim()}`
 }
 
+export function formatRecentTurnsPreamble(recent: HistoryMessage[]): string {
+  const lines = recent
+    .map((m) => {
+      const text = typeof m.text === "string" ? m.text.trim() : ""
+      if (!text) return null
+      const speaker = m.role === "assistant" ? "Assistant" : "User"
+      return `${speaker}: ${text}`
+    })
+    .filter((l): l is string => l !== null)
+  if (lines.length === 0) return ""
+  return [
+    "## Most recent turns (verbatim)",
+    "Treat these as already-spoken context. Do not re-greet or restate them; pick up naturally where the conversation left off.",
+    "",
+    ...lines,
+  ].join("\n")
+}
+
 // --- helpers ---
 
 const SUMMARY_PROMPT = [

--- a/relay-server/test/test-gemini-history-inject.ts
+++ b/relay-server/test/test-gemini-history-inject.ts
@@ -1,10 +1,14 @@
 // Verifies that the Gemini adapter, when given a conversationHistory on connect,
-// (a) sets historyConfig.initialHistoryInClientContent on the setup message and
-// (b) sends a clientContent { turns, turnComplete: true } message after
-// setupComplete with alternating user/model roles and non-empty parts.
-// turnComplete is true because this is the terminating message of the initial
-// history seed; the next user audio drives the first model turn. Uses a
-// local mock WS server. Run: yarn workspace relay-server tsx test/test-gemini-history-inject.ts
+// (a) folds the recent turns and any summary into systemInstruction.parts[0].text
+// (b) does NOT set historyConfig on the setup message
+// (c) does NOT send a post-setup clientContent message
+//
+// Background: gemini-3.1-flash-live-preview closes the upstream socket with
+// 1007 ("invalid argument") on the post-setup clientContent + historyConfig
+// path even when we match the documented contract. Baking the recent turns
+// into the system prompt is the durable workaround.
+//
+// Run: yarn workspace relay-server tsx test/test-gemini-history-inject.ts
 
 import { WebSocketServer, WebSocket as WsSocket } from "ws"
 import { GeminiAdapter } from "../src/adapters/gemini.js"
@@ -30,7 +34,7 @@ async function main() {
   console.log("=============================================")
 
   process.env.GEMINI_API_KEY = "test-key"
-  process.env.OPENAI_API_KEY = "" // force fallback path on summarizer if it runs
+  process.env.OPENAI_API_KEY = ""
 
   const MOCK_PORT = 19899
   const receivedSetups: Record<string, unknown>[] = []
@@ -62,7 +66,7 @@ async function main() {
     conversationHistory: [
       { role: "user", text: "Hi" },
       { role: "assistant", text: "Hello! How can I help?" },
-      { role: "user", text: "" }, // should be filtered
+      { role: "user", text: "" },
       { role: "user", text: "What's the weather?" },
       { role: "assistant", text: "Sunny." },
     ],
@@ -77,44 +81,26 @@ async function main() {
 
   await new Promise((r) => setTimeout(r, 200))
 
-  console.log("[3] Analyzing setup + clientContent...")
-  const setup = receivedSetups[0] as { historyConfig?: { initialHistoryInClientContent?: boolean } }
+  console.log("[3] Analyzing setup payload...")
+  const setup = receivedSetups[0] as {
+    historyConfig?: unknown
+    systemInstruction?: { parts?: { text?: string }[] }
+  }
   assert(receivedSetups.length === 1, "exactly one setup message received")
-  assert(
-    setup?.historyConfig?.initialHistoryInClientContent === true,
-    "setup includes historyConfig.initialHistoryInClientContent=true",
-  )
+  assert(setup?.historyConfig === undefined, "setup does NOT include historyConfig (avoids 1007 path)")
+  assert(receivedClientContent.length === 0, "no post-setup clientContent sent (avoids 1007 path)")
 
-  assert(receivedClientContent.length === 1, "exactly one clientContent message received")
-  const cc = receivedClientContent[0] as {
-    turns?: { role: string, parts: { text: string }[] }[]
-    turnComplete?: boolean
-  }
-  assert(cc?.turnComplete === true, "clientContent.turnComplete is true (terminating message of initial history seed)")
+  const sysText = setup?.systemInstruction?.parts?.[0]?.text || ""
+  assert(sysText.includes("Most recent turns (verbatim)"), "systemInstruction has recent-turns section header")
+  assert(sysText.includes("User: Hi"), "systemInstruction includes user 'Hi'")
+  assert(sysText.includes("Assistant: Hello! How can I help?"), "systemInstruction includes assistant greeting")
+  assert(sysText.includes("User: What's the weather?"), "systemInstruction includes weather question")
+  assert(sysText.includes("Assistant: Sunny."), "systemInstruction includes assistant 'Sunny.'")
+  assert(!/^User:\s*$/m.test(sysText) && !/^Assistant:\s*$/m.test(sysText), "empty-text turn is filtered out")
 
-  const turns = cc?.turns || []
-  // Empty user turn was filtered. Two consecutive user turns ("Hi", "What's the weather?")
-  // separated by an assistant in the original input remain alternating after filter:
-  //   user "Hi" → model "Hello! How can I help?" → user "What's the weather?" → model "Sunny."
-  assert(turns.length === 4, `expected 4 turns after empty filter (got ${turns.length})`)
-  assert(turns.every((t) => t.role === "user" || t.role === "model"), "all roles are user|model")
-  assert(turns.every((t) => Array.isArray(t.parts) && t.parts.length > 0 && t.parts.every((p) => typeof p.text === "string" && p.text.length > 0)), "all turns have non-empty parts[].text")
-
-  // Verify alternation
-  let alternates = true
-  for (let i = 1; i < turns.length; i++) {
-    if (turns[i].role === turns[i - 1].role) alternates = false
-  }
-  assert(alternates, "roles strictly alternate user/model")
-
-  // Verify the assistant→model role mapping
-  assert(turns[0].role === "user" && turns[0].parts[0].text === "Hi", "turn[0] is user 'Hi'")
-  assert(turns[1].role === "model" && turns[1].parts[0].text.startsWith("Hello!"), "turn[1] is model")
-  assert(turns[2].role === "user" && turns[2].parts[0].text.includes("weather"), "turn[2] is user 'weather'")
-  assert(turns[3].role === "model" && turns[3].parts[0].text === "Sunny.", "turn[3] is model 'Sunny.'")
-
-  // Coalescing: if input has consecutive same-role messages, they merge into one turn.
-  console.log("[4] Coalescing test (consecutive same-role)...")
+  // Same-role consecutive turns are preserved verbatim (no coalescing needed
+  // for plain-text rendering — every line is its own speaker line).
+  console.log("[4] Consecutive same-role rendering...")
   receivedSetups.length = 0
   receivedClientContent.length = 0
   const adapter2 = new GeminiAdapter()
@@ -129,12 +115,13 @@ async function main() {
   }
   await adapter2.connect(config2, () => { /* ignore */ })
   await new Promise((r) => setTimeout(r, 200))
-  const cc2 = receivedClientContent[0] as { turns: { role: string, parts: { text: string }[] }[] }
-  assert(cc2.turns.length === 2, `coalesced consecutive user turns: expected 2 turns, got ${cc2.turns.length}`)
-  assert(cc2.turns[0].role === "user" && cc2.turns[0].parts.length === 2, "coalesced user turn has 2 parts")
-  assert(cc2.turns[1].role === "model", "trailing model turn preserved")
+  const sys2 = (receivedSetups[0] as { systemInstruction?: { parts?: { text?: string }[] } })
+    ?.systemInstruction?.parts?.[0]?.text || ""
+  assert(sys2.includes("User: first") && sys2.includes("User: second"), "both consecutive user lines present")
+  assert(sys2.indexOf("User: first") < sys2.indexOf("User: second"), "lines preserve order")
+  assert(sys2.indexOf("User: second") < sys2.indexOf("Assistant: ok"), "trailing assistant after both user lines")
+  assert(receivedClientContent.length === 0, "no clientContent for consecutive-role case either")
 
-  // No history → no historyConfig, no clientContent.
   console.log("[5] No-history test...")
   receivedSetups.length = 0
   receivedClientContent.length = 0
@@ -143,12 +130,13 @@ async function main() {
   const config3: SessionConfigEvent = { ...config, conversationHistory: undefined }
   await adapter3.connect(config3, () => { /* ignore */ })
   await new Promise((r) => setTimeout(r, 150))
-  const setup3 = receivedSetups[0] as { historyConfig?: unknown }
-  assert(setup3?.historyConfig === undefined, "no historyConfig when no history")
-  assert(receivedClientContent.length === 0, "no clientContent sent when no history")
+  const sys3 = (receivedSetups[0] as { systemInstruction?: { parts?: { text?: string }[] } })
+    ?.systemInstruction?.parts?.[0]?.text || ""
+  assert(!sys3.includes("Most recent turns"), "no recent-turns section when history absent")
+  assert(!sys3.includes("Earlier in this conversation"), "no summary section when history absent")
+  assert(receivedClientContent.length === 0, "no clientContent when history absent")
 
-  // Malformed roles dropped, valid history still injected.
-  console.log("[6] Invalid-role filtering...")
+  console.log("[6] All-empty history is a no-op preamble...")
   receivedSetups.length = 0
   receivedClientContent.length = 0
   const adapter4 = new GeminiAdapter()
@@ -156,47 +144,21 @@ async function main() {
   const config4: SessionConfigEvent = {
     ...config,
     conversationHistory: [
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      { role: "system" as any, text: "ignore me" },
-      { role: "user", text: "real question" },
-      { role: "assistant", text: "real answer" },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      { role: "tool" as any, text: "ignore me too" },
-    ],
-  }
-  await adapter4.connect(config4, () => { /* ignore */ })
-  await new Promise((r) => setTimeout(r, 200))
-  const cc4 = receivedClientContent[0] as { turns: { role: string, parts: { text: string }[] }[] }
-  assert(cc4?.turns.length === 2, `invalid roles dropped: expected 2 turns, got ${cc4?.turns.length}`)
-  assert(cc4?.turns.every((t) => t.role === "user" || t.role === "model"), "no system/tool roles in payload")
-  assert(cc4?.turns.every((t) => !t.parts.some((p) => p.text === "ignore me" || p.text === "ignore me too")), "ignored entries' text not in payload")
-
-  // Every turn invalid → no flag, no clientContent.
-  console.log("[7] All-filtered history...")
-  receivedSetups.length = 0
-  receivedClientContent.length = 0
-  const adapter5 = new GeminiAdapter()
-  ;(adapter5 as unknown as { wsUrlOverride: string }).wsUrlOverride = `ws://localhost:${MOCK_PORT}`
-  const config5: SessionConfigEvent = {
-    ...config,
-    conversationHistory: [
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      { role: "system" as any, text: "x" },
       { role: "user", text: "" },
       { role: "assistant", text: "   " },
     ],
   }
-  await adapter5.connect(config5, () => { /* ignore */ })
-  await new Promise((r) => setTimeout(r, 200))
-  const setup5 = receivedSetups[0] as { historyConfig?: unknown }
-  assert(setup5?.historyConfig === undefined, "no historyConfig when all turns filter out")
-  assert(receivedClientContent.length === 0, "no clientContent when all turns filter out")
+  await adapter4.connect(config4, () => { /* ignore */ })
+  await new Promise((r) => setTimeout(r, 150))
+  const sys4 = (receivedSetups[0] as { systemInstruction?: { parts?: { text?: string }[] } })
+    ?.systemInstruction?.parts?.[0]?.text || ""
+  assert(!sys4.includes("Most recent turns"), "no recent-turns section when every entry is whitespace/empty")
+  assert(receivedClientContent.length === 0, "still no clientContent when every entry filters out")
 
   adapter.disconnect()
   adapter2.disconnect()
   adapter3.disconnect()
   adapter4.disconnect()
-  adapter5.disconnect()
   wss.close()
 
   console.log("")


### PR DESCRIPTION
## Why

Production resume sessions on `gemini-3.1-flash-live-preview` are still dying with a WebSocket 1007 ("Request contains an invalid argument") right after the post-setup history inject — observed live yesterday:

```
[gemini] Setup: model=gemini-3.1-flash-live-preview, voice=Zephyr, tools=3
[gemini] Setup complete
[gemini] Injecting 10 recent turn(s) via clientContent (1767 bytes)
[session:1e83c60e-...] Session ready
[gemini] WebSocket closed: 1007 Request contains an invalid argument.
[session:1e83c60e-...] Disconnecting
```

PR #248 added the documented `historyConfig.initialHistoryInClientContent: true` opt-in plus a hardened `clientContent` payload (alternating roles, non-empty parts, `turnComplete: true`). That matches the public contract and matches what the Python `google-genai` SDK puts on the wire for this scenario, but the call still 1007s one RTT after the inject. We don't have visibility into Google's server-side validation, and continuing to debug their contract while voice resume is broken in prod is the wrong tradeoff.

(An earlier draft of this PR cited [adk-python#5018](https://github.com/google/adk-python/issues/5018) as evidence that seeding is broken on this model — that's wrong. That issue and its fix are about *runtime* text input on 3.1 (switch `send_client_content` → `send_realtime_input(text=…)`); they don't touch the initial-history seeding path. The seeding path is still empirically broken for us, but that issue isn't evidence either way.)

## What changed

- `relay-server/src/adapters/gemini.ts`
  - Drop `GeminiClientTurn`, `buildClientContentTurns`, `injectResumeTurns` and the `historyConfig` opt-in.
  - Replace `resumeTurns` + `resumeSummary` state with a single `resumePreamble` string built in `connect()`.
  - `sendSetup` appends that preamble (summary + recent turns) to `systemInstruction.parts[0].text`.
- `relay-server/src/history.ts`
  - New `formatRecentTurnsPreamble(recent)` — mirrors `formatSummaryPreamble`, filters whitespace-only turns, renders `User:` / `Assistant:` lines under a `## Most recent turns (verbatim)` header with a one-line "do not re-greet" instruction.
- `relay-server/test/test-gemini-history-inject.ts` — rewritten to assert the new contract:
  - exactly one setup, **no** `historyConfig`, **no** post-setup `clientContent`
  - `systemInstruction` contains every non-empty turn in order
  - empty/whitespace turns are filtered, undefined-history is a no-op
- `docs/src/content/docs/relay-server.mdx` — documents the new approach and why the documented seeding path is avoided.

Net **-80 LOC** in the adapter.

## Tradeoffs

Recent turns are no longer first-class Gemini chat turns; they're text inside the system prompt. The model is slightly more likely to repeat or restate older context, which the new "Treat these as already-spoken context. Do not re-greet…" line tries to mitigate. Worth it: continuity survives, the call no longer dies.

If/when we figure out what specifically is wrong with our seeding payload (or Google stabilizes the contract), we can put the old path back behind a flag without changing the public surface.

## Test plan

- [x] `yarn tsc --noEmit` — clean
- [x] `yarn tsx test/test-gemini-history-inject.ts` — 18/18 pass
- [x] `yarn tsx test/test-gemini-unit.ts` — 9/9 pass (no regression)
- [x] `yarn tsx test/test-gemini-reconnect.ts` — 53/53 pass (no regression)
- [ ] Manual smoke: start a real Gemini session with prior `conversationHistory`, confirm setup succeeds, no 1007, the model picks up context naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)