### PR TITLE
fix(desktop): stage prod deps for electron-builder and smoke-test packaged app

### DIFF
--- a/.github/workflows/desktop-smoke.yml
+++ b/.github/workflows/desktop-smoke.yml
@@ -1,0 +1,90 @@
+# Build the desktop .app and run a smoke launch against it on every push
+# to main that touches desktop/ (or its build-pipeline inputs). Catches
+# regressions like missing native modules, broken asar layout, or
+# unhandled main-process exceptions BEFORE they reach a `desktop-v*` tag.
+#
+# This is a `--mac dir` build (no DMG, no notarize) — uses an ad-hoc
+# signature and runs the smoke test against the unpacked .app. Quick (~5
+# min) and doesn't burn signing credentials on every commit.
+
+name: Desktop smoke
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "desktop/**"
+      - "relay-server/**"
+      - "vendor/openclaw"
+      - ".github/workflows/desktop-smoke.yml"
+  pull_request:
+    paths:
+      - "desktop/**"
+      - "relay-server/**"
+      - "vendor/openclaw"
+      - ".github/workflows/desktop-smoke.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Build + smoke-launch packaged app
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "yarn"
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10.33.0
+
+      - name: Build openclaw
+        working-directory: vendor/openclaw
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Cache electron-builder downloads
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+          key: ${{ runner.os }}-electron-builder-${{ hashFiles('desktop/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-electron-builder-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build services + electron-vite + stage
+        working-directory: desktop
+        run: |
+          node scripts/build-services.mjs
+          yarn build
+          node scripts/stage-app.mjs
+
+      - name: Pack .app (ad-hoc signature, no DMG)
+        working-directory: desktop
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: npx electron-builder --mac dir
+
+      - name: Smoke-test packaged app
+        working-directory: desktop
+        run: yarn smoke:mac

--- a/.github/workflows/desktop-smoke.yml
+++ b/.github/workflows/desktop-smoke.yml
@@ -79,11 +79,16 @@ jobs:
           yarn build
           node scripts/stage-app.mjs
 
+      # `hardenedRuntime: false` is critical for ad-hoc-signed local
+      # builds. The release pipeline keeps it on (required for
+      # notarization), but with hardenedRuntime + ad-hoc the dyld loader
+      # rejects the embedded Electron Framework with "different Team IDs"
+      # at launch — false-positive for the smoke test.
       - name: Pack .app (ad-hoc signature, no DMG)
         working-directory: desktop
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
-        run: npx electron-builder --mac dir
+        run: npx electron-builder --mac dir -c.mac.hardenedRuntime=false
 
       - name: Smoke-test packaged app
         working-directory: desktop

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -141,6 +141,16 @@ jobs:
           RELAY_VERSION: ${{ steps.meta.outputs.relay_version }}
         run: yarn dist:mac --publish never -c.forceCodeSigning=true
 
+      # Launch the freshly-signed-and-notarized .app against an isolated
+      # HOME so it gets a clean userData dir, settle for 10s, and assert
+      # the main process is still alive with no `Cannot find module` /
+      # uncaught-exception patterns. Catches the class of regression where
+      # native modules (better-sqlite3) or workspace-hoisted prod deps
+      # silently fail to land in app.asar / app.asar.unpacked.
+      - name: Smoke-test packaged app
+        working-directory: desktop
+        run: yarn smoke:mac
+
       # release-please-action creates the GitHub Release synchronously with
       # the tag push, so electron-builder's `--publish always` raced it and
       # got 422 already_exists. Upload directly to the existing release with

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ desktop/resources/relay-server-bundle/
 desktop/resources/openclaw/
 desktop/resources/.openclaw-pack/
 
+# electron-builder app staging dir — produced by scripts/stage-app.mjs
+desktop/dist-staging/
+
 # IDE
 .idea/
 .vscode/

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -2,14 +2,30 @@ appId: com.getvoiceclaw.desktop
 productName: VoiceClaw
 copyright: "Copyright © 2026 Nano 3 Labs Ltd."
 
+# `app: dist-staging` points electron-builder at a self-contained
+# package directory produced by `scripts/stage-app.mjs`. The staging dir
+# has its own `package.json` listing only prod deps and a clean
+# `node_modules/` installed by npm — no yarn workspaces in sight. Without
+# this, electron-builder's `npm list` walks up to the workspace root and
+# treats the root's hoisted transitives as the app's dependencies,
+# silently dropping every package declared in `desktop/package.json`.
 directories:
+  app: dist-staging
   output: dist
   buildResources: build
 
 files:
   - "out/**/*"
   - "package.json"
+  - "node_modules/**/*"
   - "!node_modules/**/{README.md,LICENSE*,*.map,*.ts}"
+
+# Native modules with .node bindings cannot be loaded from inside an
+# asar — Electron requires them to live in app.asar.unpacked/ and
+# resolves the require there transparently. Without this, the main
+# process crashes at startup with `Cannot find module 'better-sqlite3'`.
+asarUnpack:
+  - "**/node_modules/better-sqlite3/**/*"
 
 # Anything under desktop/resources/ ships into <App>/Contents/Resources/
 # at the same relative path. Includes the bundled Node runtime

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,7 +9,8 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "postinstall": "electron-rebuild -f -w better-sqlite3 --module-dir .",
-    "dist:mac": "node scripts/build-services.mjs && electron-vite build && node scripts/with-build-env.mjs electron-builder --mac",
+    "dist:mac": "node scripts/build-services.mjs && electron-vite build && node scripts/stage-app.mjs && node scripts/with-build-env.mjs electron-builder --mac",
+    "smoke:mac": "node scripts/smoke-test.mjs",
     "build:icon": "tsx scripts/build-mac-icon.ts ../mobile/assets/images/ios/icon-1024x1024.png build/icon-master.png build/icon.iconset && iconutil -c icns build/icon.iconset -o build/icon.icns && cp build/icon.iconset/icon_512x512.png resources/dock/icon.png",
     "build:tray-icon": "tsx scripts/build-tray-icon.ts",
     "build:assets": "yarn build:icon && yarn build:tray-icon"

--- a/desktop/scripts/smoke-test.mjs
+++ b/desktop/scripts/smoke-test.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+import { execSync, spawn } from "node:child_process"
+import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const here = dirname(fileURLToPath(import.meta.url))
+const desktopRoot = resolve(here, "..")
+const arch = process.arch === "arm64" ? "mac-arm64" : "mac"
+const appPath = process.env.SMOKE_APP_PATH ?? findPackagedApp()
+const settleMs = Number(process.env.SMOKE_SETTLE_MS ?? "10000")
+const fakeHome = mkdtempSync(join(tmpdir(), "voiceclaw-smoke-home-"))
+
+console.log(`[smoke] app:      ${appPath}`)
+console.log(`[smoke] fakeHome: ${fakeHome}`)
+console.log(`[smoke] settling for ${settleMs}ms`)
+
+if (!existsSync(appPath)) {
+  console.error(`[smoke] FAIL — packaged app not found at ${appPath}`)
+  process.exit(1)
+}
+
+const startedAt = Date.now()
+const launchProc = spawn("open", ["-n", "-W", "--stdout", "/dev/stderr", "--stderr", "/dev/stderr", appPath], {
+  env: { ...process.env, HOME: fakeHome },
+  stdio: ["ignore", "inherit", "pipe"],
+})
+
+const stderrChunks = []
+launchProc.stderr.on("data", chunk => stderrChunks.push(chunk))
+let openExited = false
+let openExitCode = null
+launchProc.on("exit", (code) => {
+  openExited = true
+  openExitCode = code
+})
+
+await sleep(settleMs)
+
+const stderr = Buffer.concat(stderrChunks).toString("utf8")
+
+const fatalPatterns = [
+  /Cannot find module/i,
+  /Uncaught Exception/i,
+  /A JavaScript error occurred in the main process/i,
+  /Error: ENOENT/i,
+  /SIGABRT|SIGSEGV|SIGBUS/i,
+  /Library not loaded/i,
+]
+for (const pattern of fatalPatterns) {
+  if (pattern.test(stderr)) {
+    console.error(`[smoke] FAIL — fatal pattern matched in launcher stderr: ${pattern}`)
+    console.error(`[smoke] stderr:\n${stderr}`)
+    cleanup()
+    process.exit(1)
+  }
+}
+
+const aliveCount = countLiveVoiceClawProcs()
+if (aliveCount === 0) {
+  console.error(`[smoke] FAIL — no VoiceClaw process alive after ${settleMs}ms (open exited=${openExited} code=${openExitCode})`)
+  console.error(`[smoke] launcher stderr:\n${stderr}`)
+  const sysLog = recentSystemLog(startedAt)
+  if (sysLog) console.error(`[smoke] recent system log:\n${sysLog}`)
+  cleanup()
+  process.exit(1)
+}
+
+console.log(`[smoke] OK — ${aliveCount} VoiceClaw processes alive after ${settleMs}ms, no fatal patterns`)
+
+quitVoiceClaw()
+await sleep(2000)
+forceKillVoiceClaw()
+cleanup()
+process.exit(0)
+
+function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms))
+}
+
+function findPackagedApp() {
+  const candidates = [
+    join(desktopRoot, "dist", arch, "VoiceClaw.app"),
+    join(desktopRoot, "dist", "mac", "VoiceClaw.app"),
+    join(desktopRoot, "dist", "mac-arm64", "VoiceClaw.app"),
+  ]
+  for (const c of candidates) {
+    if (existsSync(c)) return c
+  }
+  const distDir = join(desktopRoot, "dist")
+  if (existsSync(distDir)) {
+    for (const entry of readdirSync(distDir)) {
+      const candidate = join(distDir, entry, "VoiceClaw.app")
+      if (existsSync(candidate)) return candidate
+    }
+  }
+  return candidates[0]
+}
+
+function countLiveVoiceClawProcs() {
+  try {
+    const out = execSync("pgrep -fl VoiceClaw", { encoding: "utf8" })
+    const lines = out.split("\n").filter(Boolean).filter(line => !line.includes("smoke-test"))
+    return lines.length
+  } catch {
+    return 0
+  }
+}
+
+function quitVoiceClaw() {
+  try {
+    execSync(`osascript -e 'try
+  tell application "VoiceClaw" to quit
+end try'`)
+  } catch {
+    // best-effort
+  }
+}
+
+function forceKillVoiceClaw() {
+  try {
+    execSync("pkill -x VoiceClaw")
+  } catch {
+    // best-effort
+  }
+}
+
+function recentSystemLog(sinceMs) {
+  try {
+    const seconds = Math.max(1, Math.ceil((Date.now() - sinceMs) / 1000) + 5)
+    return execSync(
+      `log show --predicate 'process == "VoiceClaw"' --last ${seconds}s --info 2>/dev/null | grep -iE 'sqlite|cannot find|exception|error' | head -20`,
+      { encoding: "utf8" },
+    )
+  } catch {
+    return ""
+  }
+}
+
+function cleanup() {
+  try {
+    rmSync(fakeHome, { recursive: true, force: true })
+  } catch {
+    // best-effort
+  }
+}

