### PR TITLE
fix(instructions): forbid past-tense claims before brain action confirms

### DIFF
--- a/relay-server/src/instructions.ts
+++ b/relay-server/src/instructions.ts
@@ -56,6 +56,19 @@ When in doubt, ask your brain. You are a voice interface to a powerful agent —
 
 **NEVER say "I can't do that" or "I don't have access to that" before checking with your brain.** You don't know your own capabilities — your brain does. Always try first. Say "Let me see what I can do..." and ask your brain. Only after the brain confirms something is impossible should you tell the user.
 
+## MANDATORY: Wait for action confirmations
+
+Some brain calls *answer* (look up info, check calendar). Others *act* (open a link, send a message, create an event). Action calls take 5–20 seconds and run in the background — you do NOT see the result instantly.
+
+**Never claim an action is done before the brain confirms.** This is the difference between "Opened" and "On it":
+
+- **While the action is running**, say something neutral that does NOT imply completion: "On it...", "Sending that now...", "Pulling it up...". Past-tense claims ("Opened", "Sent", "Done", "Booked") are forbidden until you actually see a confirmation.
+- **A confirmation is a Brain agent result message in your context** containing words like "Opened", "Sent", "Done", a link, an event ID, or other proof of completion. Until that lands, the action is still pending.
+- **If you don't see a confirmation within ~25 seconds**, ask the brain "did that go through?" rather than guessing.
+- **If the user asks "is it done?" before the confirmation arrives**, say "still pulling it up — give me a sec" rather than fabricating completion.
+
+This rule applies to ALL action verbs: open, send, create, book, schedule, message, delete, update, post, share, save. If the user asked you to *do* something, treat the response as pending until proven otherwise.
+
 ## MANDATORY: Memory and History Queries
 
 **This is a hard rule with zero exceptions.** You do NOT have memory of past conversations. You do NOT know what happened earlier, yesterday, last week, or in any prior session. Your conversation context only contains the current session.

--- a/relay-server/src/instructions.ts
+++ b/relay-server/src/instructions.ts
@@ -58,11 +58,11 @@ When in doubt, ask your brain. You are a voice interface to a powerful agent —
 
 ## MANDATORY: Wait for action confirmations
 
-Some brain calls *answer* (look up info, check calendar). Others *act* (open a link, send a message, create an event). Action calls take 5–20 seconds and run in the background — you do NOT see the result instantly.
+**Every ask_brain call is asynchronous and takes 5–20 seconds.** When you call ask_brain you immediately receive a placeholder ("Looking into it now…") — that is NOT the answer. The real result arrives later as a separate Brain agent result message in your context. Do not confuse the placeholder for the result.
 
-**Never claim an action is done before the brain confirms.** This is the difference between "Opened" and "On it":
+Whether the call is a question (look up info, check calendar) or an action (open a link, send a message, create an event), the same wait applies. For actions specifically, **never claim it's done before you see the confirmation**:
 
-- **While the action is running**, say something neutral that does NOT imply completion: "On it...", "Sending that now...", "Pulling it up...". Past-tense claims ("Opened", "Sent", "Done", "Booked") are forbidden until you actually see a confirmation.
+- **While the call is in flight**, say something neutral that does NOT imply completion: "On it...", "Sending that now...", "Pulling it up...". Past-tense claims ("Opened", "Sent", "Done", "Booked") are forbidden until you actually see a confirmation.
 - **A confirmation is a Brain agent result message in your context** containing words like "Opened", "Sent", "Done", a link, an event ID, or other proof of completion. Until that lands, the action is still pending.
 - **If you don't see a confirmation within ~25 seconds**, ask the brain "did that go through?" rather than guessing.
 - **If the user asks "is it done?" before the confirmation arrives**, say "still pulling it up — give me a sec" rather than fabricating completion.

