### PR TITLE
feat(tracing): stamp service.version + git sha on every span

### DIFF
--- a/relay-server/package.json
+++ b/relay-server/package.json
@@ -16,6 +16,7 @@
     "@langfuse/tracing": "^5.2.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
+    "@opentelemetry/resources": "^2.7.0",
     "@opentelemetry/sdk-node": "^0.215.0",
     "@opentelemetry/sdk-trace-base": "^2.7.0",
     "dotenv": "^17.4.2",

--- a/relay-server/src/tracing/langfuse.ts
+++ b/relay-server/src/tracing/langfuse.ts
@@ -27,8 +27,18 @@
 import { NodeSDK } from "@opentelemetry/sdk-node"
 import { LangfuseSpanProcessor } from "@langfuse/otel"
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http"
+import { resourceFromAttributes } from "@opentelemetry/resources"
 import { BatchSpanProcessor, type SpanProcessor } from "@opentelemetry/sdk-trace-base"
+import { execSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 import { log, error as logError } from "../log.js"
+
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url))
+const SERVICE_VERSION = readServiceVersion()
+const GIT_SHA = readGitShaSync()
+const GIT_BRANCH = readGitBranchSync()
 
 let sdk: NodeSDK | null = null
 let enabled = false
@@ -42,9 +52,7 @@ export function initLangfuse() {
 
   try {
     sdk = new NodeSDK({
-      // Named so Langfuse / any OTel consumer can distinguish relay-emitted
-      // spans from openclaw-emitted spans in the same unified trace.
-      serviceName: process.env.OTEL_SERVICE_NAME ?? "voiceclaw-relay",
+      resource: buildResource(),
       spanProcessors: processors,
     })
     sdk.start()
@@ -70,6 +78,17 @@ export async function shutdownLangfuse() {
   } catch (err) {
     logError(`[tracing] shutdown error: ${(err as Error).message}`)
   }
+}
+
+function buildResource() {
+  const attrs: Record<string, string> = {
+    "service.name": process.env.OTEL_SERVICE_NAME ?? "voiceclaw-relay",
+    "deployment.environment": process.env.NODE_ENV ?? "development",
+  }
+  if (SERVICE_VERSION) attrs["service.version"] = SERVICE_VERSION
+  if (GIT_SHA) attrs["vcs.git.sha"] = GIT_SHA
+  if (GIT_BRANCH) attrs["vcs.git.branch"] = GIT_BRANCH
+  return resourceFromAttributes(attrs)
 }
 
 function buildSpanProcessors(): SpanProcessor[] {
@@ -102,5 +121,33 @@ function tryBuildCollectorProcessor(): SpanProcessor | null {
   } catch (err) {
     logError(`[tracing] failed to init collector exporter at ${url}: ${(err as Error).message}`)
     return null
+  }
+}
+
+function readServiceVersion(): string {
+  const fromEnv = process.env.RELAY_VERSION?.trim()
+  if (fromEnv) return fromEnv
+  try {
+    const pkgPath = resolve(MODULE_DIR, "..", "..", "package.json")
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: string }
+    return pkg.version ?? ""
+  } catch {
+    return ""
+  }
+}
+
+function readGitShaSync(): string {
+  try {
+    return execSync("git rev-parse HEAD", { cwd: MODULE_DIR, stdio: ["ignore", "pipe", "ignore"] }).toString().trim()
+  } catch {
+    return process.env.GIT_SHA?.trim() ?? ""
+  }
+}
+
+function readGitBranchSync(): string {
+  try {
+    return execSync("git rev-parse --abbrev-ref HEAD", { cwd: MODULE_DIR, stdio: ["ignore", "pipe", "ignore"] }).toString().trim()
+  } catch {
+    return process.env.GIT_BRANCH?.trim() ?? ""
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3965,7 +3965,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/resources@npm:2.7.0, @opentelemetry/resources@npm:^2.2.0":
+"@opentelemetry/resources@npm:2.7.0, @opentelemetry/resources@npm:^2.2.0, @opentelemetry/resources@npm:^2.7.0":
   version: 2.7.0
   resolution: "@opentelemetry/resources@npm:2.7.0"
   dependencies:
@@ -19056,6 +19056,7 @@ __metadata:
     "@langfuse/tracing": "npm:^5.2.0"
     "@opentelemetry/api": "npm:^1.9.1"
     "@opentelemetry/exporter-trace-otlp-http": "npm:^0.215.0"
+    "@opentelemetry/resources": "npm:^2.7.0"
     "@opentelemetry/sdk-node": "npm:^0.215.0"
     "@opentelemetry/sdk-trace-base": "npm:^2.7.0"
     "@types/express": "npm:^5.0.2"


### PR DESCRIPTION
## Why

When debugging the relay live (e.g. the question we hit today: \"did my new code actually load, or am I looking at a span from the previous build?\") there's currently no reliable way to attribute a trace to a specific build. We have no version, no commit sha, nothing on the spans themselves.

This adds standard OpenTelemetry resource attributes so every span the relay emits carries the build identity that produced it.

## What

Switch `NodeSDK` init from `serviceName: ...` to `resource: resourceFromAttributes({...})` and stamp:

- `service.name` — same env-var fallback as before (`OTEL_SERVICE_NAME` or `voiceclaw-relay`)
- `service.version` — read from `relay-server/package.json` at module init (override via `RELAY_VERSION` env)
- `vcs.git.sha` — `git rev-parse HEAD` at module init (override via `GIT_SHA` env; omitted entirely if both fail)
- `vcs.git.branch` — `git rev-parse --abbrev-ref HEAD` (override via `GIT_BRANCH` env; omitted if both fail)
- `deployment.environment` — `NODE_ENV` (or `\"development\"`)

Resource attributes auto-flow through OpenTelemetry to every span on every processor we configure, so both backends pick them up with zero per-call wiring:

- **Langfuse** — surfaces these in trace metadata.
- **In-house collector** (`~/.voiceclaw/tracing.db`) — lands in `observations.attributes_json`, queryable from the tracing UI.

Git/version reads are cached at module load (one syscall per process), wrapped in try/catch, and empty values are skipped so we don't pollute traces with empty strings when running outside a git working tree (e.g. an installed npm package).

Added `@opentelemetry/resources` as an explicit dep — it was already pulled in transitively by `@opentelemetry/sdk-node`, but importing from a transitive dep is fragile, so it's now declared at the top level.

## Test plan

- [x] `yarn tsc --noEmit` clean
- [x] `npx tsx test/test-usage-otel-attrs.ts` passes
- [x] Boot relay locally with `RELAY_VERSION=test-version PORT=18080 yarn dev` — `[tracing] enabled (langfuse+collector)` log fires; clean shutdown
- [ ] After merge: tail one trace in Langfuse and one row in the local SQLite collector and confirm `service.version` + `vcs.git.sha` are present on the resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)