### PR TITLE
fix(relay): await in-flight transcript syncs on graceful shutdown

### DIFF
--- a/relay-server/src/index.ts
+++ b/relay-server/src/index.ts
@@ -41,12 +41,23 @@ wss.on("connection", (ws) => {
   new RelaySession(ws)
 })
 
+// Guards SIGTERM/SIGINT idempotency at the OS-signal layer; the drain-loop
+// flag in shutdown.ts guards gracefulShutdown itself.
 let shuttingDown = false
 
 async function shutdown() {
   if (shuttingDown) return
   shuttingDown = true
   log("Shutting down...")
+
+  // If server.close() hangs on a stuck keep-alive socket, the awaits below
+  // never complete and gracefulShutdown is never reached. Backstop with a
+  // hard-kill timer so the process always exits.
+  const hardKill = setTimeout(() => {
+    warn("[shutdown] hard-kill timeout reached, forcing exit")
+    process.exit(1)
+  }, SHUTDOWN_TIMEOUT_MS + 5_000)
+  hardKill.unref()
 
   // Close client sockets first so each RelaySession runs its cleanup()
   // (endSession → adapter disconnect → transcript sync) before we tear
@@ -55,6 +66,9 @@ async function shutdown() {
   wss.close()
   await new Promise<void>((resolve) => server.close(() => resolve()))
 
+  // Order: gracefulShutdown drains background tasks (which finish their bg.end()
+  // calls) BEFORE shutdownLangfuse flushes the SDK — otherwise span ends race
+  // the export pipeline and the last few ops disappear.
   await gracefulShutdown(SHUTDOWN_TIMEOUT_MS)
 
   // Drain pending spans before exiting — otherwise the last turn of every

--- a/relay-server/src/index.ts
+++ b/relay-server/src/index.ts
@@ -11,6 +11,9 @@ import { WebSocketServer } from "ws"
 import { RelaySession } from "./session.js"
 import { getTestPageHTML } from "./test-page.js"
 import { log, warn } from "./log.js"
+import { gracefulShutdown } from "./shutdown.js"
+
+const SHUTDOWN_TIMEOUT_MS = 10_000
 
 const PORT = parseInt(process.env.PORT ?? "8080", 10)
 
@@ -38,11 +41,12 @@ wss.on("connection", (ws) => {
   new RelaySession(ws)
 })
 
+let shuttingDown = false
+
 async function shutdown() {
+  if (shuttingDown) return
+  shuttingDown = true
   log("Shutting down...")
-  // Force exit if graceful shutdown hangs
-  const forceExit = setTimeout(() => process.exit(1), 3000)
-  forceExit.unref()
 
   // Close client sockets first so each RelaySession runs its cleanup()
   // (endSession → adapter disconnect → transcript sync) before we tear
@@ -50,6 +54,9 @@ async function shutdown() {
   wss.clients.forEach((ws) => ws.close())
   wss.close()
   await new Promise<void>((resolve) => server.close(() => resolve()))
+
+  await gracefulShutdown(SHUTDOWN_TIMEOUT_MS)
+
   // Drain pending spans before exiting — otherwise the last turn of every
   // active session gets dropped on SIGTERM.
   await shutdownLangfuse()

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -38,10 +38,12 @@ export class RelaySession {
   constructor(ws: WebSocket) {
     this.ws = ws
     this.ws.on("message", (raw) => this.handleMessage(raw))
-    this.ws.on("close", () => this.cleanup())
+    this.ws.on("close", () => {
+      trackBackgroundTask(this.cleanup(), `session-cleanup:${this.id}`)
+    })
     this.ws.on("error", (err) => {
       logError(`[session:${this.id}] WebSocket error:`, err.message)
-      this.cleanup()
+      trackBackgroundTask(this.cleanup(), `session-cleanup:${this.id}`)
     })
     log(`[session:${this.id}] Client connected`)
   }
@@ -81,7 +83,10 @@ export class RelaySession {
         // finalize (which races against the next turn starting) can target
         // the correct voice-turn span via attachMediaAttrs(attrs, turnId).
         const endingTurnId = this.tracer.getActiveTurnId()
-        void this.finalizeMediaTurn(endingTurnId)
+        trackBackgroundTask(
+          this.finalizeMediaTurn(endingTurnId),
+          `media-finalize:${this.id}:${endingTurnId ?? "unknown"}`,
+        )
         this.tracer.endTurn()
         break
       }

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -17,6 +17,7 @@ import { buildInstructions } from "./instructions.js"
 import { log, error as logError } from "./log.js"
 import { TurnTracer } from "./tracing/turn-tracer.js"
 import { MediaCapture } from "./media/capture.js"
+import { trackBackgroundTask } from "./shutdown.js"
 const SERVER_SIDE_TOOLS = new Set(["echo_tool", "ask_brain", "web_search"])
 
 export class RelaySession {
@@ -569,13 +570,12 @@ export class RelaySession {
       input: prompt,
     })
 
-    // Fire-and-forget with bounded retries — gateway may be busy with the
-    // tail of an ask_brain call that hadn't finished when the session ended.
-    void context.with(bg.ctx, () =>
+    const syncPromise = context.with(bg.ctx, () =>
       retryTranscriptSync({ prompt, gatewayUrl, authToken, sessionKey, sessionId })
         .then((result) => bg.end({ output: result }))
         .catch((err) => bg.end({ error: err instanceof Error ? err.message : String(err) })),
     )
+    trackBackgroundTask(syncPromise, `transcript-sync:${sessionId}`)
   }
 }
 

--- a/relay-server/src/shutdown.ts
+++ b/relay-server/src/shutdown.ts
@@ -1,0 +1,54 @@
+import { log, warn } from "./log.js"
+
+interface TrackedTask {
+  promise: Promise<unknown>
+  label: string
+}
+
+const tasks = new Set<TrackedTask>()
+let shuttingDown = false
+
+export function trackBackgroundTask(promise: Promise<unknown>, label: string): void {
+  const entry: TrackedTask = { promise, label }
+  tasks.add(entry)
+  promise.finally(() => {
+    tasks.delete(entry)
+  })
+}
+
+export function inFlightTaskCount(): number {
+  return tasks.size
+}
+
+export async function gracefulShutdown(timeoutMs: number): Promise<void> {
+  if (shuttingDown) return
+  shuttingDown = true
+
+  const pending = Array.from(tasks)
+  if (pending.length === 0) return
+
+  log(`[shutdown] awaiting ${pending.length} in-flight background task(s) (cap ${timeoutMs}ms)`)
+
+  let timer: NodeJS.Timeout | undefined
+  const timeout = new Promise<"timeout">((resolve) => {
+    timer = setTimeout(() => resolve("timeout"), timeoutMs)
+    timer.unref()
+  })
+
+  const settled = Promise.allSettled(pending.map((t) => t.promise)).then(() => "done" as const)
+
+  const outcome = await Promise.race([settled, timeout])
+  if (timer) clearTimeout(timer)
+
+  if (outcome === "timeout") {
+    const unfinished = pending.filter((t) => tasks.has(t)).map((t) => t.label)
+    warn(`[shutdown] timed out after ${timeoutMs}ms with ${unfinished.length} unfinished task(s): ${unfinished.join(", ")}`)
+  } else {
+    log("[shutdown] all background tasks settled")
+  }
+}
+
+export function __resetShutdownStateForTests(): void {
+  tasks.clear()
+  shuttingDown = false
+}

--- a/relay-server/src/shutdown.ts
+++ b/relay-server/src/shutdown.ts
@@ -1,3 +1,7 @@
+// Tracks background tasks (transcript syncs, media finalize) so gracefulShutdown
+// can await them before exit. Caller is responsible for handling promise
+// rejections; trackBackgroundTask only observes resolution to remove from set.
+
 import { log, warn } from "./log.js"
 
 interface TrackedTask {
@@ -6,12 +10,16 @@ interface TrackedTask {
 }
 
 const tasks = new Set<TrackedTask>()
+// Guards gracefulShutdown's drain loop against concurrent invocation. The
+// SIGTERM/SIGINT-layer flag in index.ts is a separate concern.
 let shuttingDown = false
 
 export function trackBackgroundTask(promise: Promise<unknown>, label: string): void {
   const entry: TrackedTask = { promise, label }
   tasks.add(entry)
-  promise.finally(() => {
+  // Neutralize rejections at the tracking boundary so callers that forget to
+  // attach a .catch() don't trigger an unhandledRejection via .finally's rethrow.
+  promise.then(noop, noop).finally(() => {
     tasks.delete(entry)
   })
 }
@@ -24,27 +32,38 @@ export async function gracefulShutdown(timeoutMs: number): Promise<void> {
   if (shuttingDown) return
   shuttingDown = true
 
-  const pending = Array.from(tasks)
-  if (pending.length === 0) return
+  const deadline = Date.now() + timeoutMs
 
-  log(`[shutdown] awaiting ${pending.length} in-flight background task(s) (cap ${timeoutMs}ms)`)
+  if (tasks.size === 0) {
+    log("[shutdown] no in-flight background tasks")
+    return
+  }
 
-  let timer: NodeJS.Timeout | undefined
-  const timeout = new Promise<"timeout">((resolve) => {
-    timer = setTimeout(() => resolve("timeout"), timeoutMs)
-    timer.unref()
-  })
+  log(`[shutdown] awaiting ${tasks.size} in-flight background task(s) (cap ${timeoutMs}ms)`)
 
-  const settled = Promise.allSettled(pending.map((t) => t.promise)).then(() => "done" as const)
+  while (tasks.size > 0) {
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) break
 
-  const outcome = await Promise.race([settled, timeout])
-  if (timer) clearTimeout(timer)
+    const snapshot = Array.from(tasks).map((t) => t.promise)
+    await Promise.race([
+      Promise.allSettled(snapshot),
+      new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, remaining)
+        timer.unref()
+      }),
+    ])
+    // Yield so the .finally(deletion) microtasks chained in trackBackgroundTask
+    // fire before we re-check tasks.size — otherwise the loop can iterate one
+    // extra time on entries whose promises have already settled.
+    await Promise.resolve()
+  }
 
-  if (outcome === "timeout") {
-    const unfinished = pending.filter((t) => tasks.has(t)).map((t) => t.label)
-    warn(`[shutdown] timed out after ${timeoutMs}ms with ${unfinished.length} unfinished task(s): ${unfinished.join(", ")}`)
-  } else {
+  if (tasks.size === 0) {
     log("[shutdown] all background tasks settled")
+  } else {
+    const unfinished = Array.from(tasks).map((t) => t.label)
+    warn(`[shutdown] timed out after ${timeoutMs}ms with ${unfinished.length} unfinished task(s): ${unfinished.join(", ")}`)
   }
 }
 
@@ -52,3 +71,5 @@ export function __resetShutdownStateForTests(): void {
   tasks.clear()
   shuttingDown = false
 }
+
+function noop(): void {}

--- a/relay-server/test/shutdown.test.ts
+++ b/relay-server/test/shutdown.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from "vitest"
+import {
+  __resetShutdownStateForTests,
+  gracefulShutdown,
+  inFlightTaskCount,
+  trackBackgroundTask,
+} from "../src/shutdown.js"
+
+describe("gracefulShutdown", () => {
+  afterEach(() => {
+    __resetShutdownStateForTests()
+  })
+
+  it("awaits in-flight tasks and resolves shortly after they settle", async () => {
+    let resolved = false
+    const task = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        resolved = true
+        resolve()
+      }, 200)
+    })
+    trackBackgroundTask(task, "test-task")
+
+    const start = Date.now()
+    await gracefulShutdown(1000)
+    const elapsed = Date.now() - start
+
+    expect(resolved).toBe(true)
+    expect(elapsed).toBeGreaterThanOrEqual(150)
+    expect(elapsed).toBeLessThan(500)
+    expect(inFlightTaskCount()).toBe(0)
+  })
+
+  it("returns within the cap when a task never resolves", async () => {
+    const stuck = new Promise<void>(() => {})
+    trackBackgroundTask(stuck, "stuck-task")
+
+    const start = Date.now()
+    await gracefulShutdown(100)
+    const elapsed = Date.now() - start
+
+    expect(elapsed).toBeGreaterThanOrEqual(80)
+    expect(elapsed).toBeLessThan(250)
+  })
+
+  it("is idempotent — second call is a no-op", async () => {
+    let resolved = false
+    const task = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        resolved = true
+        resolve()
+      }, 100)
+    })
+    trackBackgroundTask(task, "idempotent-task")
+
+    await gracefulShutdown(500)
+    expect(resolved).toBe(true)
+
+    let secondTaskRan = false
+    const second = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        secondTaskRan = true
+        resolve()
+      }, 200)
+    })
+    trackBackgroundTask(second, "second-task")
+
+    const start = Date.now()
+    await gracefulShutdown(500)
+    const elapsed = Date.now() - start
+
+    expect(elapsed).toBeLessThan(50)
+    expect(secondTaskRan).toBe(false)
+
+    await second
+  })
+})

