### PR TITLE
feat(desktop): export diagnostic bundle for support

### DIFF
--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -4,6 +4,7 @@ import { isLaunchAtLoginEnabled, setLaunchAtLogin } from './login-items'
 import { serviceManager } from './services/service-manager'
 import { buildRelayEnv } from './services/relay-server'
 import { applyGeminiKeyToOpenClawConfig } from './services/openclaw-gateway'
+import { buildDiagnosticBundle } from './services/diagnostic-bundle'
 import {
   type AgentIdentity,
   readAgentIdentity,
@@ -352,6 +353,15 @@ export function registerIpcHandlers() {
     const dir = app.getPath('logs')
     await shell.openPath(dir)
     return { ok: true, path: dir }
+  })
+
+  // Diagnostic bundle
+  ipcMain.handle('diagnostics:export', async () => {
+    const result = await buildDiagnosticBundle()
+    if (result.ok) {
+      shell.showItemInFolder(result.path)
+    }
+    return result
   })
 
   // Network: test relay server connection from main process (avoids CORS)

--- a/desktop/src/main/services/diagnostic-bundle.test.ts
+++ b/desktop/src/main/services/diagnostic-bundle.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { redactOpenClawConfig } from './diagnostic-bundle'
+
+describe('redactOpenClawConfig', () => {
+  it('replaces apiKey values with <redacted>', () => {
+    const config = {
+      models: {
+        mode: 'merge',
+        providers: {
+          google: { apiKey: 'AIzaSyABCDEF1234567890realkey', model: 'gemini-pro' },
+          openai: { apiKey: 'sk-real-openai-key-here', model: 'gpt-4' },
+        },
+      },
+    }
+
+    const result = redactOpenClawConfig(config)
+
+    const providers = (result.models as Record<string, unknown>)
+      .providers as Record<string, Record<string, unknown>>
+    expect(providers.google.apiKey).toBe('<redacted>')
+    expect(providers.openai.apiKey).toBe('<redacted>')
+  })
+
+  it('does not contain the original key string in the output JSON', () => {
+    const realKey = 'AIzaSyABCDEF1234567890realkey'
+    const config = {
+      models: {
+        providers: { google: { apiKey: realKey } },
+      },
+    }
+
+    const result = redactOpenClawConfig(config)
+    const json = JSON.stringify(result)
+
+    expect(json).not.toContain(realKey)
+    expect(json).toContain('<redacted>')
+  })
+
+  it('redacts gateway auth token', () => {
+    const config = {
+      gateway: { auth: { mode: 'token', token: 'super-secret-token-abc123' } },
+    }
+
+    const result = redactOpenClawConfig(config)
+    const gateway = result.gateway as Record<string, Record<string, unknown>>
+    expect(gateway.auth.token).toBe('<redacted>')
+    expect(JSON.stringify(result)).not.toContain('super-secret-token-abc123')
+  })
+
+  it('does not mutate the original config', () => {
+    const config = {
+      models: { providers: { google: { apiKey: 'original-key' } } },
+    }
+    redactOpenClawConfig(config)
+    const providers = config.models.providers as Record<string, Record<string, unknown>>
+    expect(providers.google.apiKey).toBe('original-key')
+  })
+
+  it('handles missing providers gracefully', () => {
+    const config = { models: { mode: 'merge' } }
+    expect(() => redactOpenClawConfig(config)).not.toThrow()
+  })
+
+  it('handles empty config gracefully', () => {
+    expect(() => redactOpenClawConfig({})).not.toThrow()
+  })
+
+  it('handles provider without apiKey', () => {
+    const config = {
+      models: {
+        providers: {
+          localModel: { endpoint: 'http://localhost:1234' },
+        },
+      },
+    }
+    const result = redactOpenClawConfig(config)
+    const providers = (result.models as Record<string, unknown>)
+      .providers as Record<string, Record<string, unknown>>
+    expect(providers.localModel.endpoint).toBe('http://localhost:1234')
+    expect('apiKey' in providers.localModel).toBe(false)
+  })
+})

