### PR TITLE
feat(desktop): inline tool-call rows in chat (NAN-690)

### DIFF
--- a/desktop/src/renderer/src/components/ToolCallRow.tsx
+++ b/desktop/src/renderer/src/components/ToolCallRow.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef, useState } from 'react'
+import { ChevronDown, ChevronRight, Loader2, CheckCircle2, XCircle, Ban } from 'lucide-react'
+import type { ToolCallEntry } from '../lib/tool-call-store'
+
+interface ToolCallRowProps {
+  entry: ToolCallEntry
+}
+
+export function ToolCallRow({ entry }: ToolCallRowProps) {
+  const { status, name, args, result, error, startedAt, durationMs } = entry
+  const [argsExpanded, setArgsExpanded] = useState(false)
+  const [resultExpanded, setResultExpanded] = useState(status === 'error')
+  const [elapsed, setElapsed] = useState(0)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  useEffect(() => {
+    if (status !== 'in-progress') {
+      if (intervalRef.current !== null) clearInterval(intervalRef.current)
+      return
+    }
+    const tick = () => setElapsed(Date.now() - startedAt)
+    tick()
+    intervalRef.current = setInterval(tick, 200)
+    return () => {
+      if (intervalRef.current !== null) clearInterval(intervalRef.current)
+    }
+  }, [status, startedAt])
+
+  useEffect(() => {
+    if (status === 'error') setResultExpanded(true)
+  }, [status])
+
+  const displayMs = status === 'in-progress' ? elapsed : (durationMs ?? 0)
+
+  return (
+    <div className="mb-2 mx-1">
+      <div className="flex items-start gap-2 px-3 py-2 rounded border border-border/60 bg-muted/30 text-xs">
+        <div className="mt-0.5 flex-shrink-0">
+          <StatusIcon status={status} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <code className="font-mono text-[11px] text-foreground/90 truncate">{name}</code>
+            <span className={`flex-shrink-0 tabular-nums ${statusTextClass(status)}`}>
+              {statusLabel(status)} · {formatMs(displayMs)}
+            </span>
+          </div>
+
+          {args && (
+            <button
+              className="mt-1 flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => setArgsExpanded((v) => !v)}
+            >
+              {argsExpanded ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+              <span className="truncate max-w-[280px]">{summarize(args)}</span>
+            </button>
+          )}
+
+          {argsExpanded && (
+            <pre className="mt-1.5 rounded bg-background/50 border border-border/40 p-2 text-[10px] leading-relaxed overflow-auto max-h-40 whitespace-pre-wrap break-all">
+              {prettyPrint(args)}
+            </pre>
+          )}
+
+          {(status === 'success' || status === 'error' || status === 'cancelled') && result && (
+            <button
+              className="mt-1 flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => setResultExpanded((v) => !v)}
+            >
+              {resultExpanded ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+              <span>{resultExpanded ? 'Hide result' : 'Show result'}</span>
+            </button>
+          )}
+
+          {status === 'error' && error && !result && (
+            <div className="mt-1 text-destructive leading-relaxed break-words">{error}</div>
+          )}
+
+          {resultExpanded && result && (
+            <pre className="mt-1.5 rounded bg-background/50 border border-border/40 p-2 text-[10px] leading-relaxed overflow-auto max-h-40 whitespace-pre-wrap break-all">
+              {prettyPrint(result)}
+            </pre>
+          )}
+
+          {resultExpanded && status === 'error' && error && (
+            <div className="mt-1 text-destructive text-[10px] leading-relaxed break-words">{error}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// --- Helpers ---
+
+function StatusIcon({ status }: { status: ToolCallEntry['status'] }) {
+  switch (status) {
+    case 'in-progress':
+      return <Loader2 size={13} className="animate-spin text-muted-foreground" />
+    case 'success':
+      return <CheckCircle2 size={13} className="text-[var(--brand-sage)]" />
+    case 'error':
+      return <XCircle size={13} className="text-destructive" />
+    case 'cancelled':
+      return <Ban size={13} className="text-muted-foreground" />
+  }
+}
+
+function statusLabel(status: ToolCallEntry['status']): string {
+  switch (status) {
+    case 'in-progress': return 'in-progress'
+    case 'success': return 'done'
+    case 'error': return 'failed'
+    case 'cancelled': return 'cancelled'
+  }
+}
+
+function statusTextClass(status: ToolCallEntry['status']): string {
+  switch (status) {
+    case 'in-progress': return 'text-muted-foreground'
+    case 'success': return 'text-[var(--brand-sage)]'
+    case 'error': return 'text-destructive'
+    case 'cancelled': return 'text-muted-foreground'
+  }
+}
+
+function formatMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+function summarize(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw)
+    const values = Object.values(parsed)
+      .map((v) => (typeof v === 'string' ? v : JSON.stringify(v)))
+      .join(', ')
+    return values.length > 80 ? values.slice(0, 77) + '…' : values
+  } catch {
+    return raw.length > 80 ? raw.slice(0, 77) + '…' : raw
+  }
+}
+
+function prettyPrint(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2)
+  } catch {
+    return raw
+  }
+}

--- a/desktop/src/renderer/src/lib/tool-call-store.ts
+++ b/desktop/src/renderer/src/lib/tool-call-store.ts
@@ -1,0 +1,61 @@
+export type ToolCallStatus = 'in-progress' | 'success' | 'error' | 'cancelled'
+
+export interface ToolCallEntry {
+  callId: string
+  name: string
+  args: string
+  status: ToolCallStatus
+  startedAt: number
+  durationMs?: number
+  result?: string
+  error?: string
+}
+
+export function applyToolCallStarted(
+  entries: ToolCallEntry[],
+  callId: string,
+  name: string,
+  args: string,
+): ToolCallEntry[] {
+  if (entries.some((e) => e.callId === callId)) return entries
+  return [
+    ...entries,
+    { callId, name, args, status: 'in-progress', startedAt: Date.now() },
+  ]
+}
+
+export function applyToolCallCompleted(
+  entries: ToolCallEntry[],
+  callId: string,
+  durationMs: number,
+  result: string,
+): ToolCallEntry[] {
+  return entries.map((e) =>
+    e.callId === callId ? { ...e, status: 'success', durationMs, result } : e,
+  )
+}
+
+export function applyToolCallFailed(
+  entries: ToolCallEntry[],
+  callId: string,
+  durationMs: number,
+  error: string,
+  cancelled: boolean,
+): ToolCallEntry[] {
+  return entries.map((e) =>
+    e.callId === callId
+      ? { ...e, status: cancelled ? 'cancelled' : 'error', durationMs, error }
+      : e,
+  )
+}
+
+export function applyToolCallCancelled(
+  entries: ToolCallEntry[],
+  callIds: string[],
+): ToolCallEntry[] {
+  return entries.map((e) =>
+    callIds.includes(e.callId) && e.status === 'in-progress'
+      ? { ...e, status: 'cancelled', durationMs: Date.now() - e.startedAt }
+      : e,
+  )
+}

--- a/desktop/src/renderer/src/lib/use-realtime.ts
+++ b/desktop/src/renderer/src/lib/use-realtime.ts
@@ -48,6 +48,9 @@ export interface RealtimeCallbacks {
   onTranscriptDone?: (text: string, role: 'user' | 'assistant') => void
   onToolCall?: (callId: string, name: string, args: string) => void
   onToolProgress?: (callId: string, summary: string) => void
+  onToolCallCompleted?: (callId: string, name: string, durationMs: number, result: string) => void
+  onToolCallFailed?: (callId: string, name: string, durationMs: number, error: string, cancelled: boolean) => void
+  onToolCancelled?: (callIds: string[]) => void
   onBrainResult?: (callId: string, query: string, result?: string, error?: string) => void
   onTurnStarted?: () => void
   onTurnEnded?: () => void
@@ -176,6 +179,18 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
 
         case 'tool.progress':
           cb.onToolProgress?.(data.callId, data.summary)
+          break
+
+        case 'tool_call.completed':
+          cb.onToolCallCompleted?.(data.callId, data.name, data.durationMs, data.result)
+          break
+
+        case 'tool_call.failed':
+          cb.onToolCallFailed?.(data.callId, data.name, data.durationMs, data.error, data.cancelled)
+          break
+
+        case 'tool.cancelled':
+          cb.onToolCancelled?.(data.callIds)
           break
 
         case 'brain.result':

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -7,9 +7,17 @@ import { AudioLevelMeter } from '../components/AudioLevelMeter'
 import { VoiceClawMark } from '../components/brand/VoiceClawMark'
 import { ScreenSharePicker } from '../components/ScreenSharePicker'
 import { VolumeControl } from '../components/VolumeControl'
+import { ToolCallRow } from '../components/ToolCallRow'
 import { ScreenCapture, type ScreenSource } from '../lib/screen-capture'
 import { useRealtime, type RealtimeCallbacks } from '../lib/use-realtime'
 import { useConversationContext } from '../lib/conversation-context'
+import {
+  applyToolCallStarted,
+  applyToolCallCompleted,
+  applyToolCallFailed,
+  applyToolCallCancelled,
+  type ToolCallEntry,
+} from '../lib/tool-call-store'
 import {
   addMessage,
   createConversation,
@@ -28,6 +36,7 @@ const XAI_VOICES = ['eve', 'ara', 'rex', 'sal', 'leo'] as const
 
 export function ChatPage() {
   const [messages, setMessages] = useState<Message[]>([])
+  const [toolCalls, setToolCalls] = useState<ToolCallEntry[]>([])
   const [conversationId, setConversationId] = useState<number | null>(null)
   const conversationIdRef = useRef<number | null>(null)
   const titleGeneratedRef = useRef(false)
@@ -65,7 +74,7 @@ export function ChatPage() {
   // Auto-scroll to bottom on new messages
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages, streamingText, isThinking])
+  }, [messages, toolCalls, streamingText, isThinking])
 
   // Load conversation when selected from History tab
   useEffect(() => {
@@ -157,8 +166,8 @@ export function ChatPage() {
     onTurnEnded: () => {
       setIsThinking(false)
     },
-    onToolCall: async (_callId, name, args) => {
-      // Handle displayText tool call locally
+    onToolCall: async (callId, name, args) => {
+      setToolCalls((prev) => applyToolCallStarted(prev, callId, name, args))
       if (name === 'displayText') {
         try {
           const parsed = JSON.parse(args)
@@ -169,6 +178,15 @@ export function ChatPage() {
           // ignore parse errors
         }
       }
+    },
+    onToolCallCompleted: (callId, _name, durationMs, result) => {
+      setToolCalls((prev) => applyToolCallCompleted(prev, callId, durationMs, result))
+    },
+    onToolCallFailed: (callId, _name, durationMs, error, cancelled) => {
+      setToolCalls((prev) => applyToolCallFailed(prev, callId, durationMs, error, cancelled))
+    },
+    onToolCancelled: (callIds) => {
+      setToolCalls((prev) => applyToolCallCancelled(prev, callIds))
     },
     onToolProgress: (_callId, summary) => {
       streamingRoleRef.current = 'assistant'
@@ -335,6 +353,7 @@ export function ChatPage() {
     conversationIdRef.current = null
     setConversationId(null)
     setMessages([])
+    setToolCalls([])
     titleGeneratedRef.current = false
   }, [isCallActive, endCall])
 
@@ -434,9 +453,13 @@ export function ChatPage() {
             </p>
           </div>
         )}
-        {messages.map((msg) => (
-          <MessageBubble key={msg.id} message={msg} showLatency={showLatency} />
-        ))}
+        {buildTimeline(messages, toolCalls).map((item) =>
+          item.kind === 'message' ? (
+            <MessageBubble key={`msg-${item.data.id}`} message={item.data} showLatency={showLatency} />
+          ) : (
+            <ToolCallRow key={`tool-${item.data.callId}`} entry={item.data} />
+          )
+        )}
         {/* Streaming text */}
         {streamingText.trim() && (
           <div className={`flex ${streamingRole === 'user' ? 'justify-end' : 'justify-start'} mb-3`}>
@@ -563,6 +586,19 @@ export function ChatPage() {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+type TimelineItem =
+  | { kind: 'message'; ts: number; data: Message }
+  | { kind: 'tool'; ts: number; data: ToolCallEntry }
+
+function buildTimeline(messages: Message[], toolCalls: ToolCallEntry[]): TimelineItem[] {
+  const items: TimelineItem[] = [
+    ...messages.map((m) => ({ kind: 'message' as const, ts: m.created_at, data: m })),
+    ...toolCalls.map((t) => ({ kind: 'tool' as const, ts: t.startedAt, data: t })),
+  ]
+  items.sort((a, b) => a.ts - b.ts)
+  return items
+}
 
 function generateTitle(text: string): string {
   const trimmed = text.trim()

--- a/docs/src/content/docs/desktop/tool-calls.mdx
+++ b/docs/src/content/docs/desktop/tool-calls.mdx
@@ -1,0 +1,36 @@
+---
+title: Tool call rows
+description: Small status rows that appear in the chat transcript when VoiceClaw runs a search or queries your brain agent — showing live progress, how long it took, and what went wrong if it failed.
+---
+
+import { Aside } from '@astrojs/starlight/components'
+
+When you ask VoiceClaw something that needs a live search or a knowledge lookup, a small status row appears inline in the chat — right between the message that triggered it and the agent's reply. Each row tells you which tool ran, how long it took, and whether it succeeded.
+
+## The four states
+
+| Icon | Label | What it means |
+|------|-------|---------------|
+| Spinning circle | in-progress | The tool is running. A live timer counts up. |
+| Green check | done | The tool finished and the agent has the result. |
+| Red X | failed | Something went wrong. Expand the row to see the error. |
+| Slash circle | cancelled | You started talking before the tool finished, so it was aborted. |
+
+## Expanding a row
+
+Every row shows the tool name and timing on one line. Below that:
+
+- **Arguments** — click the chevron to see what the agent sent to the tool (e.g., the search query). Useful to confirm the agent understood what you asked.
+- **Result** — available once the tool completes. Click to expand. Error rows expand automatically so you don't have to hunt for the problem.
+
+## When a row shows "failed"
+
+The most common causes:
+
+1. **Web search** — your Tavily API key is missing or invalid. Go to **Settings → Tavily API Key** and add a valid key.
+2. **Brain agent** — the brain gateway isn't reachable. Check that your relay server is running and the `BRAIN_GATEWAY_URL` points to a live instance.
+3. **Cancelled** — you interrupted the agent mid-search. This isn't an error; start a new turn and the agent will try again.
+
+<Aside type="tip">
+  Rows stay in the transcript for the lifetime of the conversation — even after the call ends. They don't affect exported transcripts or conversation history synced to the brain agent.
+</Aside>

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -33,6 +33,7 @@ export class RelaySession {
   // each turn's video to its own audio).
   private currentTurnStartMs = 0
   private inFlightTools = new Map<string, AbortController>()
+  private toolCallStartMs = new Map<string, number>()
 
   constructor(ws: WebSocket) {
     this.ws = ws
@@ -70,6 +71,7 @@ export class RelaySession {
         break
       case "tool.call":
         this.tracer.startToolCall(event.callId, event.name, event.arguments)
+        this.toolCallStartMs.set(event.callId, Date.now())
         break
       case "audio.delta":
         // Tee the model's outbound audio into the assistant capture file BEFORE
@@ -154,6 +156,7 @@ export class RelaySession {
     const syncResult = executeSyncTool(name, args)
     if (syncResult !== null) {
       this.tracer.endToolCall(callId, syncResult)
+      this.emitToolCompleted(callId, name, syncResult)
       this.adapter?.sendToolResult(callId, syncResult)
       return
     }
@@ -218,6 +221,7 @@ export class RelaySession {
       const msg = e instanceof Error ? e.message : "invalid arguments"
       const errorPayload = JSON.stringify({ error: msg })
       this.tracer.endToolCall(callId, errorPayload, msg)
+      this.emitToolFailed(callId, "web_search", msg, false)
       this.adapter?.sendToolResult(callId, errorPayload)
       return
     }
@@ -242,11 +246,13 @@ export class RelaySession {
         log(`[session:${this.id}] web_search (${callId}) was cancelled — discarding result`)
         const cancelledPayload = JSON.stringify({ status: "cancelled" })
         this.tracer.endToolCall(callId, cancelledPayload, "cancelled")
+        this.emitToolFailed(callId, "web_search", "cancelled", true)
         this.adapter?.sendToolResult(callId, cancelledPayload)
         return
       }
 
       this.tracer.endToolCall(callId, result)
+      this.emitToolCompleted(callId, "web_search", result)
       this.adapter?.sendToolResult(callId, result)
     }).catch((err) => {
       const message = err instanceof Error ? err.message : "web search failed"
@@ -256,8 +262,10 @@ export class RelaySession {
       this.tracer.endToolCall(callId, errorPayload, message)
 
       if (controller.signal.aborted) {
+        this.emitToolFailed(callId, "web_search", message, true)
         this.adapter?.sendToolResult(callId, JSON.stringify({ status: "cancelled" }))
       } else {
+        this.emitToolFailed(callId, "web_search", message, false)
         this.adapter?.sendToolResult(callId, errorPayload)
       }
     }).finally(() => {
@@ -282,6 +290,7 @@ export class RelaySession {
       const msg = e instanceof Error ? e.message : "invalid arguments"
       const errorPayload = JSON.stringify({ error: msg })
       this.tracer.endToolCall(callId, errorPayload, msg)
+      this.emitToolFailed(callId, "ask_brain", msg, false)
       this.adapter?.sendToolResult(callId, errorPayload)
       this.inFlightTools.delete(callId)
       return
@@ -309,11 +318,13 @@ export class RelaySession {
       if (controller.signal.aborted) {
         const cancelledPayload = JSON.stringify({ status: "cancelled" })
         this.tracer.endToolCall(callId, cancelledPayload, "cancelled")
+        this.emitToolFailed(callId, "ask_brain", "cancelled", true)
         this.adapter?.sendToolResult(callId, cancelledPayload)
         return
       }
 
       this.tracer.endToolCall(callId, result)
+      this.emitToolCompleted(callId, "ask_brain", result)
       this.send({ type: "brain.result", callId, query, result })
       this.adapter?.sendToolResult(callId, result)
     }).catch((err) => {
@@ -324,8 +335,10 @@ export class RelaySession {
       this.tracer.endToolCall(callId, errorPayload, message)
 
       if (controller.signal.aborted) {
+        this.emitToolFailed(callId, "ask_brain", message, true)
         this.adapter?.sendToolResult(callId, JSON.stringify({ status: "cancelled" }))
       } else {
+        this.emitToolFailed(callId, "ask_brain", message, false)
         this.send({ type: "brain.result", callId, query, error: message })
         this.adapter?.sendToolResult(callId, errorPayload)
       }
@@ -351,6 +364,7 @@ export class RelaySession {
       const msg = e instanceof Error ? e.message : "invalid arguments"
       const errorPayload = JSON.stringify({ error: msg })
       this.tracer.endToolCall(callId, errorPayload, msg)
+      this.emitToolFailed(callId, "ask_brain", msg, false)
       this.adapter?.sendToolResult(callId, errorPayload)
       this.inFlightTools.delete(callId)
       return
@@ -399,10 +413,12 @@ export class RelaySession {
       if (controller.signal.aborted) {
         log(`[session:${this.id}] ask_brain (${callId}) was cancelled — discarding result`)
         this.tracer.endToolCall(callId, JSON.stringify({ status: "cancelled" }), "cancelled")
+        this.emitToolFailed(callId, "ask_brain", "cancelled", true)
         return
       }
 
       this.tracer.endToolCall(callId, result)
+      this.emitToolCompleted(callId, "ask_brain", result)
 
       this.send({ type: "brain.result", callId, query, result })
 
@@ -416,10 +432,13 @@ export class RelaySession {
       this.tracer.endToolCall(callId, JSON.stringify({ error: message }), message)
 
       if (!controller.signal.aborted) {
+        this.emitToolFailed(callId, "ask_brain", message, false)
         this.send({ type: "brain.result", callId, query, error: message })
         this.adapter?.injectContext(
           `[Brain agent failed for query: "${query}": ${message}]\nLet the user know the search didn't work and offer to try again.`
         )
+      } else {
+        this.emitToolFailed(callId, "ask_brain", message, true)
       }
     }).finally(() => {
       this.inFlightTools.delete(callId)
@@ -433,6 +452,7 @@ export class RelaySession {
     if (!tavilyKey) {
       const errorPayload = JSON.stringify({ error: "Tavily API key not configured" })
       this.tracer.endToolCall(callId, errorPayload, "no tavily key")
+      this.emitToolFailed(callId, "web_search", "Tavily API key not configured", false)
       this.adapter?.sendToolResult(callId, errorPayload)
       return
     }
@@ -448,6 +468,7 @@ export class RelaySession {
       const msg = e instanceof Error ? e.message : "invalid arguments"
       const errorPayload = JSON.stringify({ error: msg })
       this.tracer.endToolCall(callId, errorPayload, msg)
+      this.emitToolFailed(callId, "web_search", msg, false)
       this.adapter?.sendToolResult(callId, errorPayload)
       return
     }
@@ -472,10 +493,12 @@ export class RelaySession {
 
       if (controller.signal.aborted) {
         this.tracer.endToolCall(callId, JSON.stringify({ status: "cancelled" }), "cancelled")
+        this.emitToolFailed(callId, "web_search", "cancelled", true)
         return
       }
 
       this.tracer.endToolCall(callId, result)
+      this.emitToolCompleted(callId, "web_search", result)
       this.adapter?.injectContext(
         `[Web search result for query: "${query}"]\n${result}\n\nPlease share this information with the user naturally.`
       )
@@ -486,9 +509,12 @@ export class RelaySession {
       this.tracer.endToolCall(callId, JSON.stringify({ error: message }), message)
 
       if (!controller.signal.aborted) {
+        this.emitToolFailed(callId, "web_search", message, false)
         this.adapter?.injectContext(
           `[Web search failed for query: "${query}": ${message}]\nLet the user know the search didn't work and offer to try again.`
         )
+      } else {
+        this.emitToolFailed(callId, "web_search", message, true)
       }
     }).finally(() => {
       this.inFlightTools.delete(callId)
@@ -692,6 +718,19 @@ export class RelaySession {
     }
   }
 
+  private emitToolCompleted(callId: string, name: string, result: string) {
+    const startMs = this.toolCallStartMs.get(callId) ?? Date.now()
+    this.toolCallStartMs.delete(callId)
+    const truncated = result.length > 4096 ? result.slice(0, 4096) + "…" : result
+    this.send({ type: "tool_call.completed", callId, name, durationMs: Date.now() - startMs, result: truncated })
+  }
+
+  private emitToolFailed(callId: string, name: string, error: string, cancelled: boolean) {
+    const startMs = this.toolCallStartMs.get(callId) ?? Date.now()
+    this.toolCallStartMs.delete(callId)
+    this.send({ type: "tool_call.failed", callId, name, durationMs: Date.now() - startMs, error, cancelled })
+  }
+
   private isServerSideTool(name: string): boolean {
     if (!this.config) return false
     return getRelayTools(this.config).some((tool) => tool.name === name)
@@ -704,6 +743,7 @@ export class RelaySession {
       controller.abort(new Error(reason))
     }
     this.inFlightTools.clear()
+    this.toolCallStartMs.clear()
   }
 
   private syncTranscriptToBrain() {

--- a/relay-server/src/types.ts
+++ b/relay-server/src/types.ts
@@ -102,6 +102,8 @@ export type RelayEvent =
   | TranscriptDoneEvent
   | ToolCallEvent
   | ToolProgressEvent
+  | ToolCallCompletedEvent
+  | ToolCallFailedEvent
   | TurnStartedEvent
   | TurnEndedEvent
   | SessionEndedEvent
@@ -140,6 +142,29 @@ export interface ToolCallEvent {
   callId: string
   name: string
   arguments: string
+}
+
+// Emitted when a server-side tool call finishes successfully.
+// durationMs is wall-clock time from the matching tool.call event.
+// result is the raw string payload returned by the tool (JSON or plain text,
+// keep ≤ 4 KB — strip audio/embedding fields before sending).
+export interface ToolCallCompletedEvent {
+  type: "tool_call.completed"
+  callId: string
+  name: string
+  durationMs: number
+  result: string
+}
+
+// Emitted when a server-side tool call finishes with an error or is cancelled.
+// cancelled=true distinguishes a mid-turn barge-in abort from an actual failure.
+export interface ToolCallFailedEvent {
+  type: "tool_call.failed"
+  callId: string
+  name: string
+  durationMs: number
+  error: string
+  cancelled: boolean
 }
 
 export interface ToolProgressEvent {


### PR DESCRIPTION
## Summary

- **Relay protocol additions** (`relay-server/src/types.ts`, `session.ts`): two new events — `tool_call.completed` and `tool_call.failed` — carry `callId`, `name`, `durationMs`, and result/error/cancelled payload. The session tracks `toolCallStartMs` per call and emits via `emitToolCompleted` / `emitToolFailed` helpers at every exit path (sync tools, blocking web_search / ask_brain, async paths, cancellation).
- **Client store** (`desktop/src/renderer/src/lib/tool-call-store.ts`): pure reducer functions (`applyToolCallStarted` / `applyToolCallCompleted` / `applyToolCallFailed` / `applyToolCallCancelled`) manage `ToolCallEntry[]` state. No side effects, easy to test.
- **ToolCallRow component** (`desktop/src/renderer/src/components/ToolCallRow.tsx`): renders the four states (in-progress spinner + live timer, success, error, cancelled) with expandable args + result panels. Visually distinct from chat bubbles — border + muted background, monospace tool name.
- **ChatPage integration** (`desktop/src/renderer/src/pages/ChatPage.tsx`): `toolCalls: ToolCallEntry[]` state, all four callbacks wired, `buildTimeline()` merges messages and tool call entries sorted by timestamp for chronological interleaving. Cleared on new conversation.
- **use-realtime** (`desktop/src/renderer/src/lib/use-realtime.ts`): added `onToolCallCompleted`, `onToolCallFailed`, `onToolCancelled` callbacks; dispatches `tool.cancelled` event (previously unhandled).
- **Docs** (`docs/src/content/docs/desktop/tool-calls.mdx`): user-facing page explaining the four states and what to do when a row shows an error.

## Why

Tool calls were invisible in the desktop chat: the agent would pause silently for several seconds while a web search or brain query ran, with no indication of progress. This erodes trust — users assume the session froze.

## Test plan

- [ ] Start a voice call with a Gemini key and a Tavily key configured
- [ ] Ask something that triggers `web_search` (e.g., "what's the weather in Tokyo right now") — an in-progress row should appear in the chat, then transition to "done" with elapsed time
- [ ] Ask something that triggers `ask_brain` — same row lifecycle
- [ ] Barge in mid-search — row should show "cancelled"
- [ ] Disable Tavily key in Settings, ask a search question — row should show "failed" with a Tavily error message
- [ ] Chat page mounts without console errors when no call is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)