--- a/relay-server/test/shutdown.test.ts
+++ b/relay-server/test/shutdown.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
   __resetShutdownStateForTests,
   gracefulShutdown,
@@ -7,11 +7,18 @@ import {
 } from "../src/shutdown.js"
 
 describe("gracefulShutdown", () => {
-  afterEach(() => {
-    __resetShutdownStateForTests()
+  beforeEach(() => {
+    vi.useFakeTimers()
   })
 
-  it("awaits in-flight tasks and resolves shortly after they settle", async () => {
+  afterEach(() => {
+    __resetShutdownStateForTests()
+    vi.useRealTimers()
+  })
+
+  it("awaits in-flight tasks and resolves once they settle", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+
     let resolved = false
     const task = new Promise<void>((resolve) => {
       setTimeout(() => {
@@ -21,26 +28,30 @@ describe("gracefulShutdown", () => {
     })
     trackBackgroundTask(task, "test-task")
 
-    const start = Date.now()
-    await gracefulShutdown(1000)
-    const elapsed = Date.now() - start
+    const shutdownPromise = gracefulShutdown(1000)
+    await vi.advanceTimersByTimeAsync(200)
+    await shutdownPromise
 
     expect(resolved).toBe(true)
-    expect(elapsed).toBeGreaterThanOrEqual(150)
-    expect(elapsed).toBeLessThan(500)
     expect(inFlightTaskCount()).toBe(0)
+
+    const settledMessage = logSpy.mock.calls.some((call) =>
+      call.some((arg) => typeof arg === "string" && arg.includes("all background tasks settled")),
+    )
+    expect(settledMessage).toBe(true)
+
+    logSpy.mockRestore()
   })
 
   it("returns within the cap when a task never resolves", async () => {
     const stuck = new Promise<void>(() => {})
     trackBackgroundTask(stuck, "stuck-task")
 
-    const start = Date.now()
-    await gracefulShutdown(100)
-    const elapsed = Date.now() - start
+    const shutdownPromise = gracefulShutdown(100)
+    await vi.advanceTimersByTimeAsync(100)
+    await shutdownPromise
 
-    expect(elapsed).toBeGreaterThanOrEqual(80)
-    expect(elapsed).toBeLessThan(250)
+    expect(inFlightTaskCount()).toBe(1)
   })
 
   it("is idempotent — second call is a no-op", async () => {
@@ -53,7 +64,9 @@ describe("gracefulShutdown", () => {
     })
     trackBackgroundTask(task, "idempotent-task")
 
-    await gracefulShutdown(500)
+    const first = gracefulShutdown(500)
+    await vi.advanceTimersByTimeAsync(100)
+    await first
     expect(resolved).toBe(true)
 
     let secondTaskRan = false
@@ -65,13 +78,44 @@ describe("gracefulShutdown", () => {
     })
     trackBackgroundTask(second, "second-task")
 
-    const start = Date.now()
     await gracefulShutdown(500)
-    const elapsed = Date.now() - start
-
-    expect(elapsed).toBeLessThan(50)
     expect(secondTaskRan).toBe(false)
 
+    await vi.advanceTimersByTimeAsync(200)
     await second
+  })
+
+  it("awaits tasks that get added during the drain", async () => {
+    let earlyResolved = false
+    let lateResolved = false
+
+    const early = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        earlyResolved = true
+        resolve()
+      }, 100)
+    })
+    trackBackgroundTask(early, "early-task")
+
+    const shutdownPromise = gracefulShutdown(1000)
+
+    // Yield so gracefulShutdown enters its drain loop and snapshots the first
+    // pending task before we add the late one.
+    await Promise.resolve()
+
+    const late = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        lateResolved = true
+        resolve()
+      }, 300)
+    })
+    trackBackgroundTask(late, "late-task")
+
+    await vi.advanceTimersByTimeAsync(300)
+    await shutdownPromise
+
+    expect(earlyResolved).toBe(true)
+    expect(lateResolved).toBe(true)
+    expect(inFlightTaskCount()).toBe(0)
   })
 })


