### PR TITLE
feat(mobile): inline tool-call rows in chat (NAN-691)

### DIFF
--- a/docs/src/content/docs/mobile/tool-activity.mdx
+++ b/docs/src/content/docs/mobile/tool-activity.mdx
@@ -1,0 +1,29 @@
+---
+title: Seeing what your agent is doing
+description: Tool activity rows in the VoiceClaw mobile chat
+---
+
+When you ask VoiceClaw something that requires looking things up — checking your calendar, searching the web, or querying your personal knowledge base — a small activity row appears in the chat while it works.
+
+## What you'll see
+
+Each tool call shows up as a compact row between your messages:
+
+- **Spinning indicator + elapsed time** — the agent is actively working on this step. The timer ticks live so you know it hasn't frozen.
+- **Checkmark + duration** — the step finished successfully. Tap to see what it found.
+- **Red X + error message** — something went wrong. The error details expand automatically so you can see why.
+- **Dash** — you interrupted the agent before this step completed. Nothing was lost; the agent moves on.
+
+## Tapping a row
+
+- **Success rows** are collapsed by default. Tap to expand the full result (useful for checking what data the agent is working from).
+- **Error rows** expand automatically so the reason is immediately visible.
+- Tap again to collapse.
+
+## Multiple steps
+
+Complex requests often involve several steps — a search, then a follow-up lookup, then a final answer. Each step appears as its own row in the order it ran, so you can see exactly what the agent did and how long each part took.
+
+## Performance
+
+Tool result payloads can be large (full calendar events, email threads, search results). The row only loads the full content when you tap to expand — scrolling through a long conversation with many tool calls stays smooth.

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,4 +1,5 @@
 import { LatencyBadge } from '@/components/latency-badge'
+import { ToolCallRow, type ToolCallItem } from '@/components/tool-call-row'
 import { VoiceClawMark } from '@/components/brand/voiceclaw-mark'
 import { Button } from '@/components/ui/button'
 import { Icon } from '@/components/ui/icon'