--- a/desktop/src/main/services/diagnostic-bundle.ts
+++ b/desktop/src/main/services/diagnostic-bundle.ts
@@ -1,0 +1,284 @@
+import { app } from 'electron'
+import { createRequire } from 'module'
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+  createWriteStream,
+} from 'fs'
+import { join } from 'path'
+import { release } from 'os'
+import { getDb } from '../db'
+import { getLogDir } from '../logs'
+import { serviceManager } from './service-manager'
+import { getOpenClawConfigPath } from './openclaw-gateway'
+import { getDistinctId } from '../telemetry'
+
+const require = createRequire(import.meta.url)
+const archiver = require('archiver') as typeof import('archiver').default
+
+export type BundleResult = { ok: true; path: string } | { ok: false; error: string }
+
+export async function buildDiagnosticBundle(): Promise<BundleResult> {
+  const timestamp = formatTimestamp(new Date())
+  const tempDir = join(app.getPath('temp'), `voiceclaw-diag-${timestamp}`)
+  const outPath = join(app.getPath('home'), 'Downloads', `voiceclaw-diagnostics-${timestamp}.zip`)
+
+  try {
+    mkdirSync(tempDir, { recursive: true })
+
+    await Promise.all([
+      writeSystemInfo(tempDir),
+      writeLogs(tempDir),
+      writeOpenClawConfig(tempDir),
+      writeWorkspaceManifest(tempDir),
+      writeDbDump(tempDir),
+      writeServiceHealth(tempDir),
+    ])
+
+    await zipDir(tempDir, outPath)
+    return { ok: true, path: outPath }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  } finally {
+    try {
+      rmSync(tempDir, { recursive: true, force: true })
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bundle sections
+// ---------------------------------------------------------------------------
+
+async function writeSystemInfo(dir: string): Promise<void> {
+  const distinctId = safeGet(() => getDistinctId()) ?? null
+  const info = {
+    appVersion: app.getVersion(),
+    platform: process.platform,
+    arch: process.arch,
+    osRelease: release(),
+    electronVersion: process.versions.electron,
+    nodeVersion: process.versions.node,
+    bundledAt: new Date().toISOString(),
+    telemetryDistinctId: distinctId,
+  }
+  writeJson(join(dir, 'system.json'), info)
+}
+
+function writeLogs(dir: string): Promise<void> {
+  return new Promise((resolve) => {
+    const logDir = safeGet(() => getLogDir())
+    if (!logDir || !existsSync(logDir)) {
+      resolve()
+      return
+    }
+    const destDir = join(dir, 'logs')
+    mkdirSync(destDir, { recursive: true })
+    const cutoff = Date.now() - 7 * 24 * 60 * 60 * 1000
+    let entries: string[] = []
+    try {
+      entries = readdirSync(logDir)
+    } catch {
+      resolve()
+      return
+    }
+    for (const name of entries) {
+      if (!name.endsWith('.log')) continue
+      const src = join(logDir, name)
+      try {
+        const st = statSync(src)
+        if (st.mtimeMs < cutoff) continue
+        writeFileSync(join(destDir, name), readFileSync(src))
+      } catch {
+        // skip unreadable files
+      }
+    }
+    resolve()
+  })
+}
+
+function writeOpenClawConfig(dir: string): Promise<void> {
+  return new Promise((resolve) => {
+    const configPath = safeGet(() => getOpenClawConfigPath())
+    if (!configPath || !existsSync(configPath)) {
+      resolve()
+      return
+    }
+    try {
+      const raw = readFileSync(configPath, 'utf8')
+      const parsed = JSON.parse(raw) as Record<string, unknown>
+      const redacted = redactOpenClawConfig(parsed)
+      writeJson(join(dir, 'openclaw-config.redacted.json'), redacted)
+    } catch {
+      // missing or invalid config — skip without crashing
+    }
+    resolve()
+  })
+}
+
+function writeWorkspaceManifest(dir: string): Promise<void> {
+  return new Promise((resolve) => {
+    const stateDir = join(app.getPath('userData'), 'openclaw')
+    const workspaceDir = join(stateDir, 'workspace')
+    if (!existsSync(workspaceDir)) {
+      resolve()
+      return
+    }
+    const lines: string[] = ['# Workspace file inventory (names + sizes; no contents)']
+    try {
+      for (const name of readdirSync(workspaceDir)) {
+        try {
+          const st = statSync(join(workspaceDir, name))
+          lines.push(`${name}\t${st.size} bytes`)
+        } catch {
+          lines.push(`${name}\t(unreadable)`)
+        }
+      }
+    } catch {
+      // empty workspace or no access
+    }
+    writeFileSync(join(dir, 'workspace-manifest.txt'), lines.join('\n') + '\n')
+    resolve()
+  })
+}
+
+function writeDbDump(dir: string): Promise<void> {
+  return new Promise((resolve) => {
+    try {
+      const db = getDb()
+
+      const schemaRows = db
+        .prepare('SELECT sql FROM sqlite_schema WHERE sql IS NOT NULL ORDER BY type, name')
+        .all() as { sql: string }[]
+      const schemaText = schemaRows.map((r) => r.sql + ';').join('\n\n')
+      writeFileSync(join(dir, 'schema.sql'), schemaText + '\n')
+
+      const settingKeys = db
+        .prepare('SELECT key FROM settings ORDER BY key')
+        .all() as { key: string }[]
+      writeFileSync(
+        join(dir, 'settings-keys.txt'),
+        '# Setting keys (no values)\n' + settingKeys.map((r) => r.key).join('\n') + '\n',
+      )
+
+      const telemetryRow = db
+        .prepare("SELECT value FROM settings WHERE key = 'telemetry_distinct_id'")
+        .get() as { value: string } | undefined
+      if (telemetryRow) {
+        writeFileSync(join(dir, 'telemetry-id.txt'), telemetryRow.value + '\n')
+      }
+
+      const providerInventory = safeGet(() => {
+        const rows = db
+          .prepare('SELECT provider FROM provider_keys ORDER BY provider')
+          .all() as { provider: string }[]
+        return rows.map((r) => r.provider)
+      }) ?? []
+      writeFileSync(
+        join(dir, 'provider-keys-inventory.txt'),
+        '# Providers with a saved key (no key values)\n' + providerInventory.join('\n') + '\n',
+      )
+    } catch {
+      // DB not initialized on fresh install — skip
+    }
+    resolve()
+  })
+}
+
+function writeServiceHealth(dir: string): Promise<void> {
+  return new Promise((resolve) => {
+    try {
+      const statuses = serviceManager.getAllStatuses()
+      writeJson(join(dir, 'services-health.json'), statuses)
+    } catch {
+      // serviceManager unavailable
+    }
+    resolve()
+  })
+}
+
+// ---------------------------------------------------------------------------
+// ZIP
+// ---------------------------------------------------------------------------
+
+function zipDir(srcDir: string, outPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const output = createWriteStream(outPath)
+    const archive = archiver('zip', { zlib: { level: 6 } })
+
+    output.on('close', resolve)
+    archive.on('error', reject)
+    archive.pipe(output)
+    archive.directory(srcDir, false)
+    archive.finalize()
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+export function redactOpenClawConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const copy = deepClone(config)
+  redactProviderKeys(copy)
+  redactGatewayToken(copy)
+  return copy
+}
+
+function redactProviderKeys(obj: Record<string, unknown>): void {
+  const models = obj.models as Record<string, unknown> | undefined
+  if (!models) return
+  const providers = models.providers as Record<string, unknown> | undefined
+  if (!providers) return
+  for (const providerName of Object.keys(providers)) {
+    const provider = providers[providerName] as Record<string, unknown> | undefined
+    if (provider && typeof provider === 'object' && 'apiKey' in provider) {
+      provider.apiKey = '<redacted>'
+    }
+  }
+}
+
+function redactGatewayToken(obj: Record<string, unknown>): void {
+  const gateway = obj.gateway as Record<string, unknown> | undefined
+  if (!gateway) return
+  const auth = gateway.auth as Record<string, unknown> | undefined
+  if (!auth) return
+  if ('token' in auth) {
+    auth.token = '<redacted>'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function deepClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function writeJson(path: string, data: unknown): void {
+  writeFileSync(path, JSON.stringify(data, null, 2) + '\n')
+}
+
+function safeGet<T>(fn: () => T): T | undefined {
+  try {
+    return fn()
+  } catch {
+    return undefined
+  }
+}
+
+function formatTimestamp(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+    `-${pad(d.getHours())}${pad(d.getMinutes())}`
+  )
+}

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -206,6 +206,12 @@ const electronAPI = {
       context?: Record<string, unknown>,
     ) => ipcRenderer.invoke('telemetry:captureException', err, context) as Promise<void>,
   },
+  diagnostics: {
+    export: () =>
+      ipcRenderer.invoke('diagnostics:export') as Promise<
+        { ok: true; path: string } | { ok: false; error: string }
+      >,
+  },
 }
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI)

--- a/desktop/src/renderer/src/lib/db.ts
+++ b/desktop/src/renderer/src/lib/db.ts
@@ -44,6 +44,9 @@ declare global {
   interface Window {
     electronAPI: {
       platform: string
+      diagnostics?: {
+        export: () => Promise<{ ok: true; path: string } | { ok: false; error: string }>
+      }
       db: {
         createConversation: (title?: string) => Promise<Conversation>
         getLatestConversation: () => Promise<Conversation | null>

--- a/desktop/src/renderer/src/pages/SettingsPage.tsx
+++ b/desktop/src/renderer/src/pages/SettingsPage.tsx
@@ -77,6 +77,8 @@ export function SettingsPage() {
   const [debugMode, setDebugMode] = useState(false)
   const [showLatency, setShowLatency] = useState(false)
   const [tracingEnabled, setTracingEnabled] = useState(false)
+  const [exportingBundle, setExportingBundle] = useState(false)
+  const [bundleToast, setBundleToast] = useState<{ ok: boolean; message: string } | null>(null)
 
   // Agent identity (name + description)
   const [agentName, setAgentName] = useState('')
@@ -283,6 +285,36 @@ export function SettingsPage() {
   const toggleTelemetry = useCallback(async (v: boolean) => {
     setTelemetryEnabled(v)
     await setOptedOutRenderer(!v)
+  }, [])
+
+  const exportBundle = useCallback(async () => {
+    const SUPPRESS_KEY = 'diag_privacy_preview_suppressed'
+    const suppressed = await getSetting(SUPPRESS_KEY)
+    if (suppressed !== 'true') {
+      const confirmed = await showPrivacyPreview()
+      if (!confirmed.proceed) return
+      if (confirmed.suppress) await setSetting(SUPPRESS_KEY, 'true')
+    }
+
+    setExportingBundle(true)
+    setBundleToast(null)
+    try {
+      const result = await window.electronAPI?.diagnostics?.export?.()
+      if (!result) {
+        setBundleToast({ ok: false, message: 'Export not available.' })
+        return
+      }
+      if (result.ok) {
+        setBundleToast({ ok: true, message: 'Diagnostic bundle saved to Downloads.' })
+      } else {
+        setBundleToast({ ok: false, message: result.error })
+      }
+    } catch (err) {
+      setBundleToast({ ok: false, message: err instanceof Error ? err.message : 'Export failed.' })
+    } finally {
+      setExportingBundle(false)
+      setTimeout(() => setBundleToast(null), 6000)
+    }
   }, [])
 
   const resetBundled = useCallback(async () => {
@@ -658,6 +690,32 @@ export function SettingsPage() {
               Reveal
             </Button>
           </div>
+
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-foreground">Export diagnostic bundle</p>
+              <p className="text-xs text-muted-foreground">Bundles logs and config (with API keys redacted) for support. Saved to Downloads.</p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={exportBundle}
+              disabled={exportingBundle}
+            >
+              {exportingBundle ? (
+                <span className="flex items-center gap-1.5">
+                  <span className="h-3.5 w-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                  Bundling…
+                </span>
+              ) : 'Export'}
+            </Button>
+          </div>
+
+          {bundleToast && (
+            <p className={`text-xs ${bundleToast.ok ? 'text-[var(--brand-sage)]' : 'text-destructive'}`}>
+              {bundleToast.message}
+            </p>
+          )}
         </Card>
 
         {/* Privacy */}
@@ -691,6 +749,68 @@ export function SettingsPage() {
       </div>
     </div>
   )
+}
+
+function showPrivacyPreview(): Promise<{ proceed: boolean; suppress: boolean }> {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div')
+    overlay.style.cssText =
+      'position:fixed;inset:0;z-index:9999;background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center'
+
+    const modal = document.createElement('div')
+    modal.style.cssText =
+      'background:var(--background,#1a1a1a);color:var(--foreground,#fff);border:1px solid var(--border,#333);border-radius:8px;padding:20px;max-width:420px;width:90%;font-family:inherit;font-size:13px;line-height:1.5'
+
+    modal.innerHTML = `
+      <p style="font-weight:600;margin-bottom:12px">What goes in the bundle?</p>
+      <p style="margin-bottom:6px;color:var(--muted-foreground,#999);font-size:12px">INCLUDED</p>
+      <ul style="margin:0 0 12px 16px;padding:0;color:var(--foreground,#fff);font-size:12px">
+        <li>App version, platform, OS</li>
+        <li>Last 7 days of log files</li>
+        <li>OpenClaw config (API keys replaced with &lt;redacted&gt;)</li>
+        <li>Workspace file names + sizes (no file contents)</li>
+        <li>Database schema only (no message history)</li>
+        <li>List of configured provider names (no key values)</li>
+        <li>Service health snapshot</li>
+      </ul>
+      <p style="margin-bottom:6px;color:var(--muted-foreground,#999);font-size:12px">NOT INCLUDED</p>
+      <ul style="margin:0 0 16px 16px;padding:0;color:var(--muted-foreground,#999);font-size:12px">
+        <li>API keys or auth tokens</li>
+        <li>Conversation history or messages</li>
+        <li>Workspace file contents</li>
+        <li>Audio recordings</li>
+      </ul>
+      <label style="display:flex;align-items:center;gap:8px;margin-bottom:16px;font-size:12px;cursor:pointer">
+        <input type="checkbox" id="diag-suppress" style="cursor:pointer" />
+        Don't ask again
+      </label>
+      <div style="display:flex;gap:8px;justify-content:flex-end">
+        <button id="diag-cancel" style="padding:6px 14px;border-radius:5px;border:1px solid var(--border,#444);background:transparent;color:var(--foreground,#fff);font-size:13px;cursor:pointer">Cancel</button>
+        <button id="diag-ok" style="padding:6px 14px;border-radius:5px;border:none;background:var(--primary,#4a7c59);color:#fff;font-size:13px;cursor:pointer;font-weight:500">Export</button>
+      </div>
+    `
+
+    overlay.appendChild(modal)
+    document.body.appendChild(overlay)
+
+    const cleanup = () => document.body.removeChild(overlay)
+
+    modal.querySelector('#diag-cancel')!.addEventListener('click', () => {
+      cleanup()
+      resolve({ proceed: false, suppress: false })
+    })
+    modal.querySelector('#diag-ok')!.addEventListener('click', () => {
+      const suppress = (modal.querySelector('#diag-suppress') as HTMLInputElement).checked
+      cleanup()
+      resolve({ proceed: true, suppress })
+    })
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) {
+        cleanup()
+        resolve({ proceed: false, suppress: false })
+      }
+    })
+  })
 }
 
 function maskKey(key: string): string {

--- a/docs/src/content/docs/desktop/troubleshooting.mdx
+++ b/docs/src/content/docs/desktop/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting VoiceClaw
-description: What to do when something isn't working — how to find log files, reset settings, and get help.
+description: What to do when something isn't working — how to find log files, export a diagnostic bundle, and get help.
 ---
 
 If something isn't working as expected, the first step is to check the log files VoiceClaw writes on your Mac.
@@ -10,6 +10,38 @@ If something isn't working as expected, the first step is to check the log files
 Open **Settings → Debug → Reveal Logs in Finder**. This opens the `~/Library/Logs/VoiceClaw/` folder directly in Finder.
 
 Attach the most recent `.log` file when reporting a bug or asking for help — it contains the information needed to diagnose most issues.
+
+## Export a diagnostic bundle
+
+If our team asks for more detail, you can export a bundle with one click:
+
+1. Open VoiceClaw and go to **Settings**.
+2. Scroll to the **Debug** section.
+3. Click **Export** next to "Export diagnostic bundle".
+4. On first run, a preview dialog tells you exactly what will and won't be included. Click **Export** to continue (check "Don't ask again" to skip this in the future).
+5. The bundle is saved to your **Downloads** folder and revealed in Finder automatically.
+6. Attach the ZIP file to your support email or GitHub issue.
+
+### What's in the bundle
+
+| Item | Notes |
+|------|-------|
+| App version, platform, OS | As-is |
+| Log files (last 7 days) | As-is |
+| OpenClaw config | **API keys replaced with `<redacted>`** |
+| Workspace file list | Names and sizes only — no file contents |
+| Database schema | Table definitions only — no messages or history |
+| List of configured providers | Provider names only — no key values |
+| Service health snapshot | Relay and OpenClaw status at export time |
+
+### What's never included
+
+- API keys or auth tokens
+- Conversation history or voice transcripts
+- Workspace file contents (SOUL.md, IDENTITY.md, etc.)
+- Audio recordings
+
+The bundle is a plain ZIP — no encryption, no automatic upload. It goes wherever you send it.
 
 ## Common problems
 


### PR DESCRIPTION
Adds Settings → Debug → Export diagnostic bundle. Produces a ZIP in ~/Downloads with logs + redacted OpenClaw config + DB schema + service health. Privacy preview dialog on first run. 7 unit tests verify API key redaction.