### PR TITLE
feat(desktop): show/hide toggle on onboarding API key field (NAN-683)

### DIFF
--- a/desktop/src/renderer/src/pages/onboarding/StepProvider.tsx
+++ b/desktop/src/renderer/src/pages/onboarding/StepProvider.tsx
@@ -217,7 +217,7 @@ export function StepProvider({
               onClick={() => setShowKey((prev) => !prev)}
               aria-label={showKey ? 'Hide API key' : 'Show API key'}
               aria-pressed={showKey}
-              className="absolute right-3 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-[10px] transition-colors hover:bg-[var(--panel)] focus:bg-[var(--panel)] focus:outline-none"
+              className="absolute right-3 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-[10px] transition-colors hover:bg-[var(--panel)] focus:bg-[var(--panel)] focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-[var(--ink)]"
               style={{ color: 'var(--muted)' }}
             >
               {showKey ? (

--- a/desktop/src/renderer/src/pages/onboarding/StepProvider.tsx
+++ b/desktop/src/renderer/src/pages/onboarding/StepProvider.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Eye, EyeOff } from 'lucide-react'
 import { StepFrame } from './StepFrame'
 import {
   providerApi,
@@ -69,6 +70,7 @@ export function StepProvider({
     PROVIDERS.some((p) => p.id === initialProvider) ? initialProvider : 'gemini',
   )
   const [apiKey, setApiKey] = useState('')
+  const [showKey, setShowKey] = useState(false)
   const [validation, setValidation] = useState<ValidationState>({ kind: 'empty' })
   const active = PROVIDERS.find((p) => p.id === selected) ?? PROVIDERS[0]
 
@@ -147,6 +149,7 @@ export function StepProvider({
             onSelect={() => {
               setSelected(provider.id)
               setApiKey('')
+              setShowKey(false)
               setValidation({ kind: 'empty' })
             }}
           />
@@ -189,9 +192,9 @@ export function StepProvider({
         </div>
 
         <div className="mt-5 flex items-stretch gap-3">
-          <div className="flex-1">
+          <div className="relative flex-1">
             <input
-              type="password"
+              type={showKey ? 'text' : 'password'}
               value={apiKey}
               onChange={(e) => handleKeyChange(e.target.value)}
               onBlur={() => {
@@ -200,7 +203,7 @@ export function StepProvider({
                 }
               }}
               placeholder={active.placeholder}
-              className="w-full rounded-[14px] border px-5 py-4 text-[15px] outline-none transition-colors focus:border-[var(--ink)]"
+              className="w-full rounded-[14px] border py-4 pl-5 pr-14 text-[15px] outline-none transition-colors focus:border-[var(--ink)]"
               style={{
                 fontFamily: 'var(--font-mono)',
                 borderColor: 'var(--line-strong)',
@@ -209,6 +212,20 @@ export function StepProvider({
                 letterSpacing: '0.04em',
               }}
             />
+            <button
+              type="button"
+              onClick={() => setShowKey((prev) => !prev)}
+              aria-label={showKey ? 'Hide API key' : 'Show API key'}
+              aria-pressed={showKey}
+              className="absolute right-3 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-[10px] transition-colors hover:bg-[var(--panel)] focus:bg-[var(--panel)] focus:outline-none"
+              style={{ color: 'var(--muted)' }}
+            >
+              {showKey ? (
+                <EyeOff className="h-4 w-4" aria-hidden="true" />
+              ) : (
+                <Eye className="h-4 w-4" aria-hidden="true" />
+              )}
+            </button>
           </div>
           <ValidationBadge state={validation} />
         </div>


### PR DESCRIPTION
## Why
- Onboarding masks the API key, but users have no way to verify what they pasted — they either retype blindly or delete and start over.
- A standard eye-toggle is the lowest-friction fix and keeps masked-by-default for shoulder-surfing safety.

## What
- `StepProvider.tsx`: added `showKey` state (default `false`) and an `Eye`/`EyeOff` button (`lucide-react`) absolutely positioned at the right edge of the API key input.
- Switched input `type` to `showKey ? 'text' : 'password'`.
- Reset `showKey` when the user changes provider (the same place we reset `apiKey`).
- Tweaked input padding (`pr-14`) so the key text never collides with the toggle.
- `aria-label` flips between `Show API key` / `Hide API key`; `aria-pressed` reflects state; `type="button"` so it doesn't submit.
- No changes to validation, the `Continue` button gating, or any other onboarding step.

## Screenshots
Reference from the ticket:

![ticket reference](https://files.openclaw.ai/inbound/file_625---ea6d79a4-f9db-4911-85a2-fed21d01ce0b.jpg)

Before/after captures of the running UI weren't taken — the component lives in the Electron renderer with a preload-bridged onboarding API, so it's not trivially bootable in headless Playwright. Verified via `yarn workspace voiceclaw-desktop typecheck` + `build`. Worth a manual eyeball in `yarn workspace voiceclaw-desktop dev` before merging.

## Test plan
- [ ] `yarn workspace voiceclaw-desktop dev`, walk to the provider step
- [ ] Field starts masked; eye icon visible at right edge
- [ ] Click eye → key reveals as plaintext, icon flips to `EyeOff`
- [ ] Click again → re-masks, icon flips back to `Eye`
- [ ] Switch provider (Gemini ↔ Grok) → input clears AND re-masks
- [ ] Paste a key, tab out → still validates and shows the existing badge
- [ ] `Continue` flow unchanged (validate → green check → continue)
- [ ] Keyboard: Tab focuses the toggle, Space/Enter activates it
- [ ] Screen reader announces `Show API key` / `Hide API key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)