--- a/desktop/scripts/stage-app.mjs
+++ b/desktop/scripts/stage-app.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { execSync } from "node:child_process"
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const here = dirname(fileURLToPath(import.meta.url))
+const desktopRoot = resolve(here, "..")
+const stagingDir = join(desktopRoot, "dist-staging")
+const sourcePkg = JSON.parse(readFileSync(join(desktopRoot, "package.json"), "utf8"))
+
+step("clear staging dir", () => {
+  if (existsSync(stagingDir)) rmSync(stagingDir, { recursive: true, force: true })
+  mkdirSync(stagingDir, { recursive: true })
+})
+
+step("copy electron-vite output", () => {
+  const outSrc = join(desktopRoot, "out")
+  if (!existsSync(outSrc)) {
+    throw new Error(`[stage-app] expected ${outSrc} to exist. Run \`yarn build\` first.`)
+  }
+  cpSync(outSrc, join(stagingDir, "out"), { recursive: true })
+})
+
+step("write minimal package.json (prod deps only)", () => {
+  const stagedPkg = {
+    name: sourcePkg.name,
+    version: sourcePkg.version,
+    private: true,
+    main: sourcePkg.main,
+    dependencies: sourcePkg.dependencies,
+  }
+  writeFileSync(join(stagingDir, "package.json"), JSON.stringify(stagedPkg, null, 2))
+})
+
+step("install production deps with npm (no workspace ambiguity)", () => {
+  execSync("npm install --omit=dev --no-audit --no-fund --no-package-lock --ignore-scripts", {
+    cwd: stagingDir,
+    stdio: "inherit",
+  })
+})
+
+step("rebuild better-sqlite3 against electron ABI", () => {
+  const electronVersion = readElectronVersion()
+  const rebuildBin = join(desktopRoot, "node_modules", ".bin", "electron-rebuild")
+  execSync(
+    `"${rebuildBin}" -f -w better-sqlite3 --module-dir "${stagingDir}" --version ${electronVersion}`,
+    { stdio: "inherit", env: { ...process.env, npm_config_runtime: "electron" } },
+  )
+})
+
+console.log(`\n[stage-app] staging dir ready at ${stagingDir}`)
+
+function step(label, fn) {
+  console.log(`\n[stage-app] ${label}`)
+  fn()
+}
+
+function readElectronVersion() {
+  const electronPkg = JSON.parse(
+    readFileSync(join(desktopRoot, "node_modules", "electron", "package.json"), "utf8"),
+  )
+  return electronPkg.version
+}

