### PR TITLE
feat(mobile): wire release-please version bump + add release-mobile workflow scaffold

### DIFF
--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -1,0 +1,133 @@
+# Build the iOS app and (optionally) submit to TestFlight on mobile tag push.
+#
+# Trigger: push of a tag matching `mobile-v*.*.*` (e.g. `mobile-v1.1.2`).
+# Output: an EAS cloud build for the staging profile, and — if the submit
+#         step is enabled — a TestFlight upload via App Store Connect.
+#
+# STATUS: scaffold. The job will fail until the secrets below are populated
+# in repo Settings -> Secrets and variables -> Actions. Mobile builds today
+# are still produced by running `yarn ios:release:staging` locally on the
+# Mac that holds the Apple developer cert. This workflow exists so the
+# `mobile-v*` tag push (created by release-please) has a downstream listener.
+#
+# Required repository secrets:
+#   EXPO_TOKEN
+#     Personal access token from `eas whoami --token` (after `eas login`).
+#     Authorizes `eas build` and `eas submit` against the EAS account that
+#     owns the `voiceclaw` Expo project.
+#
+# Required for `eas submit` (App Store Connect upload). The desktop release
+# workflow already uses an ASC API key under these secret names, and we
+# reuse them here:
+#   APPLE_API_KEY_P8   Base64-encoded contents of the .p8 file. Generate with
+#                      `base64 -i AuthKey_<ID>.p8 | pbcopy`.
+#   APPLE_API_KEY_ID   The ASC API key id (e.g. `SG645CPQP8`).
+#   APPLE_API_ISSUER   The ASC issuer UUID
+#                      (e.g. `69a6de83-015f-47e3-e053-5b8c7c11a4d1`).
+#
+# `eas.json` -> submit.staging already references
+# `ascApiKeyPath: ~/.appstore/AuthKey_SG645CPQP8.p8`, so the submit step
+# below materializes the .p8 to that path before invoking eas submit.
+#
+# Alternative legacy auth (NOT used by this workflow):
+#   APPLE_ID + APPLE_APP_SPECIFIC_PASSWORD (generated at appleid.apple.com).
+# Only worth setting if the ASC API key path stops working.
+
+name: Release mobile
+
+on:
+  push:
+    tags:
+      - "mobile-v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (must already exist on origin)"
+        required: true
+      submit:
+        description: "Also submit the IPA to TestFlight"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: EAS build (staging)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Trigger EAS build (staging, no-wait)
+        working-directory: mobile
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          npx eas-cli@latest build \
+            --platform ios \
+            --profile staging \
+            --non-interactive \
+            --no-wait
+
+  submit:
+    name: EAS submit (staging)
+    needs: build
+    if: ${{ github.event_name == 'push' || inputs.submit == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Write App Store Connect API key
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          mkdir -p ~/.appstore
+          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > ~/.appstore/AuthKey_${APPLE_API_KEY_ID}.p8
+          chmod 600 ~/.appstore/AuthKey_${APPLE_API_KEY_ID}.p8
+
+      - name: Submit latest staging build to TestFlight
+        working-directory: mobile
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          npx eas-cli@latest submit \
+            --platform ios \
+            --profile staging \
+            --latest \
+            --non-interactive

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -24,7 +24,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: 'VoiceClaw',
   slug: 'voiceclaw',
-  version: '1.0.0',
+  // x-release-please-version
+  version: '1.1.2',
   orientation: 'portrait',
   icon: './assets/images/icon.png',
   scheme: variant.scheme,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -31,7 +31,11 @@
       "package-name": "voiceclaw-mobile",
       "component": "mobile",
       "include-component-in-tag": true,
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        { "type": "generic", "path": "app.config.ts" },
+        { "type": "json", "path": "app.json", "jsonpath": "$.expo.version" }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Why

`mobile/app.config.ts` is the file Expo evaluates at prebuild time for `CFBundleShortVersionString`. release-please bumps `mobile/package.json` and `CHANGELOG.md` but had **no `extra-files` entry** for the mobile package, so every iOS build kept stamping `1.0.0` regardless of what tag was cut. The current TestFlight latest is `1.0.0 (353)` from Apr 27, even though `mobile-v1.1.1` was tagged the same day.

There is also no GitHub Actions workflow listening for `mobile-v*` tags. Mobile ships have always been manual `yarn ios:release:staging` from a Mac with the Apple developer cert.

## What

1. **`mobile/app.config.ts`**: add `// x-release-please-version` annotation and bump `version` to `'1.1.2'`. (Without the bump, ASC would also reject because build 353 is the highest taken and `git rev-list --count HEAD + 50` would collide if no commit landed.)
2. **`release-please-config.json`**: add `extra-files` for the mobile package pointing at `app.config.ts` (generic, uses the annotation) and `app.json` (typed JSON updater with `jsonpath: $.expo.version`). Future release PRs will keep both files in sync with `package.json`.
3. **`.github/workflows/release-mobile.yml`**: scaffold workflow that triggers on `mobile-v*.*.*` tag push (and `workflow_dispatch`). Two jobs:
   - `build`: `eas-cli build --platform ios --profile staging --non-interactive --no-wait`
   - `submit`: writes the ASC API key to `~/.appstore/AuthKey_<ID>.p8` then runs `eas-cli submit --latest`.

## Required GitHub secrets

Existing (already set, used by `release-desktop.yml`, reused here):
- `APPLE_API_KEY_P8` - base64-encoded `.p8` contents
- `APPLE_API_KEY_ID` - e.g. `SG645CPQP8`
- `APPLE_API_ISSUER` - issuer UUID

**Missing - blocks the cloud workflow until set**:
- `EXPO_TOKEN` - generate locally with `eas login` then `eas whoami --token`, set with `gh secret set EXPO_TOKEN --repo yagudaev/voiceclaw`.

Until `EXPO_TOKEN` is populated, the manual local-Mac path remains the only working ship route. This PR does not break that path - `scripts/build-ios.sh` still reads `app.config.ts` via `expo prebuild --clean`, so the version bump flows through naturally on the next local build.

## Manual ship for tonight

```bash
cd /Users/michaelyagudaev/code/voiceclaw/voiceclaw-nan-mobile-pipeline-v2/mobile
yarn ios:release:staging
```

Produces `1.1.2 (376)` (commit count 326 + offset 50) on TestFlight under the staging ASC app.

## Verification done

- `python3 json.load(release-please-config.json)` -> OK
- `python3 yaml.safe_load(release-mobile.yml)` -> OK
- `npx tsc --noEmit` in `mobile/` -> clean
- `APP_VARIANT=staging npx expo config --type prebuild` -> shows `version: '1.1.2'`
- `git diff main --stat` -> only the 3 intended files

## Not done

- No `eas build` / `eas submit` triggered from this PR (no `EXPO_TOKEN` yet).
- No `mobile-v*` tag pushed.
- `actionlint` not installed locally; YAML validated via PyYAML only.