### PR TITLE
chore: post-release main hygiene fixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: "22"
       # The repo root lists `docs` in the yarn workspaces array, so a plain
       # `npm install` inside `docs/` walks up, discovers the other workspaces
       # (notably `desktop` with vite@8), and fails on electron-vite's vite

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,11 +53,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           PRS: ${{ steps.release.outputs.prs }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           echo "$PRS" | jq -c '.[]' | while read -r pr; do
             number=$(echo "$pr" | jq -r '.number')
             echo "Enabling auto-merge on PR #$number"
-            gh pr merge "$number" --auto --squash --delete-branch || \
-              gh pr merge "$number" --auto --squash
+            gh pr merge "$number" --repo "$REPO" --auto --squash --delete-branch || \
+              gh pr merge "$number" --repo "$REPO" --auto --squash
           done


### PR DESCRIPTION
## Why

Audit of `main` after today's heavy merge day (14+ PRs incl. desktop 0.3.0/0.3.1 release flow) surfaced two long-standing CI regressions. Both are tractable one-line fixes.

## Fixes

### 1. `docs.yml`: Node 20 → Node 22

The Pages deploy has failed on **every push touching `docs/`** since Astro 6 landed. Build log:
```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```
Last 10 `Deploy docs to GitHub Pages` runs on main are all red. `desktop-smoke.yml` and `release-desktop.yml` already use Node 22, so this is the workflow nobody had bumped.

### 2. `release-please.yml`: pass `--repo` to `gh pr merge`

The auto-merge step fails when `release-please-action` returns an existing (already-open) release PR rather than creating a new one. `gh pr merge` inspects the local working copy to figure out the remote, but this workflow has no `actions/checkout`, so it explodes with:
```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```
Visible on the runs for `32c8a48` and `3ba6d32` — the actual release downstream (tag push → `release-desktop.yml`) succeeded both times, but the Release-please run shows up red. Adding `--repo "$REPO"` lets gh skip the local-git probe.

## Audit summary (other items)

- `yarn install`: clean (only pre-existing peer-dep warnings)
- `tsc --noEmit` across all 7 workspaces: clean
- `relay-server` vitest: 72 passed + 2 skipped
- `desktop` vitest: 16 passed
- `Desktop smoke` workflow on main: green for both 0.3.0 and 0.3.1
- `vendor/openclaw` submodule: clean pointer at `619b44a`, `pnpm install --frozen-lockfile` works
- `.gitignore` `.scratch/` entry intact (PR #272)
- 0 open Dependabot/Renovate PRs
- 0 stale release-please PRs

## Surfaced (no fix)

- 1 open Dependabot alert: `@anthropic-ai/sdk` GHSA-p7fg-763f-g4gf (medium, "Insecure Default File Permissions in Local Filesystem Memory Tool"). `first_patched_vulnerable_version: null` — no upstream fix available yet. Source: `vendor/openclaw` only, not direct in voiceclaw workspaces.

## Test plan

- [ ] CI green on this PR (commitlint, CodeQL — docs.yml/release-please.yml don't run on PRs)
- [ ] After merge: next push touching `docs/` triggers a green `Deploy docs to GitHub Pages` run
- [ ] After merge: next release-please run that returns an existing PR succeeds at the auto-merge step

🤖 Generated with [Claude Code](https://claude.com/claude-code)