### PR TITLE
feat(website): social share banner via opengraph-image (NAN-672)

### DIFF
--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -39,10 +39,27 @@ const themeScript = `
 })()
 `
 
+const SITE_URL = "https://voiceclaw.io"
+const SITE_TITLE = "VoiceClaw - Voice for the Agent You Already Trust"
+const SITE_DESCRIPTION =
+  "VoiceClaw is an open source voice layer for your own agent on iPhone and Mac."
+
 export const metadata: Metadata = {
-  title: "VoiceClaw - Voice for the Agent You Already Trust",
-  description:
-    "VoiceClaw is an open source voice layer for your own agent on iPhone and Mac.",
+  metadataBase: new URL(SITE_URL),
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    type: "website",
+    url: SITE_URL,
+    siteName: "VoiceClaw",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
 }
 
 export default function RootLayout({

--- a/website/src/app/opengraph-image.tsx
+++ b/website/src/app/opengraph-image.tsx
@@ -1,0 +1,193 @@
+import { ImageResponse } from "next/og"
+
+export const alt = "VoiceClaw — Voice for the agent you already trust."
+export const size = { width: 1200, height: 630 }
+export const contentType = "image/png"
+
+const PAPER = "#F1E8DA"
+const PAPER_STRONG = "#E8DDCD"
+const PANEL = "#FDF9F1"
+const INK = "#191511"
+const MUTED = "#665F58"
+const ACCENT = "#B4492F"
+const LINE = "rgba(25, 21, 17, 0.2)"
+
+export default async function OpenGraphImage() {
+  const [fraunces, jetbrains] = await Promise.all([
+    loadGoogleFont("Fraunces", 600),
+    loadGoogleFont("JetBrains Mono", 500),
+  ])
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          background: PAPER,
+          backgroundImage: `linear-gradient(135deg, ${PAPER} 0%, ${PAPER_STRONG} 100%)`,
+          color: INK,
+          padding: 80,
+          fontFamily: "Fraunces",
+          position: "relative",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            backgroundImage: `linear-gradient(to right, rgba(25,21,17,0.06) 1px, transparent 1px), linear-gradient(to bottom, rgba(25,21,17,0.06) 1px, transparent 1px)`,
+            backgroundSize: "112px 112px",
+            opacity: 0.7,
+          }}
+        />
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 16,
+            fontFamily: "JetBrains Mono",
+            fontSize: 22,
+            color: MUTED,
+            letterSpacing: 2,
+            textTransform: "uppercase",
+            zIndex: 1,
+          }}
+        >
+          <Mark />
+          <span>Open source voice layer</span>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            flex: 1,
+            justifyContent: "center",
+            zIndex: 1,
+          }}
+        >
+          <div
+            style={{
+              fontFamily: "Fraunces",
+              fontSize: 168,
+              lineHeight: 0.95,
+              color: INK,
+              letterSpacing: -2,
+            }}
+          >
+            VoiceClaw
+          </div>
+          <div
+            style={{
+              marginTop: 28,
+              fontFamily: "Fraunces",
+              fontSize: 64,
+              lineHeight: 1.05,
+              color: INK,
+              maxWidth: 980,
+            }}
+          >
+            Voice for the agent you already trust.
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            paddingTop: 28,
+            borderTop: `1px solid ${LINE}`,
+            zIndex: 1,
+          }}
+        >
+          <div
+            style={{
+              fontFamily: "JetBrains Mono",
+              fontSize: 22,
+              color: MUTED,
+              letterSpacing: 1.5,
+            }}
+          >
+            iPhone · Mac · BYO agent
+          </div>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 14,
+              padding: "10px 18px",
+              border: `1px solid ${LINE}`,
+              background: PANEL,
+              borderRadius: 8,
+              fontFamily: "JetBrains Mono",
+              fontSize: 22,
+              color: INK,
+              letterSpacing: 1.5,
+            }}
+          >
+            <span
+              style={{
+                width: 12,
+                height: 12,
+                borderRadius: 999,
+                background: ACCENT,
+              }}
+            />
+            voiceclaw.io
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [
+        { name: "Fraunces", data: fraunces, style: "normal", weight: 600 },
+        { name: "JetBrains Mono", data: jetbrains, style: "normal", weight: 500 },
+      ],
+    },
+  )
+}
+
+async function loadGoogleFont(family: string, weight: number): Promise<ArrayBuffer> {
+  const cssUrl = `https://fonts.googleapis.com/css2?family=${encodeURIComponent(family)}:wght@${weight}`
+  const cssResponse = await fetch(cssUrl, {
+    headers: {
+      "User-Agent":
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Safari/534.50",
+    },
+  })
+  if (!cssResponse.ok) {
+    throw new Error(`Failed to fetch font CSS for ${family}: ${cssResponse.status}`)
+  }
+  const css = await cssResponse.text()
+  const match = css.match(/src:\s*url\((https:\/\/[^)]+)\)/)
+  if (!match) {
+    throw new Error(`Could not find font URL for ${family}`)
+  }
+  const fontResponse = await fetch(match[1])
+  if (!fontResponse.ok) {
+    throw new Error(`Failed to fetch font file for ${family}: ${fontResponse.status}`)
+  }
+  return fontResponse.arrayBuffer()
+}
+
+function Mark() {
+  return (
+    <svg width="40" height="40" viewBox="0 0 64 64" fill="none">
+      <path d="M20 10 H14 V54 H20" stroke={INK} strokeWidth="4" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M20 10 L27 17" stroke={INK} strokeWidth="4" strokeLinecap="round" />
+      <path d="M20 54 L27 47" stroke={INK} strokeWidth="4" strokeLinecap="round" />
+      <path d="M44 10 H50 V54 H44" stroke={INK} strokeWidth="4" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M44 10 L37 17" stroke={INK} strokeWidth="4" strokeLinecap="round" />
+      <path d="M44 54 L37 47" stroke={INK} strokeWidth="4" strokeLinecap="round" />
+      <path d="M29 40 V24" stroke={ACCENT} strokeWidth="4.5" strokeLinecap="round" />
+      <path d="M35 46 V18" stroke={INK} strokeWidth="4.5" strokeLinecap="round" />
+      <path d="M41 37 V27" stroke={INK} strokeWidth="4.5" strokeLinecap="round" />
+    </svg>
+  )
+}

