### PR TITLE
feat(desktop): add re-run onboarding button to Settings

### DIFF
--- a/desktop/src/renderer/src/pages/SettingsPage.tsx
+++ b/desktop/src/renderer/src/pages/SettingsPage.tsx
@@ -5,7 +5,7 @@ import { Card } from '../components/ui/Card'
 import { Input } from '../components/ui/Input'
 import { Select } from '../components/ui/Select'
 import { Toggle } from '../components/ui/Toggle'
-import { identityApi } from '../lib/onboarding-api'
+import { identityApi, onboarding } from '../lib/onboarding-api'
 import { useTheme, type Theme } from '../lib/use-theme'
 import { enumerateAudioDevices, type AudioDevice } from '../lib/audio-engine'
 import { getSetting, setSetting } from '../lib/db'
@@ -626,6 +626,23 @@ export function SettingsPage() {
               <p className="text-xs text-muted-foreground">Post per-turn latency to Langfuse via relay</p>
             </div>
             <Toggle checked={tracingEnabled} onChange={toggleTracing} />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-foreground">Re-run onboarding wizard</p>
+              <p className="text-xs text-muted-foreground">Resets the wizard cursor so you can step through it again. API keys and sign-in stay.</p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={async () => {
+                const result = await onboarding.reset()
+                if (result.ok) window.location.reload()
+              }}
+            >
+              Restart
+            </Button>
           </div>
         </Card>
 


### PR DESCRIPTION
## Summary

- Adds a **Re-run onboarding wizard** row to the Debug section of the Settings page
- Clicking **Restart** calls `onboarding:reset` IPC, which shows the existing native macOS confirmation dialog ("Restart onboarding from step 1? Saved API keys and sign-in remain in place — only the wizard cursor resets.")
- If confirmed, reloads the renderer so the app re-bootstraps and routes the user back to the wizard from step 1
- If cancelled, does nothing — no second renderer-side confirmation added
- Preserves all API keys, devices, sign-in state — only the `onboarding_state` key is cleared

Useful for re-testing the onboarding flow without uninstalling the app.

## Test plan

- [ ] Open Settings → scroll to Debug section → verify "Re-run onboarding wizard" row with "Restart" button appears
- [ ] Click Restart → macOS native dialog appears
- [ ] Click Cancel in dialog → nothing happens, Settings page stays
- [ ] Click Restart again → confirm → app reloads and wizard appears from step 1
- [ ] Verify API keys / sign-in still present after wizard completes or is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)