### PR TITLE
fix(desktop): wire bundled service defaults on fresh install (NAN-686)

### DIFF
--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -24,11 +24,19 @@ import {
   showCallBarContextMenu,
 } from './call-bar'
 import { serviceManager } from './services/service-manager'
-import { startBundledOpenClaw } from './services/openclaw-gateway'
+import {
+  applyGeminiKeyToOpenClawConfig,
+  startBundledOpenClaw,
+} from './services/openclaw-gateway'
 import { startBundledRelayServer } from './services/relay-server'
 import { ensureDefault as ensureLaunchAtLoginDefault } from './login-items'
 import { initAutoUpdater } from './updater'
-import { ensureOnboardingSchema, resetOnboarding } from './onboarding'
+import {
+  ensureBundledRelayDefaults,
+  ensureOnboardingSchema,
+  resetOnboarding,
+} from './onboarding'
+import { getProviderKey } from './provider-keys'
 import { registerAuthDeepLink } from './auth'
 import {
   capture as telemetryCapture,
@@ -61,6 +69,16 @@ app.whenReady().then(async () => {
   }
 
   ensureOnboardingSchema()
+  ensureBundledRelayDefaults()
+  // Re-apply the saved Gemini key to the openclaw config on every launch so
+  // a stale or missing entry on disk recovers itself without forcing the
+  // user back through the wizard. No-op when nothing changed.
+  try {
+    const geminiKey = getProviderKey('gemini')
+    if (geminiKey) applyGeminiKeyToOpenClawConfig(geminiKey)
+  } catch (err) {
+    console.warn('[openclaw] failed to re-apply gemini key on launch', err)
+  }
   // Dev escape hatch: VOICECLAW_RESET_ONBOARDING=1 yarn dev wipes the
   // wizard cursor before window creation so the wizard reappears at
   // step 1. Saved keys/devices stay intact.

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -3,10 +3,12 @@ import { getDb } from './db'
 import { isLaunchAtLoginEnabled, setLaunchAtLogin } from './login-items'
 import { serviceManager } from './services/service-manager'
 import { buildRelayEnv } from './services/relay-server'
+import { applyGeminiKeyToOpenClawConfig } from './services/openclaw-gateway'
 import { getAllocatedPorts } from './ports'
 import {
   type OnboardingPayload,
   type WizardStepId,
+  ensureBundledRelayDefaults,
   getOnboardingState,
   markOnboardingComplete,
   resetOnboarding,
@@ -40,6 +42,24 @@ export function registerIpcHandlers() {
   })
   ipcMain.handle('app:getServiceStatuses', () => serviceManager.getAllStatuses())
   ipcMain.handle('app:getServicePorts', () => getAllocatedPorts())
+  ipcMain.handle('app:resetBundledDefaults', async () => {
+    const defaults = ensureBundledRelayDefaults({ force: true })
+    const geminiKey = getProviderKey('gemini')
+    if (geminiKey) {
+      try {
+        applyGeminiKeyToOpenClawConfig(geminiKey)
+      } catch (err) {
+        console.warn('[bundled-defaults] failed to re-apply gemini key', err)
+      }
+    }
+    serviceManager.restart('relay', () => buildRelayEnv()).catch((err) => {
+      console.warn('[bundled-defaults] relay restart failed', err)
+    })
+    serviceManager.restart('openclawGateway').catch((err) => {
+      console.warn('[bundled-defaults] openclaw restart failed', err)
+    })
+    return { ok: true as const, relayApiKey: defaults.relayApiKey }
+  })
 
   // Telemetry. The renderer initializes its own posthog-js client but
   // shares the same distinct_id so a session ties events from main and
@@ -272,6 +292,18 @@ export function registerIpcHandlers() {
         serviceManager.restart('relay', () => buildRelayEnv()).catch((err) => {
           console.warn('[relay] restart after provider key save failed', err)
         })
+        if (provider === 'gemini') {
+          try {
+            const changed = applyGeminiKeyToOpenClawConfig(key)
+            if (changed) {
+              serviceManager.restart('openclawGateway').catch((err) => {
+                console.warn('[openclaw] restart after gemini key save failed', err)
+              })
+            }
+          } catch (err) {
+            console.warn('[openclaw] failed to apply gemini key to config', err)
+          }
+        }
       }
       return { ok: true as const }
     },

--- a/desktop/src/main/onboarding.test.ts
+++ b/desktop/src/main/onboarding.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type Row = { value: string } | undefined
+const settings = new Map<string, string>()
+
+const fakeStmt = {
+  get: (key: string): Row => {
+    const value = settings.get(key)
+    return value === undefined ? undefined : { value }
+  },
+  run: (...args: unknown[]) => {
+    if (args.length === 1) {
+      settings.delete(String(args[0]))
+      return
+    }
+    if (args.length >= 2) {
+      const key = String(args[0])
+      const value = String(args[1])
+      settings.set(key, value)
+    }
+  },
+  all: () => Array.from(settings.entries()).map(([key, value]) => ({ key, value })),
+}
+
+const fakeDb = {
+  exec: () => undefined,
+  prepare: () => fakeStmt,
+}
+
+vi.mock('./db', () => ({
+  getDb: () => fakeDb,
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/voiceclaw-onboarding-test',
+  },
+}))
+
+describe('ensureBundledRelayDefaults', () => {
+  beforeEach(() => {
+    settings.clear()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('mints and persists a uuid when no api key is stored', async () => {
+    const { ensureBundledRelayDefaults } = await import('./onboarding')
+    const result = ensureBundledRelayDefaults()
+    expect(result.relayApiKey).toMatch(/^[0-9a-f-]{36}$/)
+    expect(settings.get('realtime_api_key')).toBe(result.relayApiKey)
+  })
+
+  it('returns the existing key on a second call without rotating it', async () => {
+    settings.set('realtime_api_key', 'preexisting-uuid')
+    const { ensureBundledRelayDefaults } = await import('./onboarding')
+    const result = ensureBundledRelayDefaults()
+    expect(result.relayApiKey).toBe('preexisting-uuid')
+    expect(settings.get('realtime_api_key')).toBe('preexisting-uuid')
+  })
+
+  it('rotates the key and clears realtime_server_url when force=true', async () => {
+    settings.set('realtime_api_key', 'old-uuid')
+    settings.set('realtime_server_url', 'ws://example.com/ws')
+    const { ensureBundledRelayDefaults } = await import('./onboarding')
+    const result = ensureBundledRelayDefaults({ force: true })
+    expect(result.relayApiKey).not.toBe('old-uuid')
+    expect(result.relayApiKey).toMatch(/^[0-9a-f-]{36}$/)
+    expect(settings.has('realtime_server_url')).toBe(false)
+  })
+})
+
+describe('getBundledRelayApiKey', () => {
+  beforeEach(() => {
+    settings.clear()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('returns null when nothing has been seeded yet', async () => {
+    const { getBundledRelayApiKey } = await import('./onboarding')
+    expect(getBundledRelayApiKey()).toBeNull()
+  })
+
+  it('returns the seeded key when present', async () => {
+    settings.set('realtime_api_key', 'baked')
+    const { getBundledRelayApiKey } = await import('./onboarding')
+    expect(getBundledRelayApiKey()).toBe('baked')
+  })
+})

--- a/desktop/src/main/onboarding.ts
+++ b/desktop/src/main/onboarding.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import { getDb } from './db'
 
 // Onboarding state — single-row table (id=1) capturing the wizard's
@@ -104,6 +105,39 @@ export function markOnboardingComplete(): OnboardingState {
   const db = getDb()
   db.prepare('UPDATE onboarding_state SET completed_at = ? WHERE id = 1').run(completedAt)
   return { ...getOnboardingState(), completedAt }
+}
+
+export type BundledDefaults = {
+  relayApiKey: string
+  serverUrlPlaceholder: string | null
+}
+
+export function ensureBundledRelayDefaults(options: { force?: boolean } = {}): BundledDefaults {
+  ensureOnboardingSchema()
+  const db = getDb()
+  const existing = db
+    .prepare('SELECT value FROM settings WHERE key = ?')
+    .get('realtime_api_key') as { value: string } | undefined
+  let apiKey = existing?.value ?? ''
+  if (options.force || !apiKey) {
+    apiKey = randomUUID()
+    db.prepare(
+      'INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?',
+    ).run('realtime_api_key', apiKey, apiKey)
+  }
+  if (options.force) {
+    db.prepare('DELETE FROM settings WHERE key = ?').run('realtime_server_url')
+  }
+  return { relayApiKey: apiKey, serverUrlPlaceholder: null }
+}
+
+export function getBundledRelayApiKey(): string | null {
+  ensureOnboardingSchema()
+  const db = getDb()
+  const row = db
+    .prepare('SELECT value FROM settings WHERE key = ?')
+    .get('realtime_api_key') as { value: string } | undefined
+  return row?.value ?? null
 }
 
 export function resetOnboarding(): OnboardingState {

--- a/desktop/src/main/services/openclaw-gateway.test.ts
+++ b/desktop/src/main/services/openclaw-gateway.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const isPackagedRef = { value: false }
 const existsRef = { fn: (_p: string) => false as boolean }
 const readFileRef = { fn: (_p: string, _enc: string) => '{}' }
+const writes: { path: string; content: string }[] = []
 let originalResourcesPath: string | undefined
 
 vi.mock('electron', () => ({
@@ -19,7 +20,9 @@ vi.mock('fs', () => ({
   copyFileSync: () => undefined,
   mkdirSync: () => undefined,
   readFileSync: (path: string, enc: string) => readFileRef.fn(path, enc),
-  writeFileSync: () => undefined,
+  writeFileSync: (path: string, content: string) => {
+    writes.push({ path, content })
+  },
 }))
 
 describe('resolveBundledOpenClawScript', () => {
@@ -111,5 +114,90 @@ describe('readGatewayAuthToken', () => {
 
     readFileRef.fn = () => JSON.stringify({ gateway: { auth: { token: 123 } } })
     expect(readGatewayAuthToken('/x.json')).toBeNull()
+  })
+})
+
+describe('applyGeminiKeyToOpenClawConfig', () => {
+  beforeEach(() => {
+    writes.length = 0
+    existsRef.fn = () => false
+    readFileRef.fn = () => '{}'
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('writes provider key, primary model, and plugin enable when no config exists', async () => {
+    existsRef.fn = () => false
+    const { applyGeminiKeyToOpenClawConfig, BUNDLED_GOOGLE_PRIMARY_MODEL } = await import(
+      './openclaw-gateway'
+    )
+    const changed = applyGeminiKeyToOpenClawConfig('AIzaTESTKEY')
+    expect(changed).toBe(true)
+    expect(writes.length).toBe(1)
+    const written = JSON.parse(writes[0].content)
+    expect(written.models.providers.google.apiKey).toBe('AIzaTESTKEY')
+    expect(written.agents.defaults.model.primary).toBe(BUNDLED_GOOGLE_PRIMARY_MODEL)
+    expect(written.plugins.entries.google.enabled).toBe(true)
+  })
+
+  it('preserves existing fallbacks when overwriting the primary model', async () => {
+    existsRef.fn = () => true
+    readFileRef.fn = () =>
+      JSON.stringify({
+        agents: {
+          defaults: {
+            model: {
+              primary: 'openai-codex/gpt-5.4',
+              fallbacks: ['claude-cli/claude-haiku-4-5'],
+            },
+          },
+        },
+      })
+    const { applyGeminiKeyToOpenClawConfig, BUNDLED_GOOGLE_PRIMARY_MODEL } = await import(
+      './openclaw-gateway'
+    )
+    applyGeminiKeyToOpenClawConfig('newkey')
+    const written = JSON.parse(writes[0].content)
+    expect(written.agents.defaults.model.primary).toBe(BUNDLED_GOOGLE_PRIMARY_MODEL)
+    expect(written.agents.defaults.model.fallbacks).toEqual(['claude-cli/claude-haiku-4-5'])
+  })
+
+  it('returns false (no write) when the same key is already in place', async () => {
+    existsRef.fn = () => true
+    readFileRef.fn = () =>
+      JSON.stringify({
+        models: {
+          mode: 'merge',
+          providers: { google: { apiKey: 'samekey' } },
+        },
+        agents: {
+          defaults: {
+            model: { primary: 'google/gemini-3.1-pro-preview' },
+          },
+        },
+        plugins: { entries: { google: { enabled: true } } },
+      })
+    const { applyGeminiKeyToOpenClawConfig } = await import('./openclaw-gateway')
+    const changed = applyGeminiKeyToOpenClawConfig('samekey')
+    expect(changed).toBe(false)
+    expect(writes.length).toBe(0)
+  })
+
+  it('does not clobber unrelated channel/auth config blocks', async () => {
+    existsRef.fn = () => true
+    readFileRef.fn = () =>
+      JSON.stringify({
+        channels: { telegram: { enabled: true, botToken: 't' } },
+        auth: { profiles: { 'openai-codex:me': { mode: 'oauth' } } },
+        gateway: { auth: { mode: 'token', token: 'x' } },
+      })
+    const { applyGeminiKeyToOpenClawConfig } = await import('./openclaw-gateway')
+    applyGeminiKeyToOpenClawConfig('k')
+    const written = JSON.parse(writes[0].content)
+    expect(written.channels.telegram.botToken).toBe('t')
+    expect(written.auth.profiles['openai-codex:me'].mode).toBe('oauth')
+    expect(written.gateway.auth.token).toBe('x')
   })
 })

--- a/desktop/src/main/services/openclaw-gateway.ts
+++ b/desktop/src/main/services/openclaw-gateway.ts
@@ -1,8 +1,10 @@
 import { app } from 'electron'
+import { spawn } from 'child_process'
 import { randomUUID } from 'crypto'
 import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { dirname, join } from 'path'
 import { allocatePort } from '../ports'
+import { openLogStream } from '../logs'
 import { resolveBundledNode } from './node-runtime'
 import { serviceManager } from './service-manager'
 
@@ -20,8 +22,16 @@ export async function startBundledOpenClaw(): Promise<void> {
 
   const stateDir = join(app.getPath('userData'), 'openclaw')
   const configPath = join(stateDir, 'openclaw.json')
+  const workspaceDir = join(stateDir, 'workspace')
   ensureSeededConfig(configPath)
   ensureGatewayAuthToken(configPath)
+  await ensureWorkspaceBootstrap({
+    nodePath,
+    scriptPath,
+    stateDir,
+    configPath,
+    workspaceDir,
+  })
 
   const port = await allocatePort('openclawGateway')
 
@@ -65,6 +75,60 @@ export function getOpenClawConfigPath(): string {
   return join(app.getPath('userData'), 'openclaw', 'openclaw.json')
 }
 
+export const BUNDLED_GOOGLE_PRIMARY_MODEL = 'google/gemini-3.1-pro-preview'
+
+export function applyGeminiKeyToOpenClawConfig(geminiKey: string): boolean {
+  const configPath = getOpenClawConfigPath()
+  let parsed: Record<string, unknown> = {}
+  if (existsSync(configPath)) {
+    try {
+      parsed = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>
+    } catch {
+      parsed = {}
+    }
+  } else {
+    mkdirSync(dirname(configPath), { recursive: true })
+  }
+
+  const before = JSON.stringify(parsed)
+
+  const models = (parsed.models as Record<string, unknown> | undefined) ?? {}
+  const providers = (models.providers as Record<string, unknown> | undefined) ?? {}
+  const google = (providers.google as Record<string, unknown> | undefined) ?? {}
+  google.apiKey = geminiKey
+  providers.google = google
+  models.providers = providers
+  if (typeof models.mode !== 'string') models.mode = 'merge'
+  parsed.models = models
+
+  const agents = (parsed.agents as Record<string, unknown> | undefined) ?? {}
+  const defaults = (agents.defaults as Record<string, unknown> | undefined) ?? {}
+  const existingModel = defaults.model as Record<string, unknown> | string | undefined
+  const fallbacks =
+    existingModel && typeof existingModel === 'object' && Array.isArray(existingModel.fallbacks)
+      ? (existingModel.fallbacks as unknown[])
+      : undefined
+  defaults.model = {
+    ...(fallbacks ? { fallbacks } : {}),
+    primary: BUNDLED_GOOGLE_PRIMARY_MODEL,
+  }
+  agents.defaults = defaults
+  parsed.agents = agents
+
+  const plugins = (parsed.plugins as Record<string, unknown> | undefined) ?? {}
+  const entries = (plugins.entries as Record<string, unknown> | undefined) ?? {}
+  const googlePlugin = (entries.google as Record<string, unknown> | undefined) ?? {}
+  googlePlugin.enabled = true
+  entries.google = googlePlugin
+  plugins.entries = entries
+  parsed.plugins = plugins
+
+  const after = JSON.stringify(parsed)
+  if (before === after) return false
+  writeFileSync(configPath, JSON.stringify(parsed, null, 2) + '\n', { mode: 0o600 })
+  return true
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -78,6 +142,63 @@ function ensureSeededConfig(configPath: string): void {
   }
   mkdirSync(dirname(configPath), { recursive: true })
   copyFileSync(template, configPath)
+}
+
+async function ensureWorkspaceBootstrap(params: {
+  nodePath: string
+  scriptPath: string
+  stateDir: string
+  configPath: string
+  workspaceDir: string
+}): Promise<void> {
+  const sentinelPath = join(params.stateDir, 'workspace-bootstrapped')
+  if (existsSync(sentinelPath)) return
+  if (existsSync(join(params.workspaceDir, 'IDENTITY.md'))) {
+    writeFileSync(sentinelPath, new Date().toISOString() + '\n')
+    return
+  }
+  mkdirSync(params.workspaceDir, { recursive: true })
+  const logStream = openLogStream('openclaw-setup.log')
+  logStream.write(`\n[openclaw-setup] running setup at ${new Date().toISOString()}\n`)
+  await new Promise<void>((resolve) => {
+    const child = spawn(
+      params.nodePath,
+      [params.scriptPath, 'setup', '--workspace', params.workspaceDir],
+      {
+        env: {
+          ...process.env,
+          OPENCLAW_STATE_DIR: params.stateDir,
+          OPENCLAW_CONFIG_PATH: params.configPath,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: false,
+      },
+    )
+    child.stdout?.pipe(logStream, { end: false })
+    child.stderr?.pipe(logStream, { end: false })
+    let settled = false
+    const settle = (note: string) => {
+      if (settled) return
+      settled = true
+      clearTimeout(killTimer)
+      logStream.write(`\n[openclaw-setup] ${note}\n`)
+      resolve()
+    }
+    const killTimer = setTimeout(() => {
+      try {
+        child.kill('SIGTERM')
+      } catch {
+        // best-effort
+      }
+      settle('timed out after 30s; gateway will still start with partial bootstrap')
+    }, 30_000)
+    killTimer.unref()
+    child.once('error', (err) => settle(`spawn error: ${err.message}`))
+    child.once('exit', (code) => settle(`exit code=${code ?? 'null'}`))
+  })
+  if (existsSync(join(params.workspaceDir, 'IDENTITY.md'))) {
+    writeFileSync(sentinelPath, new Date().toISOString() + '\n')
+  }
 }
 
 function resolveConfigTemplate(): string | null {

--- a/desktop/src/main/services/relay-server.test.ts
+++ b/desktop/src/main/services/relay-server.test.ts
@@ -4,6 +4,7 @@ const isPackagedRef = { value: false }
 const existsRef = { fn: (_p: string) => false as boolean }
 const tokenRef = { value: null as string | null }
 const providerKeysRef = { fn: (_p: 'gemini' | 'openai' | 'xai') => null as string | null }
+const bundledRelayKeyRef = { value: null as string | null }
 let originalResourcesPath: string | undefined
 
 vi.mock('electron', () => ({
@@ -20,6 +21,10 @@ vi.mock('fs', () => ({
 
 vi.mock('../provider-keys', () => ({
   getProviderKey: (provider: 'gemini' | 'openai' | 'xai') => providerKeysRef.fn(provider),
+}))
+
+vi.mock('../onboarding', () => ({
+  getBundledRelayApiKey: () => bundledRelayKeyRef.value,
 }))
 
 vi.mock('./openclaw-gateway', () => ({
@@ -104,6 +109,7 @@ describe('buildRelayEnv', () => {
     delete process.env.TAVILY_API_KEY
     tokenRef.value = null
     providerKeysRef.fn = () => null
+    bundledRelayKeyRef.value = null
   })
 
   afterEach(() => {
@@ -141,5 +147,20 @@ describe('buildRelayEnv', () => {
     const { buildRelayEnv } = await import('./relay-server')
     const env = buildRelayEnv()
     expect(env.BRAIN_GATEWAY_AUTH_TOKEN).toBe('env-token')
+  })
+
+  it('injects RELAY_API_KEY from the bundled-defaults store when env is empty', async () => {
+    bundledRelayKeyRef.value = 'shared-secret-uuid'
+    const { buildRelayEnv } = await import('./relay-server')
+    const env = buildRelayEnv()
+    expect(env.RELAY_API_KEY).toBe('shared-secret-uuid')
+  })
+
+  it('does not override an explicit RELAY_API_KEY env value', async () => {
+    process.env.RELAY_API_KEY = 'env-relay-key'
+    bundledRelayKeyRef.value = 'bundled-uuid'
+    const { buildRelayEnv } = await import('./relay-server')
+    const env = buildRelayEnv()
+    expect(env.RELAY_API_KEY).toBe('env-relay-key')
   })
 })

--- a/desktop/src/main/services/relay-server.ts
+++ b/desktop/src/main/services/relay-server.ts
@@ -2,6 +2,7 @@ import { app } from 'electron'
 import { existsSync } from 'fs'
 import { join } from 'path'
 import { allocatePort } from '../ports'
+import { getBundledRelayApiKey } from '../onboarding'
 import { getProviderKey, type ProviderId } from '../provider-keys'
 import { resolveBundledNode } from './node-runtime'
 import { getOpenClawConfigPath, readGatewayAuthToken } from './openclaw-gateway'
@@ -53,6 +54,10 @@ export function buildRelayEnv(): NodeJS.ProcessEnv {
   if (!env.BRAIN_GATEWAY_AUTH_TOKEN) {
     const token = readGatewayAuthToken(getOpenClawConfigPath())
     if (token) env.BRAIN_GATEWAY_AUTH_TOKEN = token
+  }
+  if (!env.RELAY_API_KEY) {
+    const bundledKey = getBundledRelayApiKey()
+    if (bundledKey) env.RELAY_API_KEY = bundledKey
   }
   // Tavily is stored in the renderer-side settings KV today, not the
   // provider-keys vault, so the relay reads it from process.env via the

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -42,6 +42,11 @@ const electronAPI = {
       >,
     getServicePorts: () =>
       ipcRenderer.invoke('app:getServicePorts') as Promise<Record<string, number>>,
+    resetBundledDefaults: () =>
+      ipcRenderer.invoke('app:resetBundledDefaults') as Promise<{
+        ok: true
+        relayApiKey: string
+      }>,
   },
   tray: {
     setCallActive: (active: boolean) =>

--- a/desktop/src/renderer/src/pages/SettingsPage.tsx
+++ b/desktop/src/renderer/src/pages/SettingsPage.tsx
@@ -45,9 +45,11 @@ export function SettingsPage() {
   const [serverUrl, setServerUrl] = useState('')
   const [serverUrlPlaceholder, setServerUrlPlaceholder] = useState('ws://localhost:8080/ws')
   const [apiKey, setApiKey] = useState('')
+  const [apiKeyPlaceholder, setApiKeyPlaceholder] = useState('Enter your API key')
   const [showApiKey, setShowApiKey] = useState(false)
   const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'ok' | 'error'>('idle')
   const [testError, setTestError] = useState('')
+  const [resetting, setResetting] = useState(false)
 
   // Web Search (Tavily) — when enabled AND a key is set, the realtime model
   // gets a fast web_search tool alongside ask_brain. Stored as plain settings
@@ -95,7 +97,10 @@ export function SettingsPage() {
         // Keep the static fallback placeholder.
       }
       const key = await getSetting('realtime_api_key')
-      if (key) setApiKey(key)
+      if (key) {
+        setApiKey(key)
+        setApiKeyPlaceholder(maskKey(key))
+      }
       const tk = await getSetting('tavily_api_key')
       if (tk) setTavilyKey(tk)
       // Default to enabled. Only treat the explicit string 'false' as off so
@@ -235,6 +240,26 @@ export function SettingsPage() {
     await setOptedOutRenderer(!v)
   }, [])
 
+  const resetBundled = useCallback(async () => {
+    setResetting(true)
+    try {
+      const result = await window.electronAPI?.app?.resetBundledDefaults?.()
+      if (result?.ok) {
+        setApiKey(result.relayApiKey)
+        setApiKeyPlaceholder(maskKey(result.relayApiKey))
+        setSetting('realtime_api_key', result.relayApiKey)
+        setServerUrl('')
+        setSetting('realtime_server_url', '')
+        setTestStatus('idle')
+        setTestError('')
+      }
+    } catch (err) {
+      console.warn('[SettingsPage] resetBundled failed', err)
+    } finally {
+      setResetting(false)
+    }
+  }, [])
+
   const testConnection = useCallback(async () => {
     setTestStatus('testing')
     setTestError('')
@@ -292,7 +317,7 @@ export function SettingsPage() {
                   type={showApiKey ? 'text' : 'password'}
                   value={apiKey}
                   onChange={(e) => updateApiKey(e.target.value)}
-                  placeholder="Enter your API key"
+                  placeholder={apiKeyPlaceholder}
                   className="pr-10"
                 />
                 <button
@@ -310,6 +335,15 @@ export function SettingsPage() {
             error={testError}
             onTest={testConnection}
           />
+
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-muted-foreground">
+              Bundled relay running at <code className="rounded bg-muted px-1 py-0.5">{serverUrlPlaceholder}</code>
+            </span>
+            <Button variant="ghost" size="sm" onClick={resetBundled} disabled={resetting}>
+              {resetting ? 'Resetting…' : 'Reset to bundled defaults'}
+            </Button>
+          </div>
         </Card>
 
         {/* Web Search */}
@@ -555,6 +589,11 @@ export function SettingsPage() {
       </div>
     </div>
   )
+}
+
+function maskKey(key: string): string {
+  if (key.length <= 8) return '••••••••'
+  return `${key.slice(0, 4)}…${key.slice(-4)}`
 }
 
 function isRealtimeModel(model: string | null): model is RealtimeModel {


### PR DESCRIPTION
## Summary

Fresh-install desktop opens to "unauthorized" because the bundled relay never receives a shared secret, the bundled openclaw never receives the wizard's Gemini key, and `~/Library/Application Support/voiceclaw-desktop/openclaw/workspace/` is empty so the brain ships dead-eyed even after a working WS connection.

This PR closes both **NAN-686** (relay-side unauthorized) and **NAN-687** (openclaw bootstrap missing) so v0.3.3 ships a usable fresh install.

## Root cause

1. **Relay unauthorized:** `realtime_api_key` setting is unset on fresh install → renderer sends `apiKey: ""` in `session.config` → relay's `if (!config.apiKey || ...)` check rejects with `unauthorized`.
2. **OpenClaw config never primed:** `provider:validateAndSave` saves the Gemini key to the keychain but never propagates it to `userData/openclaw/openclaw.json`. The bundled openclaw boots with no provider auth.
3. **Workspace bootstrap missing:** `userData/openclaw/workspace/` starts empty, so `loadAgentIdentity()` falls back to a generic 100-char `"You are <name>, a personal AI assistant"` instead of the ~3000-char SOUL+IDENTITY content.

## Fix

- Mint a per-install relay shared secret on first launch (`ensureBundledRelayDefaults` in `onboarding.ts`). Persist it both as `settings.realtime_api_key` (renderer reads it for `session.config`) and inject it as `RELAY_API_KEY` env into the bundled relay (`buildRelayEnv`). Both ends share one secret without ever shipping a hardcoded default.
- On `provider:validateAndSave` for `gemini`, mirror the key into `userData/openclaw/openclaw.json` under `models.providers.google.apiKey`, set `agents.defaults.model.primary = google/gemini-3.1-pro-preview` (verified in `vendor/openclaw/extensions/google/onboard.ts`), enable the google plugin, then restart both the relay and openclaw services.
- Re-apply the saved Gemini key to the openclaw config on every launch so a stale or missing entry recovers itself without forcing the user back through the wizard.
- Run `openclaw setup --workspace <userData>/openclaw/workspace` once during gateway warmup with a 30s safety timeout. This invokes openclaw's own `ensureAgentWorkspace({ ensureBootstrapFiles: true })`, which writes AGENTS.md / SOUL.md / IDENTITY.md / TOOLS.md / USER.md / HEARTBEAT.md / BOOTSTRAP.md from openclaw's bundled templates. Sentinel file (`workspace-bootstrapped`) prevents repeat invocation on subsequent launches.
- New `app:resetBundledDefaults` IPC + Settings button. Force-rotates the relay api key, clears the user's custom server URL, re-applies the gemini key to openclaw, and restarts both services. Surfaces the bundled-defaults repair path the ticket asked for.
- Settings UI now shows the actual bundled relay URL (`ws://127.0.0.1:<allocated-port>/ws`) and the masked api key in placeholders so a fresh install no longer looks empty.

## Verification

- `yarn workspace voiceclaw-desktop tsc --noEmit` clean.
- `yarn workspace voiceclaw-desktop test --run`: 27 passed (was 16; +11 new tests covering `ensureBundledRelayDefaults`, `getBundledRelayApiKey`, `applyGeminiKeyToOpenClawConfig`, `RELAY_API_KEY` env wiring, and config-preservation invariants).
- `yarn workspace voiceclaw-desktop build`: clean.
- `yarn workspace relay-server test --run`: 72 passed.

## Open follow-ups for the user to test on actual fresh-Mac install

1. After download + first launch, complete onboarding entering a real Gemini key. Click Start Call. Should connect (no `unauthorized`).
2. `~/Library/Application Support/voiceclaw-desktop/openclaw/workspace/` should contain `IDENTITY.md`, `SOUL.md`, etc. after the first launch (not after wizard completion — it bootstraps when the gateway warms up).
3. The brain reply should reflect SOUL/IDENTITY content, not the generic fallback.
4. Settings → Reset to bundled defaults should rotate the relay key and bring services back up cleanly.

## Test plan

- [x] `yarn workspace voiceclaw-desktop test --run`
- [x] `yarn workspace voiceclaw-desktop tsc --noEmit`
- [x] `yarn workspace voiceclaw-desktop build`
- [ ] CI smoke test (PR #274 infra) on packaged app
- [ ] Manual fresh-install on an unused Mac userData dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)