--- a/docs/src/content/docs/desktop/releasing.mdx
+++ b/docs/src/content/docs/desktop/releasing.mdx
@@ -13,18 +13,18 @@ Every tagged release produces a signed, notarized universal DMG on GitHub, plus 
 
 1. Confirm `desktop/package.json` has the version you want to ship. Bump it on a feature branch if needed, open a PR, merge.
 
-2. From `main`, create and push the tag. The tag name must match `v*.*.*`:
+2. From `main`, create and push the tag. The tag name must match `desktop-v*.*.*` (release-please pushes this for you when its release PR is merged):
 
    ```bash
    git checkout main
    git pull
-   git tag v0.1.0
-   git push origin v0.1.0
+   git tag desktop-v0.3.1
+   git push origin desktop-v0.3.1
    ```
 
 3. Watch the `Release desktop` workflow run in GitHub Actions. On `macos-14` it typically takes 15–25 minutes, most of which is Apple notarization.
 
-4. When the workflow finishes, a new draft-free GitHub Release exists at `https://github.com/yagudaev/voiceclaw/releases/tag/v0.1.0` with the DMG, `.blockmap`, and `latest-mac.yml` attached.
+4. When the workflow finishes, a new draft-free GitHub Release exists at `https://github.com/yagudaev/voiceclaw/releases/tag/desktop-v0.3.1` with the DMG, `.blockmap`, and `latest-mac.yml` attached.
 
 5. Edit the release description with the user-facing changelog if needed. The download page pulls the latest release automatically within 5 minutes of publishing.
 
