### PR TITLE
feat(desktop): reveal-logs button + wire PostHog telemetry (NAN-692)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -139,6 +139,11 @@ jobs:
           # binary can't shell out to git.
           GIT_SHA: ${{ steps.meta.outputs.git_sha }}
           RELAY_VERSION: ${{ steps.meta.outputs.relay_version }}
+          # PostHog telemetry tokens. VITE_* is picked up by the renderer
+          # bundle; NEXT_PUBLIC_* is accepted by the main-process posthog-node
+          # wrapper. Both must be set for full coverage.
+          VITE_POSTHOG_PROJECT_TOKEN: ${{ secrets.VITE_POSTHOG_PROJECT_TOKEN }}
+          NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ secrets.VITE_POSTHOG_PROJECT_TOKEN }}
         run: yarn dist:mac --publish never -c.forceCodeSigning=true
 
       # Launch the freshly-signed-and-notarized .app against an isolated

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -42,6 +42,7 @@ import {
   capture as telemetryCapture,
   captureException,
   flush as flushTelemetry,
+  getDistinctId,
   identify as telemetryIdentify,
   registerProcessHandlers as registerTelemetryHandlers,
   shutdown as shutdownTelemetry,
@@ -90,8 +91,9 @@ app.whenReady().then(async () => {
   registerIpcHandlers()
   registerScreenCaptureHandlers()
   registerTelemetryHandlers()
+  const firstLaunch = isFirstLaunch()
   telemetryIdentify()
-  telemetryCapture('app_launched', { dev: isDev })
+  telemetryCapture('app_launched', { dev: isDev, first_launch: firstLaunch })
 
   const wasOpenedAsHidden = app.getLoginItemSettings().wasOpenedAsHidden
 
@@ -284,6 +286,20 @@ function isCallBarEnabled(): boolean {
     return row?.value !== 'false'
   } catch {
     return true
+  }
+}
+
+function isFirstLaunch(): boolean {
+  try {
+    const db = getDb()
+    const row = db
+      .prepare('SELECT value FROM settings WHERE key = ?')
+      .get('telemetry_distinct_id') as { value: string } | undefined
+    const isNew = !row?.value
+    getDistinctId()
+    return isNew
+  } catch {
+    return false
   }
 }
 

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { dialog, ipcMain, net, shell, systemPreferences } from 'electron'
+import { app, dialog, ipcMain, net, shell, systemPreferences } from 'electron'
 import { getDb } from './db'
 import { isLaunchAtLoginEnabled, setLaunchAtLogin } from './login-items'
 import { serviceManager } from './services/service-manager'
@@ -346,6 +346,13 @@ export function registerIpcHandlers() {
       return speakGreetingPreview({ apiKey, voice: params.voice, text: params.text })
     },
   )
+
+  // Logs
+  ipcMain.handle('logs:reveal', async () => {
+    const dir = app.getPath('logs')
+    await shell.openPath(dir)
+    return { ok: true, path: dir }
+  })
 
   // Network: test relay server connection from main process (avoids CORS)
   ipcMain.handle('net:healthCheck', async (_e, url: string) => {

--- a/desktop/src/main/onboarding.ts
+++ b/desktop/src/main/onboarding.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto'
 import { getDb } from './db'
+import { capture as telemetryCapture } from './telemetry'
 
 // Onboarding state — single-row table (id=1) capturing the wizard's
 // resume point and accumulated payload. Renderer reads on mount; if
@@ -110,6 +111,7 @@ export function markOnboardingComplete(): OnboardingState {
   const completedAt = new Date().toISOString()
   const db = getDb()
   db.prepare('UPDATE onboarding_state SET completed_at = ? WHERE id = 1').run(completedAt)
+  telemetryCapture('onboarding_completed')
   return { ...getOnboardingState(), completedAt }
 }
 

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -188,6 +188,9 @@ const electronAPI = {
         }>
       >,
   },
+  logs: {
+    reveal: () => ipcRenderer.invoke('logs:reveal') as Promise<{ ok: boolean, path: string }>,
+  },
   net: {
     healthCheck: (url: string) => ipcRenderer.invoke('net:healthCheck', url) as Promise<{ ok: boolean, error?: string }>,
   },

--- a/desktop/src/renderer/src/lib/db.ts
+++ b/desktop/src/renderer/src/lib/db.ts
@@ -65,6 +65,9 @@ declare global {
         setSetting: (key: string, value: string) => Promise<void>
         getAllSettings: () => Promise<Record<string, string>>
       }
+      logs: {
+        reveal: () => Promise<{ ok: boolean, path: string }>
+      }
       net: {
         healthCheck: (url: string) => Promise<{ ok: boolean, error?: string }>
       }

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -10,6 +10,7 @@ import { VolumeControl } from '../components/VolumeControl'
 import { ToolCallRow } from '../components/ToolCallRow'
 import { ScreenCapture, type ScreenSource } from '../lib/screen-capture'
 import { useRealtime, type RealtimeCallbacks } from '../lib/use-realtime'
+import { captureRenderer } from '../lib/telemetry'
 import { useConversationContext } from '../lib/conversation-context'
 import {
   applyToolCallStarted,
@@ -60,6 +61,8 @@ export function ChatPage() {
   const [screenSourceName, setScreenSourceName] = useState('')
   const screenCaptureRef = useRef<ScreenCapture | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const activeRelayUrlRef = useRef<string>('')
+  const brainCallStartRef = useRef<Map<string, number>>(new Map())
   const { selectedConversationId, selectConversation } = useConversationContext()
 
   // Reload messages from DB — single source of truth, prevents duplicates.
@@ -167,6 +170,7 @@ export function ChatPage() {
       setIsThinking(false)
     },
     onToolCall: async (callId, name, args) => {
+      if (name === 'ask_brain') brainCallStartRef.current.set(callId, Date.now())
       setToolCalls((prev) => applyToolCallStarted(prev, callId, name, args))
       if (name === 'displayText') {
         try {
@@ -193,7 +197,15 @@ export function ChatPage() {
       setStreamingRole('assistant')
       setStreamingText(summary)
     },
-    onBrainResult: async (_callId, query, result, error) => {
+    onBrainResult: async (callId, query, result, error) => {
+      if (error) {
+        const startedAt = brainCallStartRef.current.get(callId)
+        const duration_ms = startedAt != null ? Date.now() - startedAt : 0
+        brainCallStartRef.current.delete(callId)
+        captureRenderer('brain_failed', { error_type: error, duration_ms })
+      } else {
+        brainCallStartRef.current.delete(callId)
+      }
       const body = error
         ? `[Brain] Failed for "${query}": ${error}`
         : `[Brain] ${result ?? ''}`
@@ -215,8 +227,11 @@ export function ChatPage() {
       setStreamingText('')
       streamingRoleRef.current = 'assistant'
     },
-    onError: (message) => {
+    onError: (message, code) => {
       console.error('[ChatPage] Relay error:', message)
+      if (code === 401) {
+        captureRenderer('relay_unauthorized', { relay_url: activeRelayUrlRef.current })
+      }
       setConnectionError(message)
       setIsConnecting(false)
       setIsCallActive(false)
@@ -241,6 +256,7 @@ export function ChatPage() {
     setIsConnecting(true)
     setOutputMuted(false)
     const serverUrl = (await getSetting('realtime_server_url')) || (await defaultRelayUrl())
+    activeRelayUrlRef.current = serverUrl
     const model = normalizeRealtimeModel(await getSetting('realtime_model'))
     const voice = normalizeRealtimeVoice(model, await getSetting('realtime_voice'))
     const apiKey = (await getSetting('realtime_api_key')) || ''

--- a/desktop/src/renderer/src/pages/SettingsPage.tsx
+++ b/desktop/src/renderer/src/pages/SettingsPage.tsx
@@ -644,6 +644,20 @@ export function SettingsPage() {
               Restart
             </Button>
           </div>
+
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-foreground">Reveal Logs in Finder</p>
+              <p className="text-xs text-muted-foreground">Opens ~/Library/Logs/VoiceClaw/ in Finder. Useful when troubleshooting.</p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => { window.electronAPI.logs.reveal() }}
+            >
+              Reveal
+            </Button>
+          </div>
         </Card>
 
         {/* Privacy */}

--- a/docs/src/content/docs/desktop/troubleshooting.mdx
+++ b/docs/src/content/docs/desktop/troubleshooting.mdx
@@ -1,0 +1,20 @@
+---
+title: Troubleshooting VoiceClaw
+description: What to do when something isn't working — how to find log files, reset settings, and get help.
+---
+
+If something isn't working as expected, the first step is to check the log files VoiceClaw writes on your Mac.
+
+## Reveal log files in Finder
+
+Open **Settings → Debug → Reveal Logs in Finder**. This opens the `~/Library/Logs/VoiceClaw/` folder directly in Finder.
+
+Attach the most recent `.log` file when reporting a bug or asking for help — it contains the information needed to diagnose most issues.
+
+## Common problems
+
+**The assistant isn't responding.** Check that your Gemini API key is saved correctly in Settings → Provider. If the key is valid but calls still fail, restart VoiceClaw.
+
+**Microphone isn't working.** Open Settings → Permissions and confirm microphone access is granted. If it shows "Denied", click the link to open System Settings and re-enable it.
+
+**The relay won't connect.** Check the relay URL in Settings. If you're using the built-in relay (default), try Settings → Debug → Re-run onboarding wizard to reset the relay configuration.


### PR DESCRIPTION
## Summary

- **Part A** — Adds a "Reveal Logs in Finder" row to Settings → Debug. Click opens `~/Library/Logs/VoiceClaw/` in Finder via `shell.openPath`. New `logs:reveal` IPC handler + preload bridge + UI row.
- **Part B (CI wiring)** — Injects `VITE_POSTHOG_PROJECT_TOKEN` and `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` into `release-desktop.yml` from repo secret `VITE_POSTHOG_PROJECT_TOKEN`. **Blocked on secret:** no `phc_` token was found anywhere in the codebase or env files — the PostHog project token must be created and added to GitHub Secrets before telemetry flows from production builds. The code path is fully wired; it no-ops when the secret is empty.
- **Part C** — Four high-signal capture events:
  - `app_launched` — now includes `first_launch: boolean` (checks whether `telemetry_distinct_id` existed before this launch)
  - `onboarding_completed` — fires in `markOnboardingComplete()`
  - `relay_unauthorized` — fires in ChatPage `onError` when `code === 401`, with `relay_url`
  - `brain_failed` — fires in `onBrainResult` when error is present, with `error_type` and `duration_ms`

## Test plan

- [ ] Build desktop app and open Settings → Debug — confirm "Reveal Logs in Finder" row is visible
- [ ] Click Reveal — confirm Finder opens at `~/Library/Logs/VoiceClaw/`
- [ ] Verify typecheck passes (`yarn workspace voiceclaw-desktop typecheck`)
- [ ] (After PostHog secret is set) Build a fresh DMG, install, launch — verify `app_launched` event appears in PostHog within 60s
- [ ] Complete onboarding flow — verify `onboarding_completed` event fires
- [ ] Trigger a relay auth failure — verify `relay_unauthorized` event fires with relay_url

## PostHog secret action required

Add `VITE_POSTHOG_PROJECT_TOKEN` to GitHub repo secrets (Settings → Secrets and variables → Actions) with the `phc_...` public write key from the nano3labs PostHog project. The CI workflow is already wired to inject it.

Closes NAN-692

🤖 Generated with [Claude Code](https://claude.com/claude-code)