@@ -82,6 +83,9 @@ const DISPLAY_TEXT_FUNCTION = {
 
 type ContentPart = { type: 'text', text: string } | { type: 'image', url: string, alt: string }
 type PipelineDebugPhase = 'idle' | 'listening' | 'thinking' | 'speaking'
+type DisplayItem =
+  | { kind: 'message', message: Message }
+  | { kind: 'tool_call', item: ToolCallItem }
 
 const INITIAL_PIPELINE_DEBUG_STATE = {
   phase: 'idle' as PipelineDebugPhase,
@@ -105,6 +109,7 @@ export default function ChatScreen() {
   const { colorScheme } = useColorScheme()
   const palette = colorScheme === 'dark' ? BRAND.colors.dark : BRAND.colors.light
   const [messages, setMessages] = useState<Message[]>([])
+  const [toolCalls, setToolCalls] = useState<Map<string, ToolCallItem>>(new Map())
   const [inputText, setInputText] = useState('')
   const [isCallActive, setIsCallActive] = useState(false)
   const [isMuted, setIsMuted] = useState(false)
@@ -116,7 +121,7 @@ export default function ChatScreen() {
   const [debugMode, setDebugMode] = useState(false)
   const [streamingRole, setStreamingRole] = useState<'user' | 'assistant'>('assistant')
   const [isUserSpeaking, setIsUserSpeaking] = useState(false)
-  const flatListRef = useRef<FlatList<Message>>(null)
+  const flatListRef = useRef<FlatList<DisplayItem>>(null)
   const hasScrolledRef = useRef(false)
   const { playJoin, playEnd, startThinking, stopThinking } = useCallSounds()
   const soundsRef = useRef({ playJoin, playEnd, startThinking, stopThinking })
@@ -289,8 +294,32 @@ export default function ChatScreen() {
       setIsConnecting(false)
       cancelReconnectRef.current?.()
       soundsRef.current.playJoin()
-      // Start mic capture after session is ready
       ExpoRealtimeAudioModule.startCapture()
+    },
+    onToolCall: (callId, name, args) => {
+      setToolCalls((prev) => {
+        const next = new Map(prev)
+        next.set(callId, { callId, name, args, status: 'in-progress', startedAt: Date.now() })
+        return next
+      })
+    },
+    onToolCompleted: (callId, name, durationMs, result) => {
+      setToolCalls((prev) => {
+        const existing = prev.get(callId)
+        if (!existing) return prev
+        const next = new Map(prev)
+        next.set(callId, { ...existing, status: 'success', durationMs, result })
+        return next
+      })
+    },
+    onToolFailed: (callId, name, durationMs, error, cancelled) => {
+      setToolCalls((prev) => {
+        const existing = prev.get(callId)
+        if (!existing) return prev
+        const next = new Map(prev)
+        next.set(callId, { ...existing, status: cancelled ? 'cancelled' : 'error', durationMs, error })
+        return next
+      })
     },
     onTranscriptDelta: (text, role) => {
       if (role === 'user') setIsUserSpeaking(false)
@@ -589,6 +618,7 @@ export default function ChatScreen() {
     const conv = await createConversation()
     setConversationId(conv.id)
     setMessages([])
+    setToolCalls(new Map())
     setStreamingText(null)
     setIsThinking(false)
   }, [])
@@ -597,6 +627,7 @@ export default function ChatScreen() {
     hasScrolledRef.current = false
     setConversationId(id)
     setMessages(await getMessages(id))
+    setToolCalls(new Map())
     setStreamingText(null)
     setIsThinking(false)
   }, [])
@@ -861,14 +892,16 @@ export default function ChatScreen() {
     setIsMuted(newMuted)
   }, [isMuted, realtime])
 
-  let displayMessages = messages as Message[]
+  let baseMessages = messages as Message[]
   if (streamingText !== null) {
-    displayMessages = [...messages, { id: -1, conversation_id: conversationId ?? 0, role: streamingRole, content: streamingText, created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null, stt_provider: null, llm_provider: null, tts_provider: null }]
+    baseMessages = [...messages, { id: -1, conversation_id: conversationId ?? 0, role: streamingRole, content: streamingText, created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null, stt_provider: null, llm_provider: null, tts_provider: null }]
   } else if (isUserSpeaking) {
-    displayMessages = [...messages, { id: LISTENING_MESSAGE_ID, conversation_id: conversationId ?? 0, role: 'user' as const, content: '', created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null, stt_provider: null, llm_provider: null, tts_provider: null }]
+    baseMessages = [...messages, { id: LISTENING_MESSAGE_ID, conversation_id: conversationId ?? 0, role: 'user' as const, content: '', created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null, stt_provider: null, llm_provider: null, tts_provider: null }]
   } else if (isThinking) {
-    displayMessages = [...messages, { id: THINKING_MESSAGE_ID, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: '', created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null, stt_provider: null, llm_provider: null, tts_provider: null }]
+    baseMessages = [...messages, { id: THINKING_MESSAGE_ID, conversation_id: conversationId ?? 0, role: 'assistant' as const, content: '', created_at: Date.now(), stt_latency_ms: null, llm_latency_ms: null, tts_latency_ms: null, stt_provider: null, llm_provider: null, tts_provider: null }]
   }
+
+  const displayItems = buildDisplayItems(baseMessages, toolCalls)
 
   const { partials } = transcriptBuffer
 
@@ -893,14 +926,19 @@ export default function ChatScreen() {
       <FlatList
         testID="messages-list"
         ref={flatListRef}
-        data={displayMessages}
-        keyExtractor={(item) => item.id.toString()}
-        renderItem={({ item }) => (
-          <>
-            <MessageBubble message={item} />
-            {showLatency && item.id !== THINKING_MESSAGE_ID && item.id !== LISTENING_MESSAGE_ID && <LatencyBadge message={item} />}
-          </>
-        )}
+        data={displayItems}
+        keyExtractor={(item) => item.kind === 'tool_call' ? `tc:${item.item.callId}` : `msg:${item.message.id}`}
+        renderItem={({ item }) => {
+          if (item.kind === 'tool_call') {
+            return <ToolCallRow item={item.item} />
+          }
+          return (
+            <>
+              <MessageBubble message={item.message} />
+              {showLatency && item.message.id !== THINKING_MESSAGE_ID && item.message.id !== LISTENING_MESSAGE_ID && <LatencyBadge message={item.message} />}
+            </>
+          )
+        }}
         contentContainerStyle={{ paddingTop: 16, paddingBottom: 8 }}
         onContentSizeChange={() => {
           const animated = hasScrolledRef.current
@@ -1119,6 +1157,19 @@ export default function ChatScreen() {
 }
 
 // --- Helper Components ---
+
+function buildDisplayItems(messages: Message[], toolCalls: Map<string, ToolCallItem>): DisplayItem[] {
+  const items: DisplayItem[] = messages.map((m) => ({ kind: 'message' as const, message: m }))
+  for (const tc of toolCalls.values()) {
+    items.push({ kind: 'tool_call' as const, item: tc })
+  }
+  items.sort((a, b) => {
+    const aTime = a.kind === 'message' ? a.message.created_at : a.item.startedAt
+    const bTime = b.kind === 'message' ? b.message.created_at : b.item.startedAt
+    return aTime - bTime
+  })
+  return items
+}
 
 function PartialBubble({ role, text }: { role: 'user' | 'assistant', text: string }) {
   const isUser = role === 'user'

--- a/mobile/components/tool-call-row.tsx
+++ b/mobile/components/tool-call-row.tsx
@@ -1,0 +1,239 @@
+import { BRAND, type BrandPalette } from '@/lib/brand'
+import { useColorScheme } from 'nativewind'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  ActivityIndicator,
+  LayoutAnimation,
+  Platform,
+  Pressable,
+  ScrollView,
+  UIManager,
+  View,
+} from 'react-native'
+import { Text } from '@/components/ui/text'
+
+if (Platform.OS === 'android') {
+  UIManager.setLayoutAnimationEnabledExperimental?.(true)
+}
+
+export type ToolCallStatus = 'in-progress' | 'success' | 'error' | 'cancelled'
+
+export interface ToolCallItem {
+  callId: string
+  name: string
+  args: string
+  status: ToolCallStatus
+  startedAt: number
+  durationMs?: number
+  result?: string
+  error?: string
+}
+
+interface ToolCallRowProps {
+  item: ToolCallItem
+}
+
+export function ToolCallRow({ item }: ToolCallRowProps) {
+  const { colorScheme } = useColorScheme()
+  const palette = colorScheme === 'dark' ? BRAND.colors.dark : BRAND.colors.light
+  const [expanded, setExpanded] = useState(item.status === 'error')
+  const [elapsed, setElapsed] = useState(0)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  useEffect(() => {
+    if (item.status !== 'in-progress') {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+      return
+    }
+    intervalRef.current = setInterval(() => {
+      setElapsed(Date.now() - item.startedAt)
+    }, 250)
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+    }
+  }, [item.status, item.startedAt])
+
+  useEffect(() => {
+    if (item.status === 'error' && !expanded) {
+      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
+      setExpanded(true)
+    }
+  }, [item.status])
+
+  const toggleExpanded = useCallback(() => {
+    if (item.status === 'in-progress') return
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
+    setExpanded((v) => !v)
+  }, [item.status])
+
+  const displayDuration = item.durationMs != null
+    ? formatDuration(item.durationMs)
+    : item.status === 'in-progress'
+    ? formatDuration(elapsed)
+    : null
+
+  const argsSummary = summarizeArgs(item.args)
+  const canExpand = item.status !== 'in-progress' && item.status !== 'cancelled'
+
+  return (
+    <Pressable
+      onPress={toggleExpanded}
+      disabled={!canExpand}
+      accessibilityRole="button"
+      accessibilityLabel={`Tool call ${item.name}, status ${item.status}`}
+      style={{ paddingHorizontal: 16, marginBottom: 8 }}
+    >
+      <View
+        style={{
+          borderRadius: 8,
+          borderWidth: 1,
+          borderColor: borderColor(item.status, palette),
+          backgroundColor: bgColor(item.status, palette, colorScheme === 'dark'),
+          paddingHorizontal: 12,
+          paddingVertical: 10,
+          overflow: 'hidden',
+        }}
+      >
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+          <StatusIcon status={item.status} palette={palette} />
+          <Text
+            style={{
+              fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+              fontSize: 13,
+              fontWeight: '500',
+              color: palette.ink,
+              flexShrink: 1,
+            }}
+            numberOfLines={1}
+          >
+            {item.name}
+          </Text>
+          {displayDuration != null && (
+            <Text
+              style={{ fontSize: 11, color: palette.muted, marginLeft: 'auto', flexShrink: 0 }}
+              numberOfLines={1}
+            >
+              {displayDuration}
+            </Text>
+          )}
+          {canExpand && (
+            <Text style={{ fontSize: 11, color: palette.muted, marginLeft: displayDuration ? 4 : 'auto' }}>
+              {expanded ? '▲' : '▼'}
+            </Text>
+          )}
+        </View>
+
+        {argsSummary ? (
+          <Text
+            style={{ fontSize: 12, color: palette.muted, marginTop: 4 }}
+            numberOfLines={expanded ? undefined : 1}
+          >
+            {argsSummary}
+          </Text>
+        ) : null}
+
+        {expanded && item.status === 'success' && item.result != null && (
+          <ExpandedContent label="Result" content={item.result} palette={palette} />
+        )}
+
+        {expanded && item.status === 'error' && item.error != null && (
+          <ExpandedContent label="Error" content={item.error} palette={palette} isError />
+        )}
+      </View>
+    </Pressable>
+  )
+}
+
+function ExpandedContent({
+  label,
+  content,
+  palette,
+  isError = false,
+}: {
+  label: string
+  content: string
+  palette: BrandPalette
+  isError?: boolean
+}) {
+  const prettyContent = prettyPrint(content)
+  return (
+    <View style={{ marginTop: 8, borderTopWidth: 1, borderTopColor: palette.line, paddingTop: 8 }}>
+      <Text style={{ fontSize: 10, color: palette.muted, marginBottom: 4, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+        {label}
+      </Text>
+      <ScrollView style={{ maxHeight: 200 }} nestedScrollEnabled>
+        <Text
+          selectable
+          style={{
+            fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+            fontSize: 11,
+            color: isError ? palette.destructive : palette.ink,
+            lineHeight: 16,
+          }}
+        >
+          {prettyContent}
+        </Text>
+      </ScrollView>
+    </View>
+  )
+}
+
+function StatusIcon({ status, palette }: { status: ToolCallStatus, palette: BrandPalette }) {
+  if (status === 'in-progress') {
+    return <ActivityIndicator size="small" color={palette.muted} style={{ width: 16, height: 16 }} />
+  }
+  const icon = status === 'success' ? '✓' : status === 'error' ? '✕' : '—'
+  const color = status === 'success' ? palette.sage : status === 'error' ? palette.destructive : palette.muted
+  return (
+    <Text style={{ fontSize: 13, color, fontWeight: '600', width: 16, textAlign: 'center' }}>
+      {icon}
+    </Text>
+  )
+}
+
+// --- Helper Functions ---
+
+function borderColor(status: ToolCallStatus, palette: BrandPalette): string {
+  if (status === 'error') return palette.destructive + '60'
+  if (status === 'success') return palette.sage + '60'
+  return palette.lineStrong
+}
+
+function bgColor(status: ToolCallStatus, palette: BrandPalette, dark: boolean): string {
+  if (status === 'error') return dark ? 'rgba(248,113,113,0.08)' : 'rgba(239,68,68,0.05)'
+  if (status === 'success') return dark ? 'rgba(156,172,153,0.08)' : 'rgba(105,118,104,0.06)'
+  return palette.panel
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+function summarizeArgs(args: string): string {
+  try {
+    const parsed = JSON.parse(args)
+    const entries = Object.entries(parsed)
+    if (entries.length === 0) return ''
+    const [key, value] = entries[0]
+    const str = typeof value === 'string' ? value : JSON.stringify(value)
+    const truncated = str.length > 80 ? str.slice(0, 80) + '…' : str
+    return entries.length === 1 ? truncated : `${key}: ${truncated}`
+  } catch {
+    return args.length > 80 ? args.slice(0, 80) + '…' : args
+  }
+}
+
+function prettyPrint(content: string): string {
+  try {
+    return JSON.stringify(JSON.parse(content), null, 2)
+  } catch {
+    return content
+  }
+}

--- a/mobile/lib/brand.ts
+++ b/mobile/lib/brand.ts
@@ -46,4 +46,4 @@ export const BRAND = {
   },
 } as const
 
-export type BrandPalette = typeof BRAND.colors.light
+export type BrandPalette = typeof BRAND.colors.light | typeof BRAND.colors.dark

--- a/mobile/lib/use-realtime.ts
+++ b/mobile/lib/use-realtime.ts
@@ -38,6 +38,8 @@ export interface RealtimeCallbacks {
   onTranscriptDelta?: (text: string, role: 'user' | 'assistant') => void
   onTranscriptDone?: (text: string, role: 'user' | 'assistant') => void
   onToolCall?: (callId: string, name: string, args: string) => void
+  onToolCompleted?: (callId: string, name: string, durationMs: number, result: string) => void
+  onToolFailed?: (callId: string, name: string, durationMs: number, error: string, cancelled: boolean) => void
   onToolProgress?: (callId: string, summary: string) => void
   onTurnStarted?: () => void
   onTurnEnded?: () => void
@@ -176,6 +178,14 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
 
       case 'tool.call':
         cb.onToolCall?.(data.callId, data.name, data.arguments)
+        break
+
+      case 'tool_call.completed':
+        cb.onToolCompleted?.(data.callId, data.name, data.durationMs, data.result)
+        break
+
+      case 'tool_call.failed':
+        cb.onToolFailed?.(data.callId, data.name, data.durationMs, data.error, data.cancelled)
         break
 
       case 'tool.progress':


### PR DESCRIPTION
## Summary

- Surface tool calls as inline event rows in the mobile chat FlatList, ordered chronologically with messages
- Four states: in-progress (spinner + live timer), success (checkmark + duration), error (red X, auto-expanded), cancelled (dash)
- Tap to expand/collapse result or error payload; LayoutAnimation for smooth native transition on iOS

## What changed

### relay-server/src/types.ts
Two new outgoing events (shared contract — same shape as desktop NAN-690):
```typescript
tool_call.completed  { callId, name, durationMs, result }
tool_call.failed     { callId, name, durationMs, error, cancelled }
```
`cancelled: true` means user interrupted mid-turn; `false` is a real failure.

### relay-server/src/session.ts
- Added `toolStartTimes: Map<string, number>` to track wall-clock start per callId
- `emitToolCompleted` / `emitToolFailed` helpers that compute `durationMs` and send events
- Wired into all execution paths: sync tools, blocking web_search, async web_search, blocking ask_brain, async ask_brain — including all abort/cancellation branches

### mobile/lib/use-realtime.ts
- New callbacks: `onToolCompleted`, `onToolFailed` (with `cancelled: boolean`)
- Dispatches `tool_call.completed` and `tool_call.failed` WS messages to callbacks

### mobile/components/tool-call-row.tsx (new)
- `ToolCallRow` component with four visual states
- Live elapsed timer via 250 ms interval (cleared on completion)
- Args summary smart-truncated to one line; errors auto-expanded
- `ExpandedContent` with ScrollView for large payloads (lazy — not mounted until tap)
- Uses platform monospace font (Menlo on iOS)

### mobile/app/(tabs)/index.tsx
- `toolCalls: Map<string, ToolCallItem>` state (ephemeral, not persisted)
- `buildDisplayItems` helper merges messages + tool calls by timestamp
- FlatList updated to render `DisplayItem` union (`message` | `tool_call`)
- Tool calls cleared on conversation switch / new conversation

### docs/src/content/docs/mobile/tool-activity.mdx (new)
User-facing doc explaining what the rows mean, four states, tap behaviour, and multi-step calls.

## Coordination note for desktop (NAN-690)
The relay protocol additions (`tool_call.completed` / `tool_call.failed`) are landed here per the coordinator's spec. The desktop agent should consume the same event shapes verbatim — no changes needed on their side.

## Test plan
- [ ] Trigger `ask_brain` via voice on device → spinner row appears with live timer
- [ ] On completion → row transitions to checkmark, duration frozen, tap expands result JSON
- [ ] On error → row auto-expands with red error message
- [ ] Interrupt mid-turn → row shows dash (cancelled state), no error styling
- [ ] Multiple sequential tool calls → separate rows in chronological order
- [ ] Scroll 50+ tool call chat → 60fps maintained (FlatList virtualization)
- [ ] Tap to collapse expanded row → LayoutAnimation fires smoothly

## Build note
Device (iPhone 12 Pro) was offline during testing window. Build compiled without TS errors against the relay-server and mobile type systems. Simulator test pending device reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)