### PR TITLE
ci(desktop): upload DMG via gh CLI to fix release-please race

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -98,7 +98,7 @@ jobs:
             || { echo "FAIL: p12 has no private key (or wrong password / corrupted base64)"; exit 1; }
           rm -f "$cert"
 
-      - name: Build, sign, notarize, and publish
+      - name: Build, sign, notarize
         working-directory: desktop
         env:
           # CSC_LINK + CSC_KEY_PASSWORD let electron-builder import the
@@ -116,10 +116,24 @@ jobs:
           APPLE_API_KEY: ${{ format('/Users/runner/.appstore/AuthKey_{0}.p8', secrets.APPLE_API_KEY_ID) }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          # GH_TOKEN scopes the GitHub Releases upload done by
-          # electron-builder's `--publish always`.
+        run: yarn dist:mac --publish never -c.forceCodeSigning=true
+
+      # release-please-action creates the GitHub Release synchronously with
+      # the tag push, so electron-builder's `--publish always` raced it and
+      # got 422 already_exists. Upload directly to the existing release with
+      # the gh CLI — idempotent (`--clobber`) and free of that race.
+      - name: Upload DMG to GitHub Release
+        working-directory: desktop
+        env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: yarn dist:mac --publish always -c.forceCodeSigning=true
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG" \
+            dist/*.dmg \
+            dist/*.blockmap \
+            dist/latest-mac.yml \
+            --clobber
 
       - name: Upload DMG as workflow artifact
         if: always()


### PR DESCRIPTION
## Summary
- \`release-please-action\` creates the GitHub Release synchronously with the tag push.
- \`electron-builder --publish always\` then POSTs \`/releases\` and loses the race → \`422 already_exists\` (run 25020864572 on \`desktop-v0.2.2\`).
- Switch to \`--publish never\` for the build, then \`gh release upload \$TAG dist/*.{dmg,blockmap} dist/latest-mac.yml --clobber\` to the pre-existing release.

## Why this is the right fix
- \`gh release upload --clobber\` is idempotent — safe under reruns.
- No dependency on read-after-write timing.
- Keeps release-please's auto-generated changelog notes on the release.
- v0.2.1 only succeeded because its build was \*manually rerun\* 90 minutes after the release was created. Don't ship something that requires waiting an hour.

## Test plan
- [x] Reran failed v0.2.2 build manually (existing race-prone code) to unblock the current release. Once that finishes, this PR ensures the next desktop release doesn't repeat the same bug.
- [ ] Merge this PR.
- [ ] Future desktop release PR auto-merges → tag pushed → DMG built and uploaded without 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)