### PR DESCRIPTION
## The bug

On 2026-04-28, a 30+ minute SF-trip session was force-killed when the relay was restarted at 15:13. The session's `Disconnecting` log line never fired and `Syncing transcript to brain (N turns, Mmin)` never ran. ~30 minutes of brain queries about the SF trip vanished from the brain's memory because the transcript was never synced.

Root cause: `relay-server/src/session.ts::syncTranscriptToBrain()` is fire-and-forget. The session's WebSocket `close` handler triggers it via `void context.with(bg.ctx, () => retryTranscriptSync(...))` and returns immediately. The shutdown handler in `index.ts` closed the websocket and called `shutdownLangfuse()`, but never awaited the pending HTTP request to the brain gateway. A 3-second `forceExit` then killed the request mid-flight. SIGTERM (e.g. `kill <pid>` from `tsx watch`) and SIGINT both hit this path.

## The fix

New module `relay-server/src/shutdown.ts`:

- `trackBackgroundTask(promise, label)` — adds the promise to a module-scope `Set`; auto-removes via `.finally()` on settle.
- `gracefulShutdown(timeoutMs)` — `Promise.race` between `Promise.allSettled([...inflight])` and a timer. Idempotent via a `shuttingDown` flag.
- On timeout, logs a warning naming each unfinished task label, then resolves so the caller can exit anyway.