--- a/relay-server/src/instructions.ts
+++ b/relay-server/src/instructions.ts
@@ -84,6 +84,8 @@ When the user asks ANYTHING about:
 You MUST call ask_brain FIRST. Say "Let me check on that..." and call the tool. Do NOT answer from your own knowledge or make anything up. Do NOT synthesize a plausible answer. Do NOT guess. If you answer a memory question without calling ask_brain, you WILL fabricate false information and destroy the user's trust.
 
 This applies even if you think you know the answer from the current conversation. Your brain has the complete history — you do not.
+
+**While ask_brain is still running** (5–20 seconds), do NOT start composing the answer in any form — no "Today we talked about…", no "I think we covered…", no warm-up sentence that begins answering. Two reasons: (1) you don't have the answer yet, and (2) anything you say in that gap is invention. Acceptable: short verbal bridges ("let me check…", "pulling it up…", "one sec…", brief silence). Unacceptable: any sentence whose meaning depends on the answer you don't yet have. Wait until the Brain agent result message lands in your context, then speak from it.
 `.trim()
 
 export function buildInstructions(config: SessionConfigEvent): string {


### PR DESCRIPTION
## Summary
- Voice Kira fires \`ask_brain\` calls **fire-and-forget** (no sync \`toolResponse\` round-trip), so she starts speaking 1–2 s into a 5–20 s action and routinely says past-tense "Opened it" / "Sent it" before the brain has actually finished. Today's "Open the Google Maps link" call took 19 s with codex; Kira had moved on to a different tool by the time the confirmation landed.
- Add an explicit rule to \`BRAIN_CAPABILITIES\` in \`relay-server/src/instructions.ts\`: progress-tense only ("On it…", "Sending that now…") until a Brain agent result with a real confirmation token (link, ID, "Opened"/"Sent"/"Done") shows up in context. After ~25 s with no confirmation, ask the brain "did that go through?" instead of guessing.
- Cheap "fix path A" (per the design conversation) — no architecture change, no dead air, just stops the lying. The structural option (split \`ask_brain\` into query vs action tools with synchronous \`toolResponse\` for actions) is left for a follow-up.

## Evidence from today's relay log

```
15:46:13.561  Tool call: ask_brain ("Open the Google Maps link...")
15:46:14.942  ←  Gemini starts speaking (1.4 s after request)
15:46:17.575  Gemini's spoken turn ends ("Opened it for you" or similar)
15:46:22.847  turnComplete
15:46:26–29   User responds (presumably reacting / asking again)
15:46:29.263  Gemini fires a SECOND tool call: web_search "Fiction Coffee hours"
15:46:32.805  ← Brain finally returns "Opened." (19.2 s after the request)
15:46:32.805  Relay injects "Opened." into the session
```

By the time the actual confirmation lands, Kira's "Opened" claim is 18 seconds stale and the conversation has moved on twice.

## Why a prompt-only fix works
The async wire path is the same: relay still calls \`adapter.injectContext()\` with the brain result whenever it arrives. The model has always seen these results. What's missing is the rule "do not assert completion before that injection happens." This PR adds exactly that rule, plus an explicit 25 s self-check.

## Test plan
- [x] \`yarn tsc --noEmit\` clean.
- [x] \`yarn tsx test/test-gemini-reconnect.ts\` — 58 / 58 passing (no behavioral change to the reconnect path).
- [ ] Manual: restart relay, ask Kira to "open the Google Maps link for X", confirm her spoken response uses "On it…" / "Pulling it up…" rather than "Opened" until the actual brain confirmation lands.
- [ ] Manual: ask Kira to send a message; check she doesn't claim "Sent" before the brain confirms.

## Out of scope
- Splitting \`ask_brain\` into separate query / action tools (fix path B). That's a meatier change involving relay tool registry + openclaw cooperation; this PR removes the most painful symptom first.
- Reducing brain latency (codex is ~2.4 × slower than the prior haiku setup; if 19 s windows persist we should profile the brain side separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)