### PR TITLE
fix(gemini): don't false-poison idle resumed sessions

### DIFF
--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -54,12 +54,8 @@ export class GeminiAdapter implements ProviderAdapter {
   private userSpeaking = false
   private hasVideoInput = false
   private watchdogEnabled = false
-  // Post-resume liveness tracking. After a resumed setupComplete we wait for
-  // ASR-side activity (inputTranscription) before arming the generation
-  // watchdog. The poisoned signature is "ASR alive, generation dead", so
-  // arming on idle resume would false-positive on healthy quiet sessions
-  // where the user simply isn't speaking. Any generation-side event clears
-  // both flags.
+  // Watchdog arms only after the first post-resume ASR text; any generation
+  // event clears it.
   private postResumeTimer: ReturnType<typeof setTimeout> | null = null
   private awaitingResumeGeneration = false
   private awaitingResumeFirstInput = false
@@ -599,9 +595,6 @@ export class GeminiAdapter implements ProviderAdapter {
       // Every input-transcription delta refreshes our proxy for end-of-speech
       // — the LAST one before modelTurn is our best non-explicit signal.
       this.lastInputTranscriptionAtMs = Date.now()
-      // First post-resume ASR activity is our cue to start watching for
-      // the matching generation. Until ASR fires, an "idle" resumed session
-      // is healthy and must not be flagged as poisoned.
       if (this.awaitingResumeFirstInput) {
         this.awaitingResumeFirstInput = false
         this.armPostResumeWatchdog()

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -54,12 +54,15 @@ export class GeminiAdapter implements ProviderAdapter {
   private userSpeaking = false
   private hasVideoInput = false
   private watchdogEnabled = false
-  // Post-resume liveness tracking. When a resumed session completes setup we
-  // arm a timer; any generation-side activity disarms it. ASR-only activity
-  // (inputTranscription or empty serverContent) does not disarm — that's the
-  // exact failure signature we're trying to detect.
+  // Post-resume liveness tracking. After a resumed setupComplete we wait for
+  // ASR-side activity (inputTranscription) before arming the generation
+  // watchdog. The poisoned signature is "ASR alive, generation dead", so
+  // arming on idle resume would false-positive on healthy quiet sessions
+  // where the user simply isn't speaking. Any generation-side event clears
+  // both flags.
   private postResumeTimer: ReturnType<typeof setTimeout> | null = null
   private awaitingResumeGeneration = false
+  private awaitingResumeFirstInput = false
 
   // Session resumption state
   private resumptionHandle: string | null = null
@@ -68,6 +71,7 @@ export class GeminiAdapter implements ProviderAdapter {
   private isReconnecting = false
   private disconnected = false
   private wsUrlOverride: string | null = null // for tests to point at a mock server
+  private postResumeTimeoutMs: number = POST_RESUME_GENERATION_TIMEOUT_MS // overridable in tests
   // Resume context (summary + recent turns) baked into systemInstruction at setup.
   // Built once on initial connect; reconnects rely on Gemini's resumption handle.
   // We avoid the post-setup clientContent + historyConfig.initialHistoryInClientContent
@@ -284,7 +288,7 @@ export class GeminiAdapter implements ProviderAdapter {
         this.isReconnecting = false
         this.sendToClient?.({ type: "session.rotated", sessionId: `gemini-resumed-${Date.now()}` })
         log(`[gemini] Reconnected on attempt ${attempt}`)
-        if (resumingWithHandle) this.armPostResumeWatchdog()
+        if (resumingWithHandle) this.armPostResumeListener()
         return
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err)
@@ -595,6 +599,13 @@ export class GeminiAdapter implements ProviderAdapter {
       // Every input-transcription delta refreshes our proxy for end-of-speech
       // — the LAST one before modelTurn is our best non-explicit signal.
       this.lastInputTranscriptionAtMs = Date.now()
+      // First post-resume ASR activity is our cue to start watching for
+      // the matching generation. Until ASR fires, an "idle" resumed session
+      // is healthy and must not be flagged as poisoned.
+      if (this.awaitingResumeFirstInput) {
+        this.awaitingResumeFirstInput = false
+        this.armPostResumeWatchdog()
+      }
       if (!this.userSpeaking) {
         this.userSpeaking = true
         // Reset per-turn marks at the start of the user's turn. Done here
@@ -751,23 +762,29 @@ export class GeminiAdapter implements ProviderAdapter {
     for (const p of audio) this.upstream.send(p)
   }
 
-  private armPostResumeWatchdog() {
+  private armPostResumeListener() {
     this.clearPostResumeWatchdog()
+    this.awaitingResumeFirstInput = true
+  }
+
+  private armPostResumeWatchdog() {
+    if (this.postResumeTimer) clearTimeout(this.postResumeTimer)
     this.awaitingResumeGeneration = true
     this.postResumeTimer = setTimeout(() => {
       if (!this.awaitingResumeGeneration || this.disconnected) return
-      logError(`[gemini] Post-resume generation timeout (${POST_RESUME_GENERATION_TIMEOUT_MS}ms) — handle is poisoned, forcing fresh session`)
+      logError(`[gemini] Post-resume generation timeout (${this.postResumeTimeoutMs}ms) — handle is poisoned, forcing fresh session`)
       this.awaitingResumeGeneration = false
       this.postResumeTimer = null
       // Drop the poisoned handle so the next reconnect starts a fresh session.
       this.resumptionHandle = null
       this.currentlyResumable = false
       void this.reconnect("poisoned handle — fresh session", true)
-    }, POST_RESUME_GENERATION_TIMEOUT_MS)
+    }, this.postResumeTimeoutMs)
   }
 
   private clearPostResumeWatchdog() {
     this.awaitingResumeGeneration = false
+    this.awaitingResumeFirstInput = false
     if (this.postResumeTimer) {
       clearTimeout(this.postResumeTimer)
       this.postResumeTimer = null

--- a/relay-server/test/test-gemini-reconnect.ts
+++ b/relay-server/test/test-gemini-reconnect.ts
@@ -1091,21 +1091,15 @@ async function runIdleResumeNoFalsePoisonTest() {
     receivedSetups,
     onConnect: (ws, index) => {
       if (index === 0) {
-        // Original session: emit a handle, then a goAway. Conversation is idle —
-        // no inputTranscription, no modelTurn. Mirrors a session whose user
-        // finished talking minutes ago and is just sitting on the call.
         setTimeout(() => ws.send(JSON.stringify({
           sessionResumptionUpdate: { newHandle: "idle-handle", resumable: true },
         })), 20)
         setTimeout(() => ws.send(JSON.stringify({ goAway: { timeLeft: "2s" } })), 40)
         setTimeout(() => ws.close(1011, "rotating"), 80)
       } else if (index === 1) {
-        // Resumed session: emit a handle but stay quiet — no user input
-        // means no inputTranscription, no modelTurn. Healthy idle session.
         setTimeout(() => ws.send(JSON.stringify({
           sessionResumptionUpdate: { newHandle: "idle-handle-2", resumable: true },
         })), 20)
-        // Stay open. Adapter must NOT classify this as a poisoned handle.
       }
     },
   }, MOCK_PORT)
@@ -1124,15 +1118,10 @@ async function runIdleResumeNoFalsePoisonTest() {
   type AdapterInternals = { wsUrlOverride: string, postResumeTimeoutMs: number }
   const internals = adapter as unknown as AdapterInternals
   internals.wsUrlOverride = `ws://localhost:${MOCK_PORT}`
-  // Compress the post-resume window so the test runs quickly. The poisoned
-  // signature only matters when ASR-side activity arrived without generation;
-  // in this test no ASR activity arrives at all, so the watchdog must not fire
-  // regardless of timeout length.
   internals.postResumeTimeoutMs = 200
 
   await adapter.connect(config, (event) => clientEvents.push(event as RelayEvent))
 
-  // Wait through original goAway (~80ms) + reconnect + 4× postResumeTimeout window
   await new Promise((r) => setTimeout(r, 1500))
 
   console.log(`    Setups: ${receivedSetups.length}, events: ${clientEvents.map((e) => e.type).join(", ")}`)
@@ -1172,13 +1161,9 @@ async function runResumeWithUserSilentThenSpeakingTest() {
         setTimeout(() => ws.send(JSON.stringify({
           sessionResumptionUpdate: { newHandle: "h2", resumable: true },
         })), 20)
-        // Simulate the documented poisoned-handle signature: ASR comes back
-        // (inputTranscription deltas flow) but generation never fires.
         setTimeout(() => ws.send(JSON.stringify({
           serverContent: { inputTranscription: { text: "hello" } },
         })), 50)
-      } else {
-        // Third connection (post-poison fresh session): just stay open
       }
     },
   }, MOCK_PORT)

--- a/relay-server/test/test-gemini-reconnect.ts
+++ b/relay-server/test/test-gemini-reconnect.ts
@@ -1079,6 +1079,144 @@ async function runControlOverflowTest() {
 // Must mirror the adapter's MAX_PENDING_CONTROL constant
 const MAX_PENDING_CONTROL_FROM_ADAPTER = 20
 
+async function runIdleResumeNoFalsePoisonTest() {
+  console.log("\nGemini Idle Resume Test (idle session resume must not trigger poisoned-handle reconnect)")
+  console.log("=========================================================================================")
+
+  const MOCK_PORT = 19900
+  const clientEvents: RelayEvent[] = []
+  const receivedSetups: Record<string, unknown>[] = []
+
+  const wss = await startMockGemini({
+    receivedSetups,
+    onConnect: (ws, index) => {
+      if (index === 0) {
+        // Original session: emit a handle, then a goAway. Conversation is idle —
+        // no inputTranscription, no modelTurn. Mirrors a session whose user
+        // finished talking minutes ago and is just sitting on the call.
+        setTimeout(() => ws.send(JSON.stringify({
+          sessionResumptionUpdate: { newHandle: "idle-handle", resumable: true },
+        })), 20)
+        setTimeout(() => ws.send(JSON.stringify({ goAway: { timeLeft: "2s" } })), 40)
+        setTimeout(() => ws.close(1011, "rotating"), 80)
+      } else if (index === 1) {
+        // Resumed session: emit a handle but stay quiet — no user input
+        // means no inputTranscription, no modelTurn. Healthy idle session.
+        setTimeout(() => ws.send(JSON.stringify({
+          sessionResumptionUpdate: { newHandle: "idle-handle-2", resumable: true },
+        })), 20)
+        // Stay open. Adapter must NOT classify this as a poisoned handle.
+      }
+    },
+  }, MOCK_PORT)
+
+  const config: SessionConfigEvent = {
+    type: "session.config",
+    provider: "gemini",
+    model: "gemini-3.1-flash-live-preview",
+    voice: "Zephyr",
+    apiKey: "test",
+    brainAgent: "none",
+    deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
+  }
+
+  const adapter = new GeminiAdapter()
+  type AdapterInternals = { wsUrlOverride: string, postResumeTimeoutMs: number }
+  const internals = adapter as unknown as AdapterInternals
+  internals.wsUrlOverride = `ws://localhost:${MOCK_PORT}`
+  // Compress the post-resume window so the test runs quickly. The poisoned
+  // signature only matters when ASR-side activity arrived without generation;
+  // in this test no ASR activity arrives at all, so the watchdog must not fire
+  // regardless of timeout length.
+  internals.postResumeTimeoutMs = 200
+
+  await adapter.connect(config, (event) => clientEvents.push(event as RelayEvent))
+
+  // Wait through original goAway (~80ms) + reconnect + 4× postResumeTimeout window
+  await new Promise((r) => setTimeout(r, 1500))
+
+  console.log(`    Setups: ${receivedSetups.length}, events: ${clientEvents.map((e) => e.type).join(", ")}`)
+
+  assert(receivedSetups.length === 2,
+    `idle resume does not trigger poisoned-handle reconnect (got ${receivedSetups.length} setups)`)
+
+  const rotated = clientEvents.filter((e) => e.type === "session.rotated")
+  assert(rotated.length === 1,
+    `exactly one rotation for the goAway; no spurious second rotation (got ${rotated.length})`)
+
+  const errors = clientEvents.filter((e) => e.type === "error")
+  assert(errors.length === 0, `no errors emitted (got ${errors.length})`)
+
+  adapter.disconnect()
+  wss.close()
+}
+
+async function runResumeWithUserSilentThenSpeakingTest() {
+  console.log("\nGemini Resume Then User Speaks Test (poisoned-handle still detected when ASR fires but generation never does)")
+  console.log("===============================================================================================================")
+
+  const MOCK_PORT = 19901
+  const clientEvents: RelayEvent[] = []
+  const receivedSetups: Record<string, unknown>[] = []
+
+  const wss = await startMockGemini({
+    receivedSetups,
+    onConnect: (ws, index) => {
+      if (index === 0) {
+        setTimeout(() => ws.send(JSON.stringify({
+          sessionResumptionUpdate: { newHandle: "h1", resumable: true },
+        })), 20)
+        setTimeout(() => ws.send(JSON.stringify({ goAway: { timeLeft: "2s" } })), 40)
+        setTimeout(() => ws.close(1011, "rotating"), 80)
+      } else if (index === 1) {
+        setTimeout(() => ws.send(JSON.stringify({
+          sessionResumptionUpdate: { newHandle: "h2", resumable: true },
+        })), 20)
+        // Simulate the documented poisoned-handle signature: ASR comes back
+        // (inputTranscription deltas flow) but generation never fires.
+        setTimeout(() => ws.send(JSON.stringify({
+          serverContent: { inputTranscription: { text: "hello" } },
+        })), 50)
+      } else {
+        // Third connection (post-poison fresh session): just stay open
+      }
+    },
+  }, MOCK_PORT)
+
+  const config: SessionConfigEvent = {
+    type: "session.config",
+    provider: "gemini",
+    model: "gemini-3.1-flash-live-preview",
+    voice: "Zephyr",
+    apiKey: "test",
+    brainAgent: "none",
+    deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
+  }
+
+  const adapter = new GeminiAdapter()
+  type AdapterInternals = { wsUrlOverride: string, postResumeTimeoutMs: number }
+  const internals = adapter as unknown as AdapterInternals
+  internals.wsUrlOverride = `ws://localhost:${MOCK_PORT}`
+  internals.postResumeTimeoutMs = 200
+
+  await adapter.connect(config, (event) => clientEvents.push(event as RelayEvent))
+
+  await new Promise((r) => setTimeout(r, 1500))
+
+  console.log(`    Setups: ${receivedSetups.length}, events: ${clientEvents.map((e) => e.type).join(", ")}`)
+
+  // Initial + first resume + poisoned-handle fresh reconnect = 3 setups
+  assert(receivedSetups.length === 3,
+    `poisoned handle (ASR alive, generation dead) triggers fresh reconnect (got ${receivedSetups.length})`)
+
+  const thirdSetup = receivedSetups[2] as { sessionResumption?: { handle?: string } }
+  assert(thirdSetup.sessionResumption?.handle === undefined,
+    `third setup is fresh (no handle) (got ${thirdSetup.sessionResumption?.handle})`)
+
+  adapter.disconnect()
+  wss.close()
+}
+
 async function main() {
   await runReconnectTest()
   await runUnrecoverableCloseTest()
@@ -1094,6 +1232,8 @@ async function main() {
   await runResumedGoAwayBeforeFreshHandleTest()
   await runQueueAcrossRetryTest()
   await runControlOverflowTest()
+  await runIdleResumeNoFalsePoisonTest()
+  await runResumeWithUserSilentThenSpeakingTest()
   console.log(`\nResults: ${passed} passed, ${failed} failed`)
   process.exit(failed > 0 ? 1 : 0)
 }


### PR DESCRIPTION
## Summary
- Every goAway-driven Gemini reconnect over the last 24h hit the post-resume watchdog at exactly 8s and dropped the resumption handle, even though the resumed session was healthy. Cause: the watchdog arms on every successful resume and fires if no model activity arrives within 8s — but in an **idle** session (model finished, user reading or away) there is nothing to generate, so the timer always wins.
- Make the watchdog two-stage. After a resumed setupComplete we arm a *listener*; the 8s timer only arms once we observe post-resume `inputTranscription`. That matches the documented poisoned signature ("ASR alive, generation dead") instead of tripping on every quiet rotation.
- The legitimate poisoned-handle path still recovers via fresh reconnect — covered by a new regression test.

## Root cause
Commit `4be523f` ("detect poisoned resumption handle and force fresh Gemini session") fixed a real bug: sometimes after a resume Gemini's ASR keeps transcribing but the generation pipeline never produces any output. The detection it shipped — "no `modelTurn`/`outputTranscription`/`turnComplete`/`generationComplete` for 8s after resume" — also matches a healthy idle conversation, where the model has nothing to say and the user is silent.

Relay logs from this morning show every single goAway → resume in the last day producing the false-positive: ~1–3 minutes of post-`turnComplete` silence, then `goAway`, then resume succeeds, then exactly 8s later `Post-resume generation timeout (8000ms) — handle is poisoned, forcing fresh session`. Each false positive drops the resumption handle and forces a `session.rotating`/`session.rotated` round-trip the user doesn't need.

## Fix
Two-stage watchdog gated on the documented poisoned signature:
1. On successful handle-based resume → `armPostResumeListener()` sets `awaitingResumeFirstInput = true`.
2. On the first post-resume `inputTranscription` → `armPostResumeWatchdog()` starts the 8s timer.
3. Any `modelTurn` / `outputTranscription` / `turnComplete` / `generationComplete` clears both flags.

Idle resumed sessions never arm the timer; the original "ASR fires but generation never does" case still triggers a fresh reconnect.

## Test plan
- [x] New regression test `runIdleResumeNoFalsePoisonTest`: idle resumed session stays quiet, asserts only 2 setups received (no spurious third) and exactly one `session.rotated` event.
- [x] New regression test `runResumeWithUserSilentThenSpeakingTest`: resumed session emits `inputTranscription` but no `modelTurn`, asserts the watchdog still fires and a third (fresh, no-handle) setup happens.
- [x] All 56 pre-existing gemini reconnect tests still pass (`test/test-gemini-reconnect.ts`).
- [x] `test/test-gemini-unit.ts`, `test/test-gemini-history-inject.ts`, `test/test-latency-metrics.ts` all green.
- [x] `tsc --noEmit` clean.
- [ ] Manual: restart relay; trigger a long idle conversation across a Gemini `goAway` and confirm no `Post-resume generation timeout` line appears in `logs/relay.log` once the resume completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)