### PR TITLE
chore: gitignore .scratch/ for inter-agent ephemeral handoffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ desktop/build/icon-master.png
 
 # Dev logs
 logs/
+
+# Inter-agent ephemeral handoffs (research → implementer in same session).
+# Per repo convention, agent-produced design notes / recon outputs that the
+# next agent needs to read live here, NOT as committed docs. See memory
+# entry feedback_inter_agent_scratch.md for the full pattern.
+.scratch/


### PR DESCRIPTION
Tiny chore — adds `.scratch/` to `.gitignore` so agent-produced research outputs (e.g. packaging-options recon) can land in `.scratch/agents/<date>/<session>/<topic>.md` for the follow-up implementer agent to read, without polluting git or requiring 200-line prompt pastes.

Pattern decided after PR #270's mistake (committed an implementer design doc to repo root → had to remove via PR #271). Codex consultation recommended this approach.

No code change. Just `.gitignore`.