### PR TITLE
fix(desktop): per-provider voice persistence + Grok default Ara (NAN-676)

### DIFF
--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -33,6 +33,11 @@ import { detectBrains } from './brain-detect'
 import { startSignInFlow } from './auth'
 import { getMainWindow } from './window-lifecycle'
 import {
+  getActiveProvider,
+  providerForVoice,
+  setVoiceForProviderSync,
+} from './voice-prefs'
+import {
   capture as telemetryCapture,
   captureException as telemetryCaptureException,
   getDistinctId,
@@ -329,10 +334,8 @@ export function registerIpcHandlers() {
   ipcMain.handle('identity:save', (_e, patch: Partial<AgentIdentity>) => {
     const saved = writeAgentIdentity(patch)
     if (saved.voice) {
-      const db = getDb()
-      db.prepare(
-        'INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?',
-      ).run('realtime_voice', saved.voice, saved.voice)
+      const provider = providerForVoice(saved.voice) ?? getActiveProvider()
+      setVoiceForProviderSync(provider, saved.voice)
     }
     serviceManager.restart('relay', () => buildRelayEnv()).catch((err) => {
       console.warn('[relay] restart after identity save failed', err)

--- a/desktop/src/main/voice-prefs.ts
+++ b/desktop/src/main/voice-prefs.ts
@@ -1,0 +1,73 @@
+// Main-process mirror of the renderer's per-provider voice preferences.
+// Used by IPC handlers that need to keep the persisted voice map in sync
+// with state owned in main (e.g. agent identity).
+
+import { getDb } from './db'
+
+export const GEMINI_VOICES = [
+  'Puck',
+  'Charon',
+  'Kore',
+  'Fenrir',
+  'Aoede',
+  'Leda',
+  'Orus',
+  'Zephyr',
+] as const
+
+export const XAI_VOICES = ['eve', 'ara', 'rex', 'sal', 'leo'] as const
+
+export type ProviderId = 'gemini' | 'xai'
+
+export const VOICES_BY_PROVIDER_KEY = 'realtime_voices_by_provider'
+export const LEGACY_VOICE_KEY = 'realtime_voice'
+export const ACTIVE_MODEL_KEY = 'realtime_model'
+
+export function providerForModel(model: string | null | undefined): ProviderId {
+  if (model && model.startsWith('grok-voice-')) return 'xai'
+  return 'gemini'
+}
+
+export function providerForVoice(voice: string): ProviderId | null {
+  if ((GEMINI_VOICES as readonly string[]).includes(voice)) return 'gemini'
+  if ((XAI_VOICES as readonly string[]).includes(voice)) return 'xai'
+  return null
+}
+
+export function setVoiceForProviderSync(provider: ProviderId, voice: string): void {
+  const db = getDb()
+  const upsert = db.prepare(
+    'INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?',
+  )
+  const row = db
+    .prepare('SELECT value FROM settings WHERE key = ?')
+    .get(VOICES_BY_PROVIDER_KEY) as { value: string } | undefined
+  const map = parseVoicesByProvider(row?.value)
+  map[provider] = voice
+  const next = JSON.stringify(map)
+  upsert.run(VOICES_BY_PROVIDER_KEY, next, next)
+  upsert.run(LEGACY_VOICE_KEY, voice, voice)
+}
+
+export function getActiveProvider(): ProviderId {
+  const db = getDb()
+  const row = db
+    .prepare('SELECT value FROM settings WHERE key = ?')
+    .get(ACTIVE_MODEL_KEY) as { value: string } | undefined
+  return providerForModel(row?.value ?? null)
+}
+
+function parseVoicesByProvider(raw: string | null | undefined): Record<string, string> {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    const out: Record<string, string> = {}
+    for (const [k, v] of Object.entries(parsed)) {
+      if (typeof v === 'string') out[k] = v
+    }
+    return out
+  } catch {
+    return {}
+  }
+}

--- a/desktop/src/main/voice-prefs.ts
+++ b/desktop/src/main/voice-prefs.ts
@@ -1,7 +1,3 @@
-// Main-process mirror of the renderer's per-provider voice preferences.
-// Used by IPC handlers that need to keep the persisted voice map in sync
-// with state owned in main (e.g. agent identity).
-
 import { getDb } from './db'
 
 export const GEMINI_VOICES = [

--- a/desktop/src/renderer/src/lib/voice-prefs.test.ts
+++ b/desktop/src/renderer/src/lib/voice-prefs.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const settings = new Map<string, string>()
+
+vi.mock('./db', () => ({
+  getSetting: vi.fn(async (key: string) => settings.get(key) ?? null),
+  setSetting: vi.fn(async (key: string, value: string) => {
+    settings.set(key, value)
+  }),
+}))
+
+import {
+  defaultVoiceFor,
+  getVoiceForProvider,
+  isVoiceForProvider,
+  loadVoicesByProvider,
+  providerForModel,
+  setVoiceForProvider,
+} from './voice-prefs'
+
+beforeEach(() => {
+  settings.clear()
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('providerForModel', () => {
+  it('maps grok models to xai', () => {
+    expect(providerForModel('grok-voice-think-fast-1.0')).toBe('xai')
+  })
+
+  it('maps gemini models (and unknown) to gemini', () => {
+    expect(providerForModel('gemini-3.1-flash-live-preview')).toBe('gemini')
+    expect(providerForModel(null)).toBe('gemini')
+    expect(providerForModel(undefined)).toBe('gemini')
+  })
+})
+
+describe('defaultVoiceFor', () => {
+  it('defaults Grok to ara', () => {
+    expect(defaultVoiceFor('xai')).toBe('ara')
+  })
+
+  it('defaults Gemini to Zephyr', () => {
+    expect(defaultVoiceFor('gemini')).toBe('Zephyr')
+  })
+})
+
+describe('isVoiceForProvider', () => {
+  it('matches voices to their provider', () => {
+    expect(isVoiceForProvider('gemini', 'Zephyr')).toBe(true)
+    expect(isVoiceForProvider('gemini', 'ara')).toBe(false)
+    expect(isVoiceForProvider('xai', 'ara')).toBe(true)
+    expect(isVoiceForProvider('xai', 'Zephyr')).toBe(false)
+  })
+})
+
+describe('per-provider voice persistence', () => {
+  it('returns the provider default when nothing is stored', async () => {
+    expect(await getVoiceForProvider('xai')).toBe('ara')
+    expect(await getVoiceForProvider('gemini')).toBe('Zephyr')
+  })
+
+  it('round-trips a voice through set/get for a provider', async () => {
+    await setVoiceForProvider('xai', 'rex')
+    await setVoiceForProvider('gemini', 'Puck')
+    expect(await getVoiceForProvider('xai')).toBe('rex')
+    expect(await getVoiceForProvider('gemini')).toBe('Puck')
+  })
+
+  it('keeps each providers voice independent across switches', async () => {
+    await setVoiceForProvider('gemini', 'Aoede')
+    await setVoiceForProvider('xai', 'leo')
+    await setVoiceForProvider('gemini', 'Charon')
+    expect(await getVoiceForProvider('xai')).toBe('leo')
+    expect(await getVoiceForProvider('gemini')).toBe('Charon')
+  })
+
+  it('falls back to default when stored value is not in providers catalog', async () => {
+    settings.set('realtime_voices_by_provider', JSON.stringify({ xai: 'Zephyr' }))
+    expect(await getVoiceForProvider('xai')).toBe('ara')
+  })
+})
+
+describe('legacy migration', () => {
+  it('seeds the new map from a Gemini-flavoured legacy value', async () => {
+    settings.set('realtime_voice', 'Aoede')
+    const map = await loadVoicesByProvider()
+    expect(map).toEqual({ gemini: 'Aoede' })
+    expect(settings.get('realtime_voices_by_provider')).toBe(
+      JSON.stringify({ gemini: 'Aoede' }),
+    )
+  })
+
+  it('seeds the new map from a Grok-flavoured legacy value', async () => {
+    settings.set('realtime_voice', 'rex')
+    const map = await loadVoicesByProvider()
+    expect(map).toEqual({ xai: 'rex' })
+  })
+
+  it('only seeds once — does not overwrite the new key after migration', async () => {
+    settings.set('realtime_voice', 'Aoede')
+    await loadVoicesByProvider()
+    await setVoiceForProvider('xai', 'sal')
+    settings.set('realtime_voice', 'Zephyr')
+    const map = await loadVoicesByProvider()
+    expect(map).toEqual({ gemini: 'Aoede', xai: 'sal' })
+  })
+
+  it('ignores malformed JSON and falls back to legacy/defaults', async () => {
+    settings.set('realtime_voices_by_provider', 'not json')
+    settings.set('realtime_voice', 'leo')
+    expect(await getVoiceForProvider('xai')).toBe('leo')
+  })
+})

--- a/desktop/src/renderer/src/lib/voice-prefs.ts
+++ b/desktop/src/renderer/src/lib/voice-prefs.ts
@@ -1,0 +1,97 @@
+// Per-provider voice preferences. Voice selection is persisted as a
+// JSON map keyed by provider so switching models in Settings restores
+// the user's prior voice for that provider instead of dropping it.
+
+import { getSetting, setSetting } from './db'
+
+export const GEMINI_VOICES = [
+  'Puck',
+  'Charon',
+  'Kore',
+  'Fenrir',
+  'Aoede',
+  'Leda',
+  'Orus',
+  'Zephyr',
+] as const
+
+export const XAI_VOICES = ['eve', 'ara', 'rex', 'sal', 'leo'] as const
+
+export type GeminiVoice = typeof GEMINI_VOICES[number]
+export type XAIVoice = typeof XAI_VOICES[number]
+export type ProviderId = 'gemini' | 'xai'
+
+export const VOICES_BY_PROVIDER_KEY = 'realtime_voices_by_provider'
+export const LEGACY_VOICE_KEY = 'realtime_voice'
+
+export const DEFAULT_VOICES: Record<ProviderId, string> = {
+  gemini: 'Zephyr',
+  xai: 'ara',
+}
+
+export function providerForModel(model: string | null | undefined): ProviderId {
+  if (model && model.startsWith('grok-voice-')) return 'xai'
+  return 'gemini'
+}
+
+export function isVoiceForProvider(provider: ProviderId, voice: string): boolean {
+  if (provider === 'xai') return (XAI_VOICES as readonly string[]).includes(voice)
+  return (GEMINI_VOICES as readonly string[]).includes(voice)
+}
+
+export function defaultVoiceFor(provider: ProviderId): string {
+  return DEFAULT_VOICES[provider]
+}
+
+export async function loadVoicesByProvider(): Promise<Record<string, string>> {
+  const raw = await getSetting(VOICES_BY_PROVIDER_KEY)
+  const parsed = parseVoicesByProvider(raw)
+  if (parsed) return parsed
+  // One-time migration: seed the new map from the legacy single-value
+  // voice setting if present. Only the provider whose catalog matches
+  // the legacy value gets its previous selection preserved.
+  const legacy = await getSetting(LEGACY_VOICE_KEY)
+  const seeded = seedFromLegacy(legacy)
+  if (Object.keys(seeded).length > 0) {
+    await setSetting(VOICES_BY_PROVIDER_KEY, JSON.stringify(seeded))
+  }
+  return seeded
+}
+
+export async function getVoiceForProvider(provider: ProviderId): Promise<string> {
+  const map = await loadVoicesByProvider()
+  const stored = map[provider]
+  if (stored && isVoiceForProvider(provider, stored)) return stored
+  return defaultVoiceFor(provider)
+}
+
+export async function setVoiceForProvider(provider: ProviderId, voice: string): Promise<void> {
+  const map = await loadVoicesByProvider()
+  const next = { ...map, [provider]: voice }
+  await setSetting(VOICES_BY_PROVIDER_KEY, JSON.stringify(next))
+  // Mirror to the legacy key so any reader that hasn't migrated yet
+  // (older code paths, on-disk inspection) still sees the active voice.
+  await setSetting(LEGACY_VOICE_KEY, voice)
+}
+
+function parseVoicesByProvider(raw: string | null): Record<string, string> | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+    const out: Record<string, string> = {}
+    for (const [k, v] of Object.entries(parsed)) {
+      if (typeof v === 'string') out[k] = v
+    }
+    return out
+  } catch {
+    return null
+  }
+}
+
+function seedFromLegacy(legacy: string | null): Record<string, string> {
+  if (!legacy) return {}
+  if (isVoiceForProvider('gemini', legacy)) return { gemini: legacy }
+  if (isVoiceForProvider('xai', legacy)) return { xai: legacy }
+  return {}
+}

--- a/desktop/src/renderer/src/lib/voice-prefs.ts
+++ b/desktop/src/renderer/src/lib/voice-prefs.ts
@@ -1,7 +1,3 @@
-// Per-provider voice preferences. Voice selection is persisted as a
-// JSON map keyed by provider so switching models in Settings restores
-// the user's prior voice for that provider instead of dropping it.
-
 import { getSetting, setSetting } from './db'
 
 export const GEMINI_VOICES = [

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -29,11 +29,10 @@ import {
   updateConversationTitle,
   type Message,
 } from '../lib/db'
+import { getVoiceForProvider, providerForModel } from '../lib/voice-prefs'
 
 const DEFAULT_REALTIME_MODEL = 'gemini-3.1-flash-live-preview'
 const REALTIME_MODELS = ['gemini-3.1-flash-live-preview', 'grok-voice-think-fast-1.0'] as const
-const GEMINI_VOICES = ['Puck', 'Charon', 'Kore', 'Fenrir', 'Aoede', 'Leda', 'Orus', 'Zephyr'] as const
-const XAI_VOICES = ['eve', 'ara', 'rex', 'sal', 'leo'] as const
 
 export function ChatPage() {
   const [messages, setMessages] = useState<Message[]>([])
@@ -258,7 +257,7 @@ export function ChatPage() {
     const serverUrl = (await getSetting('realtime_server_url')) || (await defaultRelayUrl())
     activeRelayUrlRef.current = serverUrl
     const model = normalizeRealtimeModel(await getSetting('realtime_model'))
-    const voice = normalizeRealtimeVoice(model, await getSetting('realtime_voice'))
+    const voice = await getVoiceForProvider(providerForModel(model))
     const apiKey = (await getSetting('realtime_api_key')) || ''
     // Tavily key is only forwarded when the user hasn't explicitly disabled
     // web_search. The setting is undefined on first run, which we treat as
@@ -630,14 +629,6 @@ function normalizeRealtimeModel(model: string | null): typeof REALTIME_MODELS[nu
   return (REALTIME_MODELS as readonly string[]).includes(model ?? '')
     ? model as typeof REALTIME_MODELS[number]
     : DEFAULT_REALTIME_MODEL
-}
-
-function normalizeRealtimeVoice(model: typeof REALTIME_MODELS[number], voice: string | null): string {
-  if (model.startsWith('grok-voice-')) {
-    return voice && (XAI_VOICES as readonly string[]).includes(voice) ? voice : 'eve'
-  }
-
-  return voice && (GEMINI_VOICES as readonly string[]).includes(voice) ? voice : 'Zephyr'
 }
 
 async function defaultRelayUrl(): Promise<string> {

--- a/desktop/src/renderer/src/pages/SettingsPage.tsx
+++ b/desktop/src/renderer/src/pages/SettingsPage.tsx
@@ -10,12 +10,19 @@ import { useTheme, type Theme } from '../lib/use-theme'
 import { enumerateAudioDevices, type AudioDevice } from '../lib/audio-engine'
 import { getSetting, setSetting } from '../lib/db'
 import {
+  GEMINI_VOICES,
+  XAI_VOICES,
+  getVoiceForProvider,
+  isVoiceForProvider,
+  providerForModel,
+  setVoiceForProvider,
+} from '../lib/voice-prefs'
+import {
   captureRenderer,
   isOptedOutRenderer,
   setOptedOutRenderer,
 } from '../lib/telemetry'
 
-const GEMINI_VOICES = ['Puck', 'Charon', 'Kore', 'Fenrir', 'Aoede', 'Leda', 'Orus', 'Zephyr'] as const
 const GEMINI_VOICE_LABELS: Record<typeof GEMINI_VOICES[number], string> = {
   Puck: 'Puck (M)',
   Charon: 'Charon (M)',
@@ -27,7 +34,6 @@ const GEMINI_VOICE_LABELS: Record<typeof GEMINI_VOICES[number], string> = {
   Zephyr: 'Zephyr (F)',
 }
 
-const XAI_VOICES = ['eve', 'ara', 'rex', 'sal', 'leo'] as const
 const XAI_VOICE_LABELS: Record<typeof XAI_VOICES[number], string> = {
   eve: 'Eve (F)',
   ara: 'Ara (F)',
@@ -119,10 +125,8 @@ export function SettingsPage() {
       const loadedModel = normalizeRealtimeModel(m)
       setModel(loadedModel)
       if (m && m !== loadedModel) setSetting('realtime_model', loadedModel)
-      const v = await getSetting('realtime_voice')
-      const loadedVoice = normalizeRealtimeVoice(loadedModel, v)
+      const loadedVoice = await getVoiceForProvider(providerForModel(loadedModel))
       setVoice(loadedVoice)
-      if (v !== loadedVoice) setSetting('realtime_voice', loadedVoice)
       const vol = await getSetting('realtime_volume')
       if (vol) setVolume(parseFloat(vol))
       const inDev = await getSetting('input_device_id')
@@ -198,24 +202,21 @@ export function SettingsPage() {
   const updateModel = useCallback((v: RealtimeModel) => {
     setModel(v)
     if (loadedRef.current) save('realtime_model', v)
-    // Reset voice when switching providers
-    const isGemini = v.startsWith('gemini-')
-    const currentIsGemini = (GEMINI_VOICES as readonly string[]).includes(voice)
-    const isXAI = v.startsWith('grok-voice-')
-    const currentIsXAI = (XAI_VOICES as readonly string[]).includes(voice)
-    if (isGemini && !currentIsGemini) {
-      setVoice('Zephyr')
-      save('realtime_voice', 'Zephyr')
-    } else if (isXAI && !currentIsXAI) {
-      setVoice('eve')
-      save('realtime_voice', 'eve')
-    }
+    const nextProvider = providerForModel(v)
+    if (isVoiceForProvider(nextProvider, voice)) return
+    void (async () => {
+      const restored = await getVoiceForProvider(nextProvider)
+      setVoice(restored)
+      if (loadedRef.current) await setVoiceForProvider(nextProvider, restored)
+    })()
   }, [save, voice])
 
   const updateVoice = useCallback((v: string) => {
     setVoice(v)
-    if (loadedRef.current) save('realtime_voice', v)
-  }, [save])
+    if (loadedRef.current) {
+      void setVoiceForProvider(providerForModel(model), v)
+    }
+  }, [model])
 
   const updateVolume = useCallback((v: number) => {
     setVolume(v)
@@ -824,14 +825,6 @@ function isRealtimeModel(model: string | null): model is RealtimeModel {
 
 function normalizeRealtimeModel(model: string | null): RealtimeModel {
   return isRealtimeModel(model) ? model : DEFAULT_REALTIME_MODEL
-}
-
-function normalizeRealtimeVoice(model: RealtimeModel, voice: string | null): string {
-  if (model.startsWith('grok-voice-')) {
-    return voice && (XAI_VOICES as readonly string[]).includes(voice) ? voice : 'eve'
-  }
-
-  return voice && (GEMINI_VOICES as readonly string[]).includes(voice) ? voice : 'Zephyr'
 }
 
 // --- Helper Components ---


### PR DESCRIPTION
Closes NAN-676.

## Why
Voice was stored as one global string, so the moment a user switched from Gemini to Grok in Settings, their previous voice pick on the other provider was gone. Coming back to Gemini didn't restore Zephyr (or whatever they'd picked), it just reset to a default. The ticket also calls out that Grok should default to Ara instead of the previous fallback (`eve`), since Ara is the preferred sound.

## What
- New persisted setting `realtime_voices_by_provider` — a JSON map `{ gemini, xai }` keyed by provider id.
- Settings UI loads the per-provider value on mount. Picking a model swaps the voice grid to that provider's catalog and restores the last voice for that provider (or the provider default).
- Picking a voice writes to the per-provider map (and mirrors to the legacy `realtime_voice` key so the existing relay code path stays unchanged).
- ChatPage `startCall` now reads voice from `getVoiceForProvider(providerForModel(model))` instead of the single global key.
- IPC `identity:save` (which used to write a single voice string) updates the per-provider entry that matches the saved voice's catalog (or falls back to the active provider).
- Defaults are now centralized: `gemini → Zephyr`, `xai → ara` (lowercase, matches the relay test page + the in-app voice catalog id).
- Shared helpers live in `desktop/src/renderer/src/lib/voice-prefs.ts` (renderer) and `desktop/src/main/voice-prefs.ts` (main). Removes the duplicated `GEMINI_VOICES` / `XAI_VOICES` / `normalizeRealtimeVoice` constants that were copy-pasted across `SettingsPage.tsx` and `ChatPage.tsx`.

## Migration
- First read of `realtime_voices_by_provider` seeds the map from the legacy `realtime_voice` value, slotting it into whichever provider's catalog matches. After that, the legacy key is just a write-through mirror — no destructive change to existing rows.
- Existing users who only ever used Gemini keep their Zephyr/whatever; existing Grok users (likely on `eve`) keep `eve` until they change it; new/unset Grok users now land on `ara`.

## Screenshots
Reference from the ticket:
![voice settings](https://files.openclaw.ai/inbound/file_622---b6b7d51c-3af9-4c25-8682-7f0b0e3172ea.jpg)

## Test plan
- [x] `yarn workspace voiceclaw-desktop typecheck` — clean.
- [x] `yarn workspace voiceclaw-desktop build` — clean.
- [x] `yarn workspace voiceclaw-desktop test` — 13 new tests for `voice-prefs` (provider mapping, defaults, round-trip per provider, malformed JSON, legacy migration idempotency). 48/48 desktop tests now pass that did before; the one pre-existing `diagnostic-bundle.test.ts` failure on `origin/main` is unrelated.
- [ ] Manual: launch desktop, pick Gemini → Aoede, switch to Grok → expect Ara (default), pick Rex, switch back to Gemini → expect Aoede restored.
- [ ] Manual: existing user with only `realtime_voice = Zephyr` upgrades; open Settings — voice still says Zephyr; switch to Grok — defaults to Ara without losing Zephyr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)