@@ -76,8 +76,8 @@ Apple's API keys don't expire but they can be revoked. If you ever need to rotat
 
 After a successful run you'll see three artifacts attached to the GitHub Release:
 
-- `VoiceClaw-<version>-universal.dmg` — the universal build, roughly 180–220 MB.
-- `VoiceClaw-<version>-universal.dmg.blockmap` — delta-update manifest consumed by `electron-updater`.
+- `VoiceClaw-<version>-arm64.dmg` — the Apple Silicon build, roughly 220–250 MB.
+- `VoiceClaw-<version>-arm64.dmg.blockmap` — delta-update manifest consumed by `electron-updater`.
 - `latest-mac.yml` — the top-level manifest `electron-updater` reads first. Points at the DMG and blockmap by URL + SHA-512.
 
 The workflow also uploads the same files as a workflow artifact (`voiceclaw-dmg`) for 14 days — handy if the Release publish step fails after the build succeeded.
@@ -91,6 +91,21 @@ At runtime the app reads the `publish` block from `desktop/electron-builder.yml`
 3. On Apple Silicon it verifies the DMG is signed by the same Developer ID, then stages the update for the next launch.
 
 No extra server, no extra auth — the public Release is the update channel.
+
+## Build pipeline internals
+
+`yarn dist:mac` runs four stages back-to-back:
+
+1. `node scripts/build-services.mjs` — fetches the bundled Node 22 runtime, builds the relay-server bundle, and packs the openclaw bundle into `desktop/resources/`.
+2. `electron-vite build` — emits the main + preload + renderer code to `desktop/out/`.
+3. `node scripts/stage-app.mjs` — assembles a self-contained `desktop/dist-staging/` directory containing only the things that ship: `out/`, a minimal `package.json` listing prod deps, a `node_modules/` installed by npm (no yarn workspace ambiguity), and an electron-rebuilt `better-sqlite3` binding. electron-builder then packs from `dist-staging/` rather than the workspace-aware `desktop/`.
+4. `electron-builder --mac` — codesigns, notarizes, and writes the DMG.
+
+The staging step exists because electron-builder's `npm list`-based dep walker, when invoked from a yarn-workspace child package, walks up to the workspace root and silently treats the root's hoisted transitives as the app's deps — dropping every package declared in `desktop/package.json`. Staging produces a flat npm project that is unambiguous to inspect.
+
+## Smoke test
+
+Both `release-desktop.yml` and `desktop-smoke.yml` run `yarn smoke:mac` against the packaged `.app` after build. The smoke test launches the app against an isolated `HOME`, settles for 10s, and asserts the main process is still alive with no `Cannot find module` / uncaught-exception patterns in launcher stderr or recent system logs. A failing smoke test blocks the release tag from publishing and blocks PRs that touch `desktop/**` or `relay-server/**`.
 
 ## Local builds vs CI builds
 


### PR DESCRIPTION
## Summary

The packaged DMG since v0.2.x has shipped without `better-sqlite3` (and every other runtime dep declared in `desktop/package.json`), causing an immediate main-process crash on any clean Mac:

```
A JavaScript error occurred in the main process
Error: Cannot find module 'better-sqlite3'
```

### Root cause

electron-builder's npm-based dependency walker. When invoked from a yarn workspace child package, `npm list` walks up to the workspace root and treats the root's hoisted transitives (`node-gyp` + `cacache` + friends) as the app's prod deps — silently dropping `better-sqlite3`, `react`, `react-dom`, `posthog-*`, and `tailwind-merge`. The shipped v0.3.0 `app.asar/node_modules/` contains exactly node-gyp's transitive set and zero of the actual runtime deps.

Ground-truth correction to the v0.3.0-as-regression framing: I downloaded the v0.2.3 DMG and confirmed `better-sqlite3` is missing from its asar too. The codepath at `desktop/src/main/db.ts:10` calls `require("better-sqlite3")` at module load time in both releases. v0.2.3 only worked for the original install because of leftover state on a previous machine, not because the packaging was correct. This isn't a regression introduced by #269 — it's a latent packaging bug that #269 didn't introduce and didn't fix.

### Fix

- New `desktop/scripts/stage-app.mjs` assembles `desktop/dist-staging/` containing `out/`, a minimal `package.json` listing only prod deps, a clean `node_modules/` installed by npm (no workspace ambiguity), and an electron-rebuilt `better-sqlite3` binding for the Electron 41 ABI.
- `electron-builder.yml` sets `directories.app: dist-staging` so electron-builder packs from the staging dir instead of the workspace-aware `desktop/`.
- Adds `asarUnpack: [\"**/node_modules/better-sqlite3/**/*\"]` so the `.node` binary lands at `app.asar.unpacked/` where Electron can dlopen it.
- New `desktop/scripts/smoke-test.mjs` launches the packaged `.app` against an isolated HOME, settles for 10s, and asserts the main process is alive with no `Cannot find module` / uncaught-exception / SIGABRT patterns. Wired into:
  - `release-desktop.yml` — blocks the release tag from publishing if the freshly-signed build is broken.
  - new `desktop-smoke.yml` — runs on every PR/push touching `desktop/**`, `relay-server/**`, or `vendor/openclaw`. Uses an ad-hoc-signed `dir` build (no DMG, no notarize) so it stays cheap.
- Updates `docs/src/content/docs/desktop/releasing.mdx` with the new pipeline stages and the smoke-test gate.

### Verification (local)

Built `desktop/dist/mac-arm64/VoiceClaw.app` via `dist:mac --dir`. Confirmed:

- `app.asar/node_modules/better-sqlite3/` exists with all source files
- `app.asar.unpacked/node_modules/better-sqlite3/build/Release/better_sqlite3.node` is a Mach-O arm64 bundle
- `app.asar/node_modules/` now contains 57 packages (was 50, all node-gyp deps with zero actual runtime deps in v0.3.0)
- `react`, `react-dom`, `tailwind-merge`, `@posthog/core` all present in asar
- App launches via `open` without the JavaScript-error dialog (local launch on the dev box can't fully validate because spctl rejects the ad-hoc signature, but the asar structure is provably correct)

The smoke test will run against the properly-signed-and-notarized build in CI, which is the actual gate.

## Test plan

- [ ] CI `Desktop smoke` workflow passes on this PR
- [ ] After merge, release-please cuts a `desktop-v0.3.1` PR
- [ ] Merging the release-please PR triggers `release-desktop.yml`
- [ ] `release-desktop.yml` smoke-test step passes against the signed+notarized .app
- [ ] `desktop-v0.3.1` GitHub Release publishes with `VoiceClaw-0.3.1-arm64.dmg`
- [ ] DMG installs and launches cleanly on a fresh Mac (or on a Mac without leftover dev state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)