### PR TITLE
feat(brain): stream SSE deltas to model in chunks

### DIFF
--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -384,6 +384,18 @@ export class GeminiAdapter implements ProviderAdapter {
     })
   }
 
+  injectPartial(text: string) {
+    // realtimeInput.text is append-only and never starts a new generation
+    // turn on its own, so partial chunks can land mid-response and the model
+    // sees them as more input becomes available.
+    log(`[gemini] Injecting partial context via realtimeInput.text (${text.length} chars)`)
+    this.sendUpstream({
+      realtimeInput: {
+        text,
+      },
+    })
+  }
+
   getTranscript() {
     return [...this.transcript]
   }

--- a/relay-server/src/adapters/openai.ts
+++ b/relay-server/src/adapters/openai.ts
@@ -118,6 +118,23 @@ export class OpenAIAdapter implements ProviderAdapter {
     this.requestResponse("injectContext")
   }
 
+  injectPartial(text: string) {
+    // Append the chunk as a conversation item without triggering response.create.
+    // The current model turn is already in flight (the assistant started speaking
+    // after the placeholder tool result), so the new item lands as additional
+    // context the model reads from on its next reasoning step. Requesting a
+    // response here would race the active one.
+    log(`[${this.providerName}] Injecting partial context via conversation.item.create (${text.length} chars)`)
+    this.sendUpstream({
+      type: "conversation.item.create",
+      item: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text }],
+      },
+    })
+  }
+
   commitAudio() {
     this.sendUpstream({ type: "input_audio_buffer.commit" })
   }