--- a/website/src/app/twitter-image.tsx
+++ b/website/src/app/twitter-image.tsx
@@ -1,0 +1,1 @@
+export { default, alt, size, contentType } from "./opengraph-image"


### PR DESCRIPTION
## Why

Sharing voiceclaw.io on X, LinkedIn, or Telegram currently gets a generic preview because there is no `og:image` and no `twitter:card` configured. This wires a proper 1200x630 social banner so the link looks like the rest of the brand.

Linear: NAN-672

## What

Picked **Option B** (Next.js file-convention OG image) because it keeps the asset in code, themed with the same brand tokens as the site, and there is no committed binary to drift.

- New `website/src/app/opengraph-image.tsx` — renders a 1200x630 PNG with `ImageResponse` from `next/og`. Warm editorial direction: `#F1E8DA` paper background, faint grid field, Fraunces serif wordmark + tagline in `#191511` carbon, JetBrains mono eyebrow with the rust accent mark, `voiceclaw.io` chip with rust dot in the bottom-right.
- New `website/src/app/twitter-image.tsx` — re-exports the OG route so both file conventions share one renderer.
- `website/src/app/layout.tsx` — added `metadataBase: https://voiceclaw.io`, `openGraph` (type, url, siteName, title, description), and `twitter` (`summary_large_image`, title, description). Next.js auto-merges the file-convention image into both blocks.

Fonts are fetched from the Google Fonts CSS API at build time using a Safari-era UA so the served files are TTF/WOFF (Satori-compatible). Build is fully static — `/opengraph-image` and `/twitter-image` are listed as `○ (Static)` in the build output.

## Screenshots

Rendered banner (build artifact, 1200x630 PNG, ~80 KB):

- Local preview: `/tmp/voiceclaw-og-preview.png`
- Build artifact: `website/.next/server/app/opengraph-image.body`

Visual: cream paper field with subtle grid, "OPEN SOURCE VOICE LAYER" eyebrow with the VoiceClaw mark, oversized Fraunces "VoiceClaw" wordmark, Fraunces tagline "Voice for the agent you already trust.", divider, then "iPhone · Mac · BYO agent" left and a "voiceclaw.io" chip with rust dot on the right.

## Test plan

- [x] `yarn workspace voiceclaw-web build` succeeds; both routes appear as static prerendered.
- [x] `curl -I http://localhost:3456/opengraph-image` returns `200 image/png`.
- [x] `curl -s http://localhost:3456/ | grep -oE '<meta[^>]*(og:|twitter:)[^>]*>'` shows:
  - `og:title`, `og:description`, `og:url`, `og:site_name`, `og:type=website`
  - `og:image` (absolute URL on voiceclaw.io), `og:image:type=image/png`, `og:image:width=1200`, `og:image:height=630`, `og:image:alt`
  - `twitter:card=summary_large_image`, `twitter:title`, `twitter:description`, `twitter:image` (absolute), `twitter:image:width/height/alt`
- [x] PNG opens cleanly: `file ...opengraph-image.body` reports `PNG image data, 1200 x 630, 8-bit/color RGBA`.
- [ ] Post-merge: validate via X Card Validator and LinkedIn Post Inspector against the deployed URL.

## Caveats

- `metadataBase` is hardcoded to `https://voiceclaw.io`. If we later want preview deploys to ship environment-correct OG URLs, swap to a `NEXT_PUBLIC_SITE_URL` env. Not blocking for prod.
- Font fetch hits Google Fonts at build time; if that ever flakes, we can vendor `Fraunces-SemiBold.ttf` and `JetBrainsMono-Medium.ttf` into `assets/` and switch to `readFile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)