### PR TITLE
feat(desktop): wizard captures agent name + voice + greets out loud

### DIFF
--- a/desktop/src/main/identity.test.ts
+++ b/desktop/src/main/identity.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const writes: { path: string; content: string }[] = []
+const fileSystem = new Map<string, string>()
+
+vi.mock('fs', () => ({
+  existsSync: (path: string) => fileSystem.has(path),
+  mkdirSync: () => undefined,
+  readFileSync: (path: string) => fileSystem.get(path) ?? '',
+  writeFileSync: (path: string, content: string) => {
+    writes.push({ path, content })
+    fileSystem.set(path, content)
+  },
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/voiceclaw-identity-test',
+  },
+  net: {
+    fetch: () => {
+      throw new Error('net.fetch not stubbed in this test')
+    },
+  },
+}))
+
+describe('writeAgentIdentity', () => {
+  beforeEach(() => {
+    writes.length = 0
+    fileSystem.clear()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('renders all four required fields with the user-supplied values', async () => {
+    const { writeAgentIdentity } = await import('./identity')
+    const result = writeAgentIdentity({
+      name: 'Pam',
+      description: 'Friendly and calm.',
+      voice: 'Aoede',
+    })
+    expect(result.name).toBe('Pam')
+    expect(result.description).toBe('Friendly and calm.')
+    expect(result.voice).toBe('Aoede')
+    expect(writes[0].content).toContain('**Name:** Pam')
+    expect(writes[0].content).toContain('**Vibe:** Friendly and calm.')
+    expect(writes[0].content).toContain('**Voice:** Aoede')
+    expect(writes[0].content).toContain('**Creature:** Personal voice companion')
+  })
+
+  it('falls back to defaults when fields are blank', async () => {
+    const { writeAgentIdentity, DEFAULT_IDENTITY } = await import('./identity')
+    const result = writeAgentIdentity({})
+    expect(result.name).toBe(DEFAULT_IDENTITY.name)
+    expect(result.description).toBe(DEFAULT_IDENTITY.description)
+    expect(result.voice).toBe(DEFAULT_IDENTITY.voice)
+    expect(writes[0].content).toContain(`**Name:** ${DEFAULT_IDENTITY.name}`)
+  })
+
+  it('trims whitespace and tolerates partial patches', async () => {
+    const { writeAgentIdentity, DEFAULT_IDENTITY } = await import('./identity')
+    const result = writeAgentIdentity({ name: '  Beatrix  ', voice: 'Kore' })
+    expect(result.name).toBe('Beatrix')
+    expect(result.voice).toBe('Kore')
+    expect(result.description).toBe(DEFAULT_IDENTITY.description)
+  })
+})
+
+describe('readAgentIdentity', () => {
+  beforeEach(() => {
+    writes.length = 0
+    fileSystem.clear()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('returns defaults when no IDENTITY.md exists', async () => {
+    const { readAgentIdentity, DEFAULT_IDENTITY } = await import('./identity')
+    const id = readAgentIdentity()
+    expect(id).toEqual(DEFAULT_IDENTITY)
+  })
+
+  it('parses Name / Vibe / Voice fields from a written file', async () => {
+    const { writeAgentIdentity, readAgentIdentity } = await import('./identity')
+    writeAgentIdentity({ name: 'Sage', description: 'Quiet and dry.', voice: 'Charon' })
+    const id = readAgentIdentity()
+    expect(id.name).toBe('Sage')
+    expect(id.description).toBe('Quiet and dry.')
+    expect(id.voice).toBe('Charon')
+  })
+})

--- a/desktop/src/main/identity.ts
+++ b/desktop/src/main/identity.ts
@@ -1,0 +1,119 @@
+import { app, net } from 'electron'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
+export type AgentIdentity = {
+  name: string
+  description: string
+  voice: string
+}
+
+export const DEFAULT_IDENTITY: AgentIdentity = {
+  name: 'Pam',
+  description: 'Friendly, calm, helps me stay on top of things.',
+  voice: 'Aoede',
+}
+
+export function getWorkspaceDir(): string {
+  return join(app.getPath('userData'), 'openclaw', 'workspace')
+}
+
+export function getIdentityPath(): string {
+  return join(getWorkspaceDir(), 'IDENTITY.md')
+}
+
+export function readAgentIdentity(): AgentIdentity {
+  const path = getIdentityPath()
+  if (!existsSync(path)) return { ...DEFAULT_IDENTITY }
+  let content = ''
+  try {
+    content = readFileSync(path, 'utf8')
+  } catch {
+    return { ...DEFAULT_IDENTITY }
+  }
+  return {
+    name: readField(content, 'Name') || DEFAULT_IDENTITY.name,
+    description: readField(content, 'Vibe') || DEFAULT_IDENTITY.description,
+    voice: readField(content, 'Voice') || DEFAULT_IDENTITY.voice,
+  }
+}
+
+export function writeAgentIdentity(identity: Partial<AgentIdentity>): AgentIdentity {
+  const merged: AgentIdentity = {
+    name: identity.name?.trim() || DEFAULT_IDENTITY.name,
+    description: identity.description?.trim() || DEFAULT_IDENTITY.description,
+    voice: identity.voice?.trim() || DEFAULT_IDENTITY.voice,
+  }
+  const dir = getWorkspaceDir()
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(getIdentityPath(), renderIdentityMarkdown(merged), { mode: 0o600 })
+  return merged
+}
+
+export async function speakGreetingPreview(params: {
+  apiKey: string
+  voice: string
+  text: string
+}): Promise<{ ok: true; audioBase64: string; mimeType: string } | { ok: false; error: string }> {
+  if (!params.apiKey) return { ok: false, error: 'No Gemini key configured.' }
+  const url =
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:generateContent'
+  try {
+    const response = await net.fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': params.apiKey,
+      },
+      body: JSON.stringify({
+        contents: [{ role: 'user', parts: [{ text: params.text }] }],
+        generationConfig: {
+          responseModalities: ['AUDIO'],
+          speechConfig: {
+            voiceConfig: {
+              prebuiltVoiceConfig: { voiceName: params.voice },
+            },
+          },
+        },
+      }),
+    })
+    if (!response.ok) {
+      const errText = await response.text().catch(() => '')
+      return { ok: false, error: `TTS ${response.status}: ${errText.slice(0, 200)}` }
+    }
+    const body = (await response.json()) as {
+      candidates?: { content?: { parts?: { inlineData?: { data?: string; mimeType?: string } }[] } }[]
+    }
+    const inline = body.candidates?.[0]?.content?.parts?.find((p) => p.inlineData)?.inlineData
+    if (!inline?.data) return { ok: false, error: 'TTS response missing audio data.' }
+    return {
+      ok: true,
+      audioBase64: inline.data,
+      mimeType: inline.mimeType ?? 'audio/L16;rate=24000',
+    }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'TTS request failed.' }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderIdentityMarkdown(identity: AgentIdentity): string {
+  return [
+    '# IDENTITY.md - Who Am I?',
+    '',
+    `- **Name:** ${identity.name}`,
+    `- **Creature:** Personal voice companion`,
+    `- **Vibe:** ${identity.description}`,
+    `- **Voice:** ${identity.voice}`,
+    '',
+  ].join('\n')
+}
+
+function readField(content: string, field: string): string | null {
+  const re = new RegExp(`^[-*]\\s*\\*\\*${field}:?\\*\\*\\s*(.+?)\\s*$`, 'mi')
+  const match = content.match(re)
+  return match ? match[1].trim() : null
+}

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -4,6 +4,12 @@ import { isLaunchAtLoginEnabled, setLaunchAtLogin } from './login-items'
 import { serviceManager } from './services/service-manager'
 import { buildRelayEnv } from './services/relay-server'
 import { applyGeminiKeyToOpenClawConfig } from './services/openclaw-gateway'
+import {
+  type AgentIdentity,
+  readAgentIdentity,
+  speakGreetingPreview,
+  writeAgentIdentity,
+} from './identity'
 import { getAllocatedPorts } from './ports'
 import {
   type OnboardingPayload,
@@ -314,6 +320,32 @@ export function registerIpcHandlers() {
 
   // Brain detection
   ipcMain.handle('brain:detect', () => detectBrains())
+
+  // Agent identity (name, description, voice) — persisted as IDENTITY.md
+  // in the bundled openclaw workspace so the relay's instruction builder
+  // picks it up without an extra config bridge.
+  ipcMain.handle('identity:get', () => readAgentIdentity())
+  ipcMain.handle('identity:save', (_e, patch: Partial<AgentIdentity>) => {
+    const saved = writeAgentIdentity(patch)
+    if (saved.voice) {
+      const db = getDb()
+      db.prepare(
+        'INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?',
+      ).run('realtime_voice', saved.voice, saved.voice)
+    }
+    serviceManager.restart('relay', () => buildRelayEnv()).catch((err) => {
+      console.warn('[relay] restart after identity save failed', err)
+    })
+    return saved
+  })
+  ipcMain.handle(
+    'identity:speakPreview',
+    async (_e, params: { voice: string; text: string }) => {
+      const apiKey = getProviderKey('gemini')
+      if (!apiKey) return { ok: false as const, error: 'No Gemini key configured.' }
+      return speakGreetingPreview({ apiKey, voice: params.voice, text: params.text })
+    },
+  )
 
   // Network: test relay server connection from main process (avoids CORS)
   ipcMain.handle('net:healthCheck', async (_e, url: string) => {

--- a/desktop/src/main/onboarding.ts
+++ b/desktop/src/main/onboarding.ts
@@ -13,6 +13,7 @@ export type WizardStepId =
   | 'permissions'
   | 'provider'
   | 'brain'
+  | 'identity'
   | 'testcall'
 
 export type OnboardingPayload = {
@@ -24,6 +25,11 @@ export type OnboardingPayload = {
   provider?: 'gemini' | 'openai' | 'xai'
   providerKeyValidated?: boolean
   brain?: 'openclaw' | 'claude' | 'codex' | { url: string }
+  identity?: {
+    name?: string
+    description?: string
+    voice?: string
+  }
   user?: { id?: string; email?: string | null; name?: string | null }
 }
 

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -8,6 +8,7 @@ type WizardStepId =
   | 'permissions'
   | 'provider'
   | 'brain'
+  | 'identity'
   | 'testcall'
 
 type OnboardingPayload = {
@@ -19,6 +20,7 @@ type OnboardingPayload = {
   provider?: 'gemini' | 'openai' | 'xai'
   providerKeyValidated?: boolean
   brain?: 'openclaw' | 'claude' | 'codex' | { url: string }
+  identity?: { name?: string; description?: string; voice?: string }
   user?: { id?: string; email?: string | null; name?: string | null }
 }
 
@@ -155,6 +157,25 @@ const electronAPI = {
         claude: { available: boolean; path?: string }
         codex: { available: boolean; path?: string }
       }>,
+  },
+  identity: {
+    get: () =>
+      ipcRenderer.invoke('identity:get') as Promise<{
+        name: string
+        description: string
+        voice: string
+      }>,
+    save: (patch: { name?: string; description?: string; voice?: string }) =>
+      ipcRenderer.invoke('identity:save', patch) as Promise<{
+        name: string
+        description: string
+        voice: string
+      }>,
+    speakPreview: (params: { voice: string; text: string }) =>
+      ipcRenderer.invoke('identity:speakPreview', params) as Promise<
+        | { ok: true; audioBase64: string; mimeType: string }
+        | { ok: false; error: string }
+      >,
   },
   screen: {
     getSources: () =>

--- a/desktop/src/renderer/src/lib/onboarding-api.ts
+++ b/desktop/src/renderer/src/lib/onboarding-api.ts
@@ -7,6 +7,7 @@ export type WizardStepId =
   | 'permissions'
   | 'provider'
   | 'brain'
+  | 'identity'
   | 'testcall'
 
 export type ProviderId = 'gemini' | 'openai' | 'xai'
@@ -18,6 +19,12 @@ export type PermissionStatus =
   | 'restricted'
   | 'unknown'
 
+export type AgentIdentityPatch = {
+  name?: string
+  description?: string
+  voice?: string
+}
+
 export type OnboardingPayload = {
   signedIn?: boolean
   permissions?: {
@@ -27,6 +34,7 @@ export type OnboardingPayload = {
   provider?: ProviderId
   providerKeyValidated?: boolean
   brain?: 'openclaw' | 'claude' | 'codex' | { url: string }
+  identity?: AgentIdentityPatch
   user?: { id?: string; email?: string | null; name?: string | null }
 }
 
@@ -75,6 +83,18 @@ declare global {
       brain: {
         detect: () => Promise<BrainDetection>
       }
+      identity: {
+        get: () => Promise<{ name: string; description: string; voice: string }>
+        save: (patch: AgentIdentityPatch) => Promise<{
+          name: string
+          description: string
+          voice: string
+        }>
+        speakPreview: (params: { voice: string; text: string }) => Promise<
+          | { ok: true; audioBase64: string; mimeType: string }
+          | { ok: false; error: string }
+        >
+      }
     }
   }
 }
@@ -107,4 +127,11 @@ export const providerApi = {
 
 export const brainApi = {
   detect: () => window.electronAPI.brain.detect(),
+}
+
+export const identityApi = {
+  get: () => window.electronAPI.identity.get(),
+  save: (patch: AgentIdentityPatch) => window.electronAPI.identity.save(patch),
+  speakPreview: (params: { voice: string; text: string }) =>
+    window.electronAPI.identity.speakPreview(params),
 }

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -89,6 +89,8 @@ export function ChatPage() {
     })
   }, [])
 
+  const greetingTriggeredRef = useRef(false)
+
   const loadLatestConversation = async () => {
     const conv = await getLatestConversation()
     if (conv) {
@@ -268,6 +270,19 @@ export function ChatPage() {
       tracingEnabled,
     })
   }, [realtime, outputGain])
+
+  useEffect(() => {
+    if (greetingTriggeredRef.current) return
+    greetingTriggeredRef.current = true
+    void (async () => {
+      const pending = await getSetting('pending_greeting')
+      if (pending !== 'true') return
+      await setSetting('pending_greeting', 'false')
+      setTimeout(() => {
+        if (!isCallActive && !isConnecting) startCall()
+      }, 600)
+    })()
+  }, [isCallActive, isConnecting, startCall])
 
   const endCall = useCallback(() => {
     realtime.stop()

--- a/desktop/src/renderer/src/pages/SettingsPage.tsx
+++ b/desktop/src/renderer/src/pages/SettingsPage.tsx
@@ -5,6 +5,7 @@ import { Card } from '../components/ui/Card'
 import { Input } from '../components/ui/Input'
 import { Select } from '../components/ui/Select'
 import { Toggle } from '../components/ui/Toggle'
+import { identityApi } from '../lib/onboarding-api'
 import { useTheme, type Theme } from '../lib/use-theme'
 import { enumerateAudioDevices, type AudioDevice } from '../lib/audio-engine'
 import { getSetting, setSetting } from '../lib/db'
@@ -77,6 +78,11 @@ export function SettingsPage() {
   const [showLatency, setShowLatency] = useState(false)
   const [tracingEnabled, setTracingEnabled] = useState(false)
 
+  // Agent identity (name + description)
+  const [agentName, setAgentName] = useState('')
+  const [agentDescription, setAgentDescription] = useState('')
+  const identityLoadedRef = useRef(false)
+
   // Privacy / telemetry
   const [telemetryEnabled, setTelemetryEnabled] = useState(true)
 
@@ -130,6 +136,15 @@ export function SettingsPage() {
       if (sl === 'true') setShowLatency(true)
       const tr = await getSetting('tracing_enabled')
       if (tr === 'true') setTracingEnabled(true)
+
+      try {
+        const id = await identityApi.get()
+        setAgentName(id.name)
+        setAgentDescription(id.description)
+      } catch {
+        // identity bridge unavailable — leave defaults
+      }
+      identityLoadedRef.current = true
 
       const optedOut = await isOptedOutRenderer()
       setTelemetryEnabled(!optedOut)
@@ -234,6 +249,36 @@ export function SettingsPage() {
     setTracingEnabled(v)
     setSetting('tracing_enabled', v ? 'true' : 'false')
   }, [])
+
+  const persistIdentity = useCallback(
+    (next: { name?: string; description?: string }) => {
+      if (!identityLoadedRef.current) return
+      identityApi
+        .save({
+          name: next.name ?? agentName,
+          description: next.description ?? agentDescription,
+          voice,
+        })
+        .catch((err) => console.warn('[settings] identity save failed', err))
+    },
+    [agentName, agentDescription, voice],
+  )
+
+  const updateAgentName = useCallback(
+    (v: string) => {
+      setAgentName(v)
+      persistIdentity({ name: v })
+    },
+    [persistIdentity],
+  )
+
+  const updateAgentDescription = useCallback(
+    (v: string) => {
+      setAgentDescription(v)
+      persistIdentity({ description: v })
+    },
+    [persistIdentity],
+  )
 
   const toggleTelemetry = useCallback(async (v: boolean) => {
     setTelemetryEnabled(v)
@@ -343,6 +388,32 @@ export function SettingsPage() {
             <Button variant="ghost" size="sm" onClick={resetBundled} disabled={resetting}>
               {resetting ? 'Resetting…' : 'Reset to bundled defaults'}
             </Button>
+          </div>
+        </Card>
+
+        {/* Identity */}
+        <Card className="p-4 space-y-4">
+          <h3 className="text-sm font-semibold text-foreground">Agent Identity</h3>
+          <div className="space-y-1.5">
+            <label className="text-xs text-muted-foreground">Name</label>
+            <Input
+              value={agentName}
+              onChange={(e) => updateAgentName(e.target.value)}
+              placeholder="Pam"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label className="text-xs text-muted-foreground">Description</label>
+            <textarea
+              value={agentDescription}
+              onChange={(e) => updateAgentDescription(e.target.value)}
+              placeholder="Friendly, calm, helps me stay on top of things."
+              rows={2}
+              className="w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm leading-snug outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            />
+            <p className="text-[11px] text-muted-foreground">
+              Used in the agent's system prompt. Saved as IDENTITY.md in the bundled openclaw workspace.
+            </p>
           </div>
         </Card>
 

--- a/desktop/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/desktop/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -5,7 +5,9 @@ import { StepSignIn } from './StepSignIn'
 import { StepPermissions } from './StepPermissions'
 import { StepProvider } from './StepProvider'
 import { StepBrain } from './StepBrain'
+import { StepIdentity } from './StepIdentity'
 import { StepTestCall } from './StepTestCall'
+import { identityApi } from '../../lib/onboarding-api'
 import {
   onboarding,
   type OnboardingPayload,
@@ -15,7 +17,15 @@ import {
 
 export type { WizardStepId }
 
-const STEPS: WizardStepId[] = ['welcome', 'signin', 'permissions', 'provider', 'brain', 'testcall']
+const STEPS: WizardStepId[] = [
+  'welcome',
+  'signin',
+  'permissions',
+  'provider',
+  'brain',
+  'identity',
+  'testcall',
+]
 
 type Props = {
   initialState?: OnboardingState
@@ -74,6 +84,7 @@ export function OnboardingWizard({ initialState, onComplete, previewMode = false
             await onboarding.updateStep('testcall', patch)
           }
           await onboarding.complete()
+          await window.electronAPI.db.setSetting('pending_greeting', 'true')
         } catch (err) {
           console.warn('[onboarding] complete failed', err)
         }
@@ -140,6 +151,18 @@ export function OnboardingWizard({ initialState, onComplete, previewMode = false
           previewMode={previewMode}
         />
       )
+    case 'identity':
+      return (
+        <StepIdentity
+          onContinue={(patch) => {
+            void persistIdentity(patch.identity, previewMode).then(() => next(patch))
+          }}
+          onBack={back}
+          onStartOver={startOver}
+          initialIdentity={payload.identity ?? {}}
+          previewMode={previewMode}
+        />
+      )
     case 'testcall':
       return (
         <StepTestCall
@@ -177,4 +200,16 @@ function resolveInitialBrainId(
   if (!brain) return 'openclaw'
   if (typeof brain === 'object') return 'custom'
   return brain
+}
+
+async function persistIdentity(
+  identity: OnboardingPayload['identity'],
+  previewMode: boolean,
+): Promise<void> {
+  if (previewMode || !identity) return
+  try {
+    await identityApi.save(identity)
+  } catch (err) {
+    console.warn('[onboarding] identity save failed', err)
+  }
 }

--- a/desktop/src/renderer/src/pages/onboarding/StepIdentity.tsx
+++ b/desktop/src/renderer/src/pages/onboarding/StepIdentity.tsx
@@ -1,0 +1,293 @@
+import { useEffect, useRef, useState } from 'react'
+import { StepFrame } from './StepFrame'
+import { identityApi, type OnboardingPayload } from '../../lib/onboarding-api'
+
+const GEMINI_VOICES = [
+  { id: 'Aoede', label: 'Aoede (F) — warm, conversational', preview: "Hi, I'm here." },
+  { id: 'Kore', label: 'Kore (F) — calm, focused', preview: "Hi, I'm here." },
+  { id: 'Leda', label: 'Leda (F) — bright, friendly', preview: "Hi, I'm here." },
+  { id: 'Zephyr', label: 'Zephyr (F) — soft, thoughtful', preview: "Hi, I'm here." },
+  { id: 'Puck', label: 'Puck (M) — playful, quick', preview: "Hi, I'm here." },
+  { id: 'Charon', label: 'Charon (M) — grounded, steady', preview: "Hi, I'm here." },
+  { id: 'Fenrir', label: 'Fenrir (M) — direct, confident', preview: "Hi, I'm here." },
+  { id: 'Orus', label: 'Orus (M) — measured, low', preview: "Hi, I'm here." },
+] as const
+
+const DEFAULT_NAME = 'Pam'
+const DEFAULT_DESCRIPTION = 'Friendly, calm, helps me stay on top of things.'
+const DEFAULT_VOICE = 'Aoede'
+
+type Props = {
+  onContinue?: (patch: OnboardingPayload) => void
+  onBack?: () => void
+  onStartOver?: () => void
+  initialIdentity?: { name?: string; description?: string; voice?: string }
+  previewMode?: boolean
+}
+
+export function StepIdentity({
+  onContinue,
+  onBack,
+  onStartOver,
+  initialIdentity = {},
+  previewMode = false,
+}: Props) {
+  const [name, setName] = useState(initialIdentity.name ?? DEFAULT_NAME)
+  const [description, setDescription] = useState(initialIdentity.description ?? DEFAULT_DESCRIPTION)
+  const [voice, setVoice] = useState(initialIdentity.voice ?? DEFAULT_VOICE)
+  const [previewing, setPreviewing] = useState<string | null>(null)
+  const [previewError, setPreviewError] = useState('')
+  const audioRef = useRef<HTMLAudioElement | null>(null)
+
+  useEffect(() => {
+    return () => {
+      const audio = audioRef.current
+      if (audio) {
+        try {
+          audio.pause()
+        } catch {
+          // ignore
+        }
+      }
+    }
+  }, [])
+
+  const handlePreview = async (voiceId: string) => {
+    if (previewMode) return
+    setPreviewError('')
+    setPreviewing(voiceId)
+    try {
+      const result = await identityApi.speakPreview({
+        voice: voiceId,
+        text: `Hi, I'm ${name.trim() || DEFAULT_NAME}.`,
+      })
+      if (!result.ok) {
+        setPreviewError(result.error)
+        return
+      }
+      const audio = decodeAudio(result.audioBase64, result.mimeType)
+      audioRef.current = audio
+      audio.onended = () => setPreviewing((p) => (p === voiceId ? null : p))
+      try {
+        await audio.play()
+      } catch (err) {
+        setPreviewError(err instanceof Error ? err.message : 'Could not play audio.')
+        setPreviewing(null)
+      }
+    } catch (err) {
+      setPreviewError(err instanceof Error ? err.message : 'Preview failed.')
+      setPreviewing(null)
+    }
+  }
+
+  const handleContinue = () => {
+    const trimmedName = name.trim() || DEFAULT_NAME
+    const trimmedDescription = description.trim()
+    onContinue?.({
+      identity: { name: trimmedName, description: trimmedDescription, voice },
+    })
+  }
+
+  return (
+    <StepFrame
+      stepIndex={6}
+      totalSteps={7}
+      eyebrow="06 / Voice"
+      title="Give your agent a name and a voice."
+      description="Pick how they'll sound and feel. You can change all of this later in Settings."
+      primaryAction={{ label: 'Continue', onClick: handleContinue }}
+      secondaryAction={{ label: 'Back', onClick: onBack }}
+      onStartOver={onStartOver}
+    >
+      <div className="flex flex-col gap-5">
+        <div className="grid gap-3 md:grid-cols-2">
+          <Field label="Name">
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={DEFAULT_NAME}
+              className="w-full rounded-[14px] border px-4 py-3 text-[15px] outline-none"
+              style={{
+                borderColor: 'var(--line-strong)',
+                backgroundColor: 'var(--panel-strong)',
+                color: 'var(--ink)',
+              }}
+            />
+          </Field>
+          <Field label="One-line description (optional)">
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={DEFAULT_DESCRIPTION}
+              rows={2}
+              className="w-full resize-none rounded-[14px] border px-4 py-3 text-[14px] leading-snug outline-none"
+              style={{
+                borderColor: 'var(--line-strong)',
+                backgroundColor: 'var(--panel-strong)',
+                color: 'var(--ink)',
+              }}
+            />
+          </Field>
+        </div>
+
+        <Field label="Voice">
+          <div className="flex flex-col gap-2">
+            {GEMINI_VOICES.map((v) => (
+              <VoiceRow
+                key={v.id}
+                voiceId={v.id}
+                label={v.label}
+                selected={voice === v.id}
+                previewing={previewing === v.id}
+                onSelect={() => setVoice(v.id)}
+                onPreview={() => void handlePreview(v.id)}
+              />
+            ))}
+          </div>
+        </Field>
+
+        {previewError ? (
+          <p className="text-[12px]" style={{ color: 'var(--accent)' }}>
+            {previewError}
+          </p>
+        ) : null}
+      </div>
+    </StepFrame>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-2">
+      <span
+        className="text-[10px] uppercase"
+        style={{
+          fontFamily: 'var(--font-mono)',
+          letterSpacing: '0.24em',
+          color: 'var(--accent)',
+        }}
+      >
+        {label}
+      </span>
+      {children}
+    </label>
+  )
+}
+
+function VoiceRow({
+  voiceId,
+  label,
+  selected,
+  previewing,
+  onSelect,
+  onPreview,
+}: {
+  voiceId: string
+  label: string
+  selected: boolean
+  previewing: boolean
+  onSelect: () => void
+  onPreview: () => void
+}) {
+  return (
+    <div
+      className="flex items-center gap-3 rounded-[14px] border px-4 py-3"
+      style={{
+        borderColor: selected ? 'var(--accent)' : 'var(--line-strong)',
+        backgroundColor: selected ? 'var(--accent-soft)' : 'var(--panel)',
+      }}
+    >
+      <button
+        onClick={onSelect}
+        className="flex flex-1 items-center gap-3 text-left"
+        type="button"
+      >
+        <span
+          className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-[1.5px]"
+          style={{ borderColor: selected ? 'var(--accent)' : 'var(--line-strong)' }}
+        >
+          {selected ? (
+            <span
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: 'var(--accent)' }}
+            />
+          ) : null}
+        </span>
+        <span className="text-[14px]" style={{ color: 'var(--ink)' }}>
+          {label}
+        </span>
+      </button>
+      <button
+        onClick={onPreview}
+        type="button"
+        disabled={previewing}
+        className="rounded-[10px] border px-3 py-1.5 text-[12px] uppercase tracking-[0.2em] disabled:opacity-50"
+        style={{
+          borderColor: 'var(--line-strong)',
+          backgroundColor: previewing ? 'var(--accent-soft)' : 'var(--panel-strong)',
+          color: 'var(--ink)',
+          fontFamily: 'var(--font-mono)',
+        }}
+        aria-label={`Preview ${voiceId} voice`}
+      >
+        {previewing ? 'Playing…' : 'Say hello'}
+      </button>
+    </div>
+  )
+}
+
+function decodeAudio(base64: string, mimeType: string): HTMLAudioElement {
+  if (mimeType.startsWith('audio/L16') || mimeType.startsWith('audio/pcm')) {
+    const sampleRate = parseSampleRate(mimeType) ?? 24000
+    const wav = pcmToWav(base64, sampleRate)
+    const blob = new Blob([wav], { type: 'audio/wav' })
+    return new Audio(URL.createObjectURL(blob))
+  }
+  return new Audio(`data:${mimeType};base64,${base64}`)
+}
+
+function parseSampleRate(mimeType: string): number | null {
+  const match = mimeType.match(/rate=(\d+)/i)
+  return match ? Number(match[1]) : null
+}
+
+function pcmToWav(base64: string, sampleRate: number): ArrayBuffer {
+  const binary = atob(base64)
+  const pcm = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) pcm[i] = binary.charCodeAt(i)
+
+  const numChannels = 1
+  const bitsPerSample = 16
+  const byteRate = (sampleRate * numChannels * bitsPerSample) / 8
+  const blockAlign = (numChannels * bitsPerSample) / 8
+  const dataSize = pcm.length
+  const buffer = new ArrayBuffer(44 + dataSize)
+  const view = new DataView(buffer)
+
+  writeString(view, 0, 'RIFF')
+  view.setUint32(4, 36 + dataSize, true)
+  writeString(view, 8, 'WAVE')
+  writeString(view, 12, 'fmt ')
+  view.setUint32(16, 16, true)
+  view.setUint16(20, 1, true)
+  view.setUint16(22, numChannels, true)
+  view.setUint32(24, sampleRate, true)
+  view.setUint32(28, byteRate, true)
+  view.setUint16(32, blockAlign, true)
+  view.setUint16(34, bitsPerSample, true)
+  writeString(view, 36, 'data')
+  view.setUint32(40, dataSize, true)
+
+  new Uint8Array(buffer, 44).set(pcm)
+  return buffer
+}
+
+function writeString(view: DataView, offset: number, value: string) {
+  for (let i = 0; i < value.length; i += 1) {
+    view.setUint8(offset + i, value.charCodeAt(i))
+  }
+}


### PR DESCRIPTION
## Summary

Adds a Voice step to the onboarding wizard that captures the agent's name (default `Pam`), an optional one-line description, and a Gemini Live voice with per-voice "Say hello" preview buttons. Persists everything as `IDENTITY.md` in the bundled openclaw workspace and triggers an out-loud greeting on the first ChatPage mount after wizard completion. Settings page exposes the same name + description fields for later edits.

This is the v0.3.4 follow-up to NAN-686 / NAN-687 (PR #280, shipped as v0.3.3). v0.3.3 wired the relay/openclaw bootstrap so the agent could speak; v0.3.4 makes the agent speak with the user's chosen identity and proves it's working by greeting them at the end of the wizard.

## What changed

- `desktop/src/main/identity.ts`: new module that reads/writes `IDENTITY.md` from `userData/openclaw/workspace/`. Exposes `readAgentIdentity`, `writeAgentIdentity`, and `speakGreetingPreview` (Gemini TTS one-shot via `gemini-3.1-flash-tts-preview:generateContent`).
- `desktop/src/main/ipc-handlers.ts`: new `identity:get`, `identity:save`, `identity:speakPreview` IPCs. `identity:save` mirrors voice into `settings.realtime_voice` and restarts the relay so the choice takes effect immediately.
- `desktop/src/renderer/src/pages/onboarding/StepIdentity.tsx`: new wizard step. Inline name input, description textarea, and a list of Gemini voices (Aoede, Kore, Leda, Zephyr, Puck, Charon, Fenrir, Orus) each with a "Say hello" preview that plays "Hi, I'm <name>." in that voice. PCM-to-WAV decoder in the renderer handles Gemini's `audio/L16;rate=24000` response.
- `OnboardingWizard.tsx`: inserts the new step between `brain` and `testcall`. On wizard complete, sets a `pending_greeting` flag.
- `ChatPage.tsx`: reads the `pending_greeting` flag once on mount, clears it, and auto-starts the call so the agent greets the user out loud — no manual click required.
- `SettingsPage.tsx`: new Agent Identity card with editable Name + Description. Voice already had its own card; identity-save also touches `realtime_voice` so the existing voice picker stays the source of truth.

## Verification

- `yarn workspace voiceclaw-desktop tsc --noEmit` clean.
- `yarn workspace voiceclaw-desktop test --run`: 32 passed (was 27; +5 new identity tests covering blank/full/partial patches and field round-tripping via `readAgentIdentity`).
- `yarn workspace voiceclaw-desktop build` clean.

## Open follow-ups for the user to test on actual fresh-Mac install

1. Wizard now has 7 steps (was 6). Voice step shows 8 Gemini voices with working "Say hello" previews.
2. After wizard finishes, ChatPage opens and the agent immediately greets the user in the chosen voice.
3. `~/Library/Application Support/voiceclaw-desktop/openclaw/workspace/IDENTITY.md` contains the user's chosen Name + Vibe (description).
4. Settings → Agent Identity card lets the user rename the agent or rewrite the description; voice picker still in its existing card.

## Test plan

- [x] `yarn workspace voiceclaw-desktop test --run`
- [x] `yarn workspace voiceclaw-desktop tsc --noEmit`
- [x] `yarn workspace voiceclaw-desktop build`
- [ ] Manual fresh-install on an unused Mac userData dir + complete wizard, hear greeting

🤖 Generated with [Claude Code](https://claude.com/claude-code)