--- a/relay-server/src/adapters/types.ts
+++ b/relay-server/src/adapters/types.ts
@@ -31,6 +31,16 @@ export interface ProviderAdapter {
   /** Inject context into the conversation (e.g. async tool results) */
   injectContext(text: string): void
 
+  /**
+   * Append partial context mid-response without forcing a new response cycle.
+   * Used to stream brain SSE deltas into the model's working context as they
+   * arrive, so the assistant can start speaking from the answer before the
+   * full brain reply has assembled. Optional — adapters that can't safely
+   * append without restarting generation can leave it unimplemented and the
+   * caller will fall back to buffering until the final injectContext.
+   */
+  injectPartial?(text: string): void
+
   /** Get the conversation transcript so far */
   getTranscript(): { role: "user" | "assistant", text: string }[]
 

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -296,15 +296,24 @@ export class RelaySession {
     // context.active(), which could be whatever ambient (unrelated) span
     // happens to be live at this moment and would produce a misleading trace.
     const brainCtx = this.tracer.getToolSpanContext(callId) ?? ROOT_CONTEXT
+    let streamedAnyPartial = false
+    const onPartial = this.adapter?.injectPartial
+      ? (chunk: string) => {
+          streamedAnyPartial = true
+          this.adapter?.injectPartial?.(
+            `[Brain agent partial answer for "${query}"] ${chunk}`,
+          )
+        }
+      : undefined
     const runAskBrain = () => askBrain(query, {
       gatewayUrl,
       authToken,
       sessionId: sessionKey,
-    }, sendToClient, callId, controller.signal)
+    }, sendToClient, callId, controller.signal, onPartial)
 
     context.with(brainCtx, runAskBrain).then((result) => {
       const brainMs = Date.now() - brainStart
-      log(`[session:${this.id}] ask_brain completed in ${brainMs}ms`)
+      log(`[session:${this.id}] ask_brain completed in ${brainMs}ms (streamed=${streamedAnyPartial})`)
 
       if (controller.signal.aborted) {
         log(`[session:${this.id}] ask_brain (${callId}) was cancelled — discarding result`)
@@ -314,10 +323,19 @@ export class RelaySession {
 
       this.tracer.endToolCall(callId, result)
 
-      // Inject the result back into the conversation so Gemini speaks it
-      this.adapter?.injectContext(
-        `[Brain agent result for query: "${query}"]\n${result}\n\nPlease share this information with the user naturally.`
-      )
+      // When chunks were streamed via injectPartial the model already has the
+      // body — re-injecting the full result would duplicate it. Send a short
+      // completion marker instead. When nothing was streamed (short reply or
+      // adapter without partial support), fall back to the original full inject.
+      if (streamedAnyPartial) {
+        this.adapter?.injectContext(
+          `[Brain agent answer complete for "${query}"]\nShare what you have with the user naturally.`,
+        )
+      } else {
+        this.adapter?.injectContext(
+          `[Brain agent result for query: "${query}"]\n${result}\n\nPlease share this information with the user naturally.`,
+        )
+      }
     }).catch((err) => {
       const message = err instanceof Error ? err.message : "brain agent call failed"
       logError(`[session:${this.id}] ask_brain error:`, message)

--- a/relay-server/src/tools/brain.ts
+++ b/relay-server/src/tools/brain.ts
@@ -11,12 +11,23 @@ interface BrainConfig {
   sessionId: string
 }
 
+export type PartialFlush = (chunk: string) => void
+
+// Heuristics for streaming brain SSE deltas back into the model context.
+// The provider call can take 5–20 s end-to-end; streaming partial chunks lets
+// the assistant start speaking from a forming answer instead of waiting for
+// the full reply, while the boundary checks keep us from injecting mid-word
+// fragments that would read as garbage.
+export const PARTIAL_FLUSH_MIN_CHARS = 200
+export const PARTIAL_FLUSH_BOUNDARY_RE = /([.!?])\s$|\n\n$/
+
 export async function askBrain(
   query: string,
   config: BrainConfig,
   sendToClient: SendToClient,
   callId: string,
   externalSignal?: AbortSignal,
+  onPartial?: PartialFlush,
 ): Promise<string> {
   const url = `${config.gatewayUrl.replace(/\/$/, "")}/v1/chat/completions`
 
@@ -98,6 +109,21 @@ export async function askBrain(
   const decoder = new TextDecoder()
   let fullResponse = ""
   let buffer = ""
+  let pendingDelta = ""
+  let partialFlushCount = 0
+
+  const flushPartial = () => {
+    if (!onPartial || !pendingDelta) return
+    const chunk = pendingDelta
+    pendingDelta = ""
+    partialFlushCount++
+    log(`[brain] Streaming partial chunk #${partialFlushCount} (${chunk.length} chars) to model`)
+    try {
+      onPartial(chunk)
+    } catch (err) {
+      logError(`[brain] onPartial threw — continuing without further partials:`, err)
+    }
+  }
 
   let readCount = 0
   while (true) {
@@ -144,8 +170,17 @@ export async function askBrain(
 
         // Standard OpenAI-compatible SSE chunk
         const delta = parsed.choices?.[0]?.delta?.content
-        if (delta) {
+        if (typeof delta === "string" && delta.length > 0) {
           fullResponse += delta
+          if (onPartial) {
+            pendingDelta += delta
+            if (
+              PARTIAL_FLUSH_BOUNDARY_RE.test(pendingDelta) ||
+              pendingDelta.length >= PARTIAL_FLUSH_MIN_CHARS
+            ) {
+              flushPartial()
+            }
+          }
         }
       } catch {
         // Skip unparseable chunks
@@ -154,6 +189,11 @@ export async function askBrain(
   }
 
   cleanup()
-  log(`[brain] Response: ${fullResponse.substring(0, 100)}...`)
+  // Only flush the leftover when we already emitted at least one mid-stream
+  // chunk. For short answers that never crossed a boundary, the caller's
+  // final injectContext handles delivery — flushing the leftover too would
+  // duplicate the entire response into the model's context.
+  if (pendingDelta && partialFlushCount > 0) flushPartial()
+  log(`[brain] Response: ${fullResponse.substring(0, 100)}... (partial flushes: ${partialFlushCount})`)
   return fullResponse || JSON.stringify({ error: "Empty response from brain agent" })
 }

--- a/relay-server/test/tools/brain-streaming.test.ts
+++ b/relay-server/test/tools/brain-streaming.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { createServer, type Server } from "node:http"
+import type { AddressInfo } from "node:net"
+import { askBrain, PARTIAL_FLUSH_MIN_CHARS } from "../../src/tools/brain.js"
+
+describe("askBrain SSE delta streaming", () => {
+  let server: Server | null = null
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()))
+      server = null
+    }
+  })
+
+  it("flushes at sentence boundaries", async () => {
+    const partials: string[] = []
+    const handle = await startSseServer([
+      "Today we ",
+      "talked ",
+      "about SF. ",
+      "We ",
+      "decided to ",
+      "reach out to Amir.",
+    ])
+    server = handle.server
+
+    const result = await askBrain(
+      "test",
+      { gatewayUrl: handle.url, authToken: "x", sessionId: "s" },
+      () => {},
+      "call-boundaries",
+      undefined,
+      (chunk) => { partials.push(chunk) },
+    )
+
+    expect(result).toBe("Today we talked about SF. We decided to reach out to Amir.")
+    expect(partials).toHaveLength(2)
+    expect(partials[0]).toBe("Today we talked about SF. ")
+    expect(partials[1]).toBe("We decided to reach out to Amir.")
+  })
+
+  it("flushes at the 200-char boundary when no sentence terminator is seen", async () => {
+    const partials: string[] = []
+    const wordChunks = Array.from({ length: 60 }, (_, i) => `word${i.toString().padStart(2, "0")} `)
+    const handle = await startSseServer(wordChunks)
+    server = handle.server
+
+    await askBrain(
+      "test",
+      { gatewayUrl: handle.url, authToken: "x", sessionId: "s" },
+      () => {},
+      "call-charcap",
+      undefined,
+      (chunk) => { partials.push(chunk) },
+    )
+
+    expect(partials.length).toBeGreaterThanOrEqual(1)
+    expect(partials[0].length).toBeGreaterThanOrEqual(PARTIAL_FLUSH_MIN_CHARS)
+    expect(/[.!?]/.test(partials[0])).toBe(false)
+  })
+
+  it("does not emit a partial flush for a single short response", async () => {
+    const partials: string[] = []
+    const handle = await startSseServer(["OK."])
+    server = handle.server
+
+    const result = await askBrain(
+      "test",
+      { gatewayUrl: handle.url, authToken: "x", sessionId: "s" },
+      () => {},
+      "call-short",
+      undefined,
+      (chunk) => { partials.push(chunk) },
+    )
+
+    expect(result).toBe("OK.")
+    expect(partials).toHaveLength(0)
+  })
+
+  it("ignores chunks without delta.content", async () => {
+    const partials: string[] = []
+    const handle = await startSseServer([], {
+      rawLines: [
+        'data: {"choices":[{"delta":{}}]}',
+        'data: {"choices":[{"delta":{"content":""}}]}',
+        'data: {"choices":[{"delta":{"role":"assistant"}}]}',
+        'data: {"choices":[{"delta":{"content":"hi"}}]}',
+        "data: [DONE]",
+      ],
+    })
+    server = handle.server
+
+    const result = await askBrain(
+      "test",
+      { gatewayUrl: handle.url, authToken: "x", sessionId: "s" },
+      () => {},
+      "call-empty",
+      undefined,
+      (chunk) => { partials.push(chunk) },
+    )
+
+    expect(result).toBe("hi")
+    expect(partials).toHaveLength(0)
+  })
+
+  it("does not call onPartial when no callback is provided", async () => {
+    const handle = await startSseServer(["A. ", "B. ", "C."])
+    server = handle.server
+
+    const result = await askBrain(
+      "test",
+      { gatewayUrl: handle.url, authToken: "x", sessionId: "s" },
+      () => {},
+      "call-no-cb",
+    )
+
+    expect(result).toBe("A. B. C.")
+  })
+})
+
+interface StartOptions {
+  rawLines?: string[]
+}
+
+async function startSseServer(
+  contentChunks: string[],
+  options: StartOptions = {},
+): Promise<{ server: Server, url: string }> {
+  const server = createServer((_req, res) => {
+    res.writeHead(200, { "content-type": "text/event-stream" })
+    if (options.rawLines) {
+      for (const line of options.rawLines) {
+        res.write(`${line}\n\n`)
+      }
+    } else {
+      for (const chunk of contentChunks) {
+        const payload = JSON.stringify({ choices: [{ delta: { content: chunk } }] })
+        res.write(`data: ${payload}\n\n`)
+      }
+      res.write("data: [DONE]\n\n")
+    }
+    res.end()
+  })
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const port = (server.address() as AddressInfo).port
+  return { server, url: `http://127.0.0.1:${port}` }
+}


### PR DESCRIPTION
## Summary

Closes #19. Brain calls take 5–20 s (codex p50 10 s, p95 87 s). Today the relay accumulates the full SSE response and only injects it once via `injectContext`, so the assistant has no real answer to speak from for the entire window — it either goes silent or hallucinates completion.

This streams the SSE delta content back into the model context as it arrives, sentence-by-sentence, so the assistant can start speaking from a forming answer instead of waiting for the full reply.

## How it works

- New optional `ProviderAdapter.injectPartial(text)` method.
  - **Gemini**: identical body to `injectContext` — `realtimeInput.text` is append-only and never starts a new turn on its own.
  - **OpenAI / xAI**: `conversation.item.create` *without* the `response.create` follow-up. The current assistant turn is already in flight (it started speaking after the placeholder `sendToolResult`), so the new item lands as additional context for the model to read on its next reasoning step. Triggering `response.create` here would race the active response.
- `brain.ts` buffers `delta.content` into `pendingDelta` and flushes whenever the buffer ends in `. `, `! `, `? `, or `\n\n`, OR reaches 200 characters — whichever fires first. Heuristics are exported constants (`PARTIAL_FLUSH_MIN_CHARS`, `PARTIAL_FLUSH_BOUNDARY_RE`) at the top of the file so tuning is one diff away.
- Stream-end leftover is flushed only when at least one mid-stream chunk already went out. For short answers (e.g. `"OK."`) `injectPartial` is never called — the existing `injectContext` path handles delivery and we don't duplicate the body.
- `session.ts` passes the `injectPartial` callback through to `askBrain`. When any partial fired, the final `injectContext` degrades to a short "answer complete, share it naturally" marker so we don't re-send the full body the model already has.

## Tradeoff

Two competing constraints:

1. **Latency** — inject as early as possible so the model can start speaking sooner.
2. **Coherence** — don't inject every token (context update storm) and don't inject mid-sentence partials that read as garbage.

Sentence boundaries + 200-char fallback is the middle ground. ~3-7 chunks for a typical brain reply, each at a natural reading boundary.

## Scope

All three adapters (Gemini, OpenAI, xAI) implement `injectPartial`. xAI inherits OpenAI's implementation. Existing `tool.progress` step_complete forwarding (the visible "let me check" client UX) is unchanged — that's a separate signal.

## Test plan

- [x] `yarn workspace relay-server test` — 67 passed (was 62), 2 skipped, 14 files
- [x] `yarn workspace relay-server tsc --noEmit` clean
- [x] New test file `relay-server/test/tools/brain-streaming.test.ts` (5 cases): sentence-boundary flushes, 200-char cap, no-flush for short answers, ignores empty/role-only deltas, no callback case
- [ ] Manual: run a real brain query against staging gateway and confirm assistant starts speaking before the full SSE stream completes