Wiring:

- `session.ts::syncTranscriptToBrain` wraps the existing `context.with(bg.ctx, ...)` call in `trackBackgroundTask(syncPromise, ` + "`transcript-sync:${sessionId}`" + `)`.
- `index.ts::shutdown` removes the 3s `forceExit` setTimeout, inserts `await gracefulShutdown(10_000)` between `server.close()` and `shutdownLangfuse()`, and adds a local `shuttingDown` guard so SIGTERM-while-shutting-down is a no-op.

## Why 10s?

Long enough to cover the typical brain HTTP round-trip plus the existing `retryTranscriptSync` first-attempt budget (~5s). Short enough that a wedged gateway can't hang the relay indefinitely. Bounded shutdown beats indefinite hang — if a sync is still in flight at 10s, the warning log names the session id so we can confirm whether the transcript landed via the gateway side.

## Test plan

- [x] `yarn workspace relay-server test` passes (28/28, including 3 new shutdown tests)
- [x] `yarn workspace relay-server tsc --noEmit` clean
- [x] New shutdown.test.ts covers: (1) awaits in-flight task and resolves shortly after settle, (2) returns within the cap when a task never resolves, (3) idempotency — second call is a no-op
- [ ] Manual: start relay, open a session, send `kill <pid>`, confirm `Syncing transcript to brain` log line fires AND completes before the process exits