### PR TITLE
fix(gemini): rebuild resume preamble on forced-fresh reconnect

### DIFF
--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -250,6 +250,16 @@ export class GeminiAdapter implements ProviderAdapter {
     this.currentlyResumable = false
     this.rotateAfterToolCalls = false
 
+    // Finalize any in-flight transcription before rotating. Gemini's resumed
+    // session replays transcription from its last checkpoint, so if we leave
+    // currentAssistantText / currentUserText populated, the replayed deltas
+    // concatenate onto stale text and the UI renders "How's that?How's that?".
+    // Flush as transcript.done so the client commits its current bubble; post-
+    // resume deltas then start a fresh bubble. Done before the forced-fresh
+    // preamble snapshot so a mid-turn user utterance lands in this.transcript
+    // and gets folded into the rebuilt systemInstruction.
+    this.flushPendingTranscripts()
+
     // Forced-fresh has no resumption handle, so Gemini won't replay any
     // in-call state. Rebuild the systemInstruction preamble from the original
     // conversationHistory PLUS in-call turns accumulated since connect() so
@@ -263,13 +273,6 @@ export class GeminiAdapter implements ProviderAdapter {
     }
     const handlePreview = this.resumptionHandle ? `${this.resumptionHandle.slice(0, 8)}…` : "fresh"
     log(`[gemini] Reconnecting (${reason}, handle=${handlePreview})`)
-    // Finalize any in-flight transcription before rotating. Gemini's resumed
-    // session replays transcription from its last checkpoint, so if we leave
-    // currentAssistantText / currentUserText populated, the replayed deltas
-    // concatenate onto stale text and the UI renders "How's that?How's that?".
-    // Flush as transcript.done so the client commits its current bubble; post-
-    // resume deltas then start a fresh bubble.
-    this.flushPendingTranscripts()
     this.userSpeaking = false
     this.sendToClient?.({ type: "session.rotating" })
     this.pauseWatchdog()

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -5,7 +5,7 @@ import type { SessionConfigEvent } from "../types.js"
 import type { ProviderAdapter, SendToClient } from "./types.js"
 import { buildInstructions } from "../instructions.js"
 import { getGeminiTools } from "../tools/index.js"
-import { buildHistorySplit, formatSummaryPreamble, formatRecentTurnsPreamble } from "../history.js"
+import { buildHistorySplit, formatSummaryPreamble, formatRecentTurnsPreamble, type HistoryMessage } from "../history.js"
 import { log, error as logError } from "../log.js"
 
 const GEMINI_WS_URL = "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
@@ -98,15 +98,7 @@ export class GeminiAdapter implements ProviderAdapter {
     this.disconnected = false
     this.watchdogEnabled = config.watchdog === "enabled"
 
-    const split = await buildHistorySplit(config.conversationHistory, "gemini")
-    const sections: string[] = []
-    if (split.summary) sections.push(formatSummaryPreamble(split.summary))
-    const recentPreamble = formatRecentTurnsPreamble(split.recent)
-    if (recentPreamble) sections.push(recentPreamble)
-    this.resumePreamble = sections.join("\n\n")
-    if (this.resumePreamble) {
-      log(`[gemini] Resume context folded into systemInstruction: recent=${split.recent.length} turns, summary=${split.summary ? `${split.summary.length} chars` : "none"} (${this.resumePreamble.length} chars)`)
-    }
+    await this.rebuildResumePreamble(config.conversationHistory ?? [])
 
     await this.openUpstream()
   }
@@ -257,6 +249,18 @@ export class GeminiAdapter implements ProviderAdapter {
     // prior session's stale handle.
     this.currentlyResumable = false
     this.rotateAfterToolCalls = false
+
+    // Forced-fresh has no resumption handle, so Gemini won't replay any
+    // in-call state. Rebuild the systemInstruction preamble from the original
+    // conversationHistory PLUS in-call turns accumulated since connect() so
+    // the new session sees the full conversation, not just the call-start
+    // history. Handle-based reconnects skip this — Gemini restores state
+    // from its own checkpoint.
+    if (forceFresh && this.config) {
+      const initial = this.config.conversationHistory ?? []
+      const combined: HistoryMessage[] = [...initial, ...this.transcript]
+      await this.rebuildResumePreamble(combined)
+    }
     const handlePreview = this.resumptionHandle ? `${this.resumptionHandle.slice(0, 8)}…` : "fresh"
     log(`[gemini] Reconnecting (${reason}, handle=${handlePreview})`)
     // Finalize any in-flight transcription before rotating. Gemini's resumed
@@ -785,6 +789,18 @@ export class GeminiAdapter implements ProviderAdapter {
     if (this.postResumeTimer) {
       clearTimeout(this.postResumeTimer)
       this.postResumeTimer = null
+    }
+  }
+
+  private async rebuildResumePreamble(history: HistoryMessage[]) {
+    const split = await buildHistorySplit(history, "gemini")
+    const sections: string[] = []
+    if (split.summary) sections.push(formatSummaryPreamble(split.summary))
+    const recentPreamble = formatRecentTurnsPreamble(split.recent)
+    if (recentPreamble) sections.push(recentPreamble)
+    this.resumePreamble = sections.join("\n\n")
+    if (this.resumePreamble) {
+      log(`[gemini] Resume context folded into systemInstruction: recent=${split.recent.length} turns, summary=${split.summary ? `${split.summary.length} chars` : "none"} (${this.resumePreamble.length} chars)`)
     }
   }
 

--- a/relay-server/test/adapters/gemini-forced-fresh-preamble.test.ts
+++ b/relay-server/test/adapters/gemini-forced-fresh-preamble.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { WebSocketServer, WebSocket as WsSocket } from "ws"
+import { GeminiAdapter } from "../../src/adapters/gemini.js"
+import type { SessionConfigEvent } from "../../src/types.js"
+import {
+  eventsOfType,
+  waitMs,
+  type AdapterInternals,
+  type RelayEvent,
+} from "../helpers/mock-gemini.js"
+
+describe("GeminiAdapter forced-fresh preamble rebuild", () => {
+  let handle: ScriptedHandle | null = null
+
+  afterEach(async () => {
+    await handle?.dispose()
+    handle = null
+  })
+
+  it("rebuilds preamble from initial conversationHistory + in-call transcript on forced-fresh reconnect", async () => {
+    const initialHistory = makeHistory([
+      ["user", "I'm planning a trip to San Francisco next month"],
+      ["assistant", "Exciting — what dates and what's the vibe you're after?"],
+      ["user", "April 15 to 22, mostly food and walking"],
+      ["assistant", "Got it. Mission burritos and Golden Gate Park then."],
+    ])
+
+    handle = await mountWithHistory(initialHistory, [
+      { steps: [
+        { at: 20, msg: { sessionResumptionUpdate: { newHandle: "h1", resumable: true } } },
+        { at: 40, msg: { serverContent: { inputTranscription: { text: "What about coffee in the Mission?" } } } },
+        { at: 60, msg: { serverContent: { outputTranscription: { text: "Try Four Barrel or Ritual." } } } },
+        { at: 80, msg: { serverContent: { turnComplete: true } } },
+        { at: 100, msg: { serverContent: { inputTranscription: { text: "Any rooftop bars near downtown?" } } } },
+        { at: 120, msg: { serverContent: { outputTranscription: { text: "Charmaine's at the Proper Hotel is great." } } } },
+        { at: 140, msg: { serverContent: { turnComplete: true } } },
+      ] },
+      { steps: [] },
+    ])
+
+    await waitMs(250)
+    expect(handle.adapter.getTranscript()).toHaveLength(4)
+
+    handle.internals.resumptionHandle = null
+    await handle.internals.reconnect("test forced fresh", true)
+    await waitMs(150)
+
+    expect(handle.setupsReceived).toHaveLength(2)
+    const resumedInstruction = handle.setupsReceived[1].systemInstruction?.parts?.[0]?.text ?? ""
+    expect(resumedInstruction).toContain("San Francisco")
+    expect(resumedInstruction).toContain("April 15 to 22")
+    expect(resumedInstruction).toContain("Four Barrel or Ritual")
+    expect(resumedInstruction).toContain("Charmaine's at the Proper Hotel")
+    expect(eventsOfType(handle.events, "session.rotated")).toHaveLength(1)
+    expect(eventsOfType(handle.events, "error")).toHaveLength(0)
+  })
+
+  it("leaves preamble unchanged on a handle-based reconnect (Gemini restores in-call state via the handle)", async () => {
+    const initialHistory = makeHistory([
+      ["user", "Remind me what we decided about the Q2 roadmap"],
+      ["assistant", "We agreed to ship the analytics dashboard first."],
+    ])
+
+    handle = await mountWithHistory(initialHistory, [
+      { steps: [
+        { at: 20, msg: { sessionResumptionUpdate: { newHandle: "stable-handle", resumable: true } } },
+        { at: 40, msg: { serverContent: { inputTranscription: { text: "And what about hiring?" } } } },
+        { at: 60, msg: { serverContent: { outputTranscription: { text: "Two senior engineers in Q2." } } } },
+        { at: 80, msg: { serverContent: { turnComplete: true } } },
+        { at: 100, msg: { goAway: { timeLeft: "2s" } } },
+        { at: 140, close: 1011 },
+      ] },
+      { steps: [] },
+    ])
+
+    await waitMs(800)
+
+    expect(handle.setupsReceived).toHaveLength(2)
+    const initialInstruction = handle.setupsReceived[0].systemInstruction?.parts?.[0]?.text ?? ""
+    const resumedInstruction = handle.setupsReceived[1].systemInstruction?.parts?.[0]?.text ?? ""
+    expect(resumedInstruction).toBe(initialInstruction)
+    expect(resumedInstruction).not.toContain("hiring")
+    expect(resumedInstruction).not.toContain("senior engineers")
+    expect(handle.setupsReceived[1].sessionResumption?.handle).toBe("stable-handle")
+  })
+
+  it("forced-fresh with no in-call turns leaves preamble equal to the initial preamble", async () => {
+    const initialHistory = makeHistory([
+      ["user", "Hello"],
+      ["assistant", "Hi there!"],
+    ])
+
+    handle = await mountWithHistory(initialHistory, [
+      { steps: [] },
+      { steps: [] },
+    ])
+
+    expect(handle.adapter.getTranscript()).toHaveLength(0)
+
+    handle.internals.resumptionHandle = null
+    await handle.internals.reconnect("test forced fresh no turns", true)
+    await waitMs(150)
+
+    expect(handle.setupsReceived).toHaveLength(2)
+    const initialInstruction = handle.setupsReceived[0].systemInstruction?.parts?.[0]?.text ?? ""
+    const resumedInstruction = handle.setupsReceived[1].systemInstruction?.parts?.[0]?.text ?? ""
+    expect(resumedInstruction).toBe(initialInstruction)
+  })
+})
+
+// --- helpers ---
+
+interface ScriptedHandle {
+  adapter: GeminiAdapter
+  internals: AdapterInternals
+  events: RelayEvent[]
+  setupsReceived: SetupMessage[]
+  dispose: () => Promise<void>
+}
+
+type SetupMessage = {
+  systemInstruction?: { parts?: { text?: string }[] }
+  sessionResumption?: { handle?: string }
+  [k: string]: unknown
+}
+
+type Script = {
+  ackSetup?: "auto" | number
+  steps?: { at: number, msg?: Record<string, unknown>, close?: number }[]
+}
+
+function makeHistory(pairs: ["user" | "assistant", string][]): { role: "user" | "assistant", text: string }[] {
+  return pairs.map(([role, text]) => ({ role, text }))
+}
+
+async function mountWithHistory(
+  conversationHistory: { role: "user" | "assistant", text: string }[],
+  scripts: Script[],
+): Promise<ScriptedHandle> {
+  process.env.GEMINI_API_KEY ||= "test-key"
+
+  const wss = new WebSocketServer({ port: 0 })
+  await new Promise<void>((resolve) => wss.once("listening", () => resolve()))
+  const address = wss.address()
+  const port = typeof address === "object" && address ? address.port : 0
+
+  const setupsReceived: SetupMessage[] = []
+  let connectionIndex = 0
+
+  wss.on("connection", (ws) => {
+    const myIndex = connectionIndex++
+    const script = scripts[myIndex]
+
+    ws.on("message", (raw) => {
+      const msg = JSON.parse(String(raw)) as Record<string, unknown>
+      if ("setup" in msg) {
+        setupsReceived.push(msg.setup as SetupMessage)
+        const ack = script?.ackSetup ?? "auto"
+        if (ack === "auto") {
+          if (ws.readyState === WsSocket.OPEN) ws.send(JSON.stringify({ setupComplete: {} }))
+        } else {
+          setTimeout(() => {
+            if (ws.readyState === WsSocket.OPEN) ws.send(JSON.stringify({ setupComplete: {} }))
+          }, ack)
+        }
+        for (const step of script?.steps ?? []) {
+          setTimeout(() => {
+            if (ws.readyState !== WsSocket.OPEN) return
+            if (step.msg) ws.send(JSON.stringify(step.msg))
+            else if (step.close !== undefined) ws.close(step.close)
+          }, step.at)
+        }
+      }
+    })
+  })
+
+  const config: SessionConfigEvent = {
+    type: "session.config",
+    provider: "gemini",
+    model: "gemini-3.1-flash-live-preview",
+    voice: "Zephyr",
+    apiKey: "test",
+    brainAgent: "none",
+    deviceContext: { timezone: "UTC", locale: "en-US", deviceModel: "mock" },
+    conversationHistory,
+  }
+
+  const adapter = new GeminiAdapter()
+  const internals = adapter as unknown as AdapterInternals
+  internals.wsUrlOverride = `ws://localhost:${port}`
+
+  const events: RelayEvent[] = []
+  await adapter.connect(config, (event) => events.push(event as RelayEvent))
+
+  const dispose = async () => {
+    adapter.disconnect()
+    await new Promise<void>((resolve) => wss.close(() => resolve()))
+  }
+
+  return { adapter, internals, events, setupsReceived, dispose }
+}

--- a/relay-server/test/adapters/gemini-forced-fresh-preamble.test.ts
+++ b/relay-server/test/adapters/gemini-forced-fresh-preamble.test.ts
@@ -46,6 +46,9 @@ describe("GeminiAdapter forced-fresh preamble rebuild", () => {
     await waitMs(150)
 
     expect(handle.setupsReceived).toHaveLength(2)
+    const initialInstruction = handle.setupsReceived[0].systemInstruction?.parts?.[0]?.text ?? ""
+    expect(initialInstruction).not.toContain("Four Barrel")
+    expect(initialInstruction).not.toContain("Charmaine")
     const resumedInstruction = handle.setupsReceived[1].systemInstruction?.parts?.[0]?.text ?? ""
     expect(resumedInstruction).toContain("San Francisco")
     expect(resumedInstruction).toContain("April 15 to 22")


### PR DESCRIPTION
## Why

Today's SF-trip session lost ~25 minutes of in-call context after a forced-fresh reconnect. Trace: post-resume watchdog detected a poisoned handle → forced a fresh session (no resumption handle) → new session's `systemInstruction` was the preamble built once at `connect()` from `config.conversationHistory`, so it only saw the call-start history, not anything from the live conversation.

After PR #255 (idle resume false-positive fix) the forced-fresh path is rare, but when it does fire, it's still lossy. OpenAI's `rotate()` already updates its own `resumeSummary` / `resumeRecentTurns` before reopening (PR #260) — Gemini's analog needed the same treatment.

## Fix

- Extract the preamble construction in `connect()` into a `rebuildResumePreamble(history)` helper.
- At the top of `reconnect()` when `forceFresh === true`, rebuild the preamble from `[...config.conversationHistory, ...this.transcript]` so the new Gemini session sees the original turns AND every in-call exchange accumulated since connect.
- Handle-based reconnects skip the rebuild — Gemini restores in-call state from the resumption handle, so re-folding turns into systemInstruction would just bloat the prompt.

`this.transcript` only accumulates from server events post-connect, so there's no double-count risk against `config.conversationHistory`.

## Tests

New file `relay-server/test/adapters/gemini-forced-fresh-preamble.test.ts` (3 cases):

1. Forced-fresh reconnect rebuilds the preamble from initial + in-call turns — asserts the resumed setup's `systemInstruction` text contains both the call-start history and post-connect transcript turns.
2. Handle-based reconnect leaves the preamble unchanged.
3. Forced-fresh with no in-call turns is a no-op (resumed preamble equals initial preamble).

`yarn workspace relay-server test` → 62 passed, 2 skipped (15 files).
`yarn workspace relay-server tsc --noEmit` → clean.

## Test plan

- [x] `yarn workspace relay-server test` passes
- [x] `yarn workspace relay-server tsc --noEmit` clean
- [ ] Live: trigger a forced-fresh reconnect (poisoned-handle simulation) mid-call and confirm the model continues with full context