### PR TITLE
fix(desktop): wire Google sign-in callback to complete onboarding (NAN-694)

### DIFF
--- a/desktop/src/main/auth.test.ts
+++ b/desktop/src/main/auth.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function waitForCondition(check: () => void, timeoutMs = 1000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      check()
+      return
+    } catch {
+      await new Promise((r) => setTimeout(r, 10))
+    }
+  }
+  check()
+}
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const openExternalCalls: string[] = []
+const openUrlHandlers: Array<(event: { preventDefault: () => void }, url: string) => void> = []
+const setAsDefaultProtocolClientCalls: string[] = []
+const sendCalls: Array<{ channel: string; payload: unknown }> = []
+const dbRuns: Array<unknown[]> = []
+
+const fakeDb = {
+  prepare: () => ({
+    run: (...args: unknown[]) => {
+      dbRuns.push(args)
+    },
+  }),
+}
+
+vi.mock('./db', () => ({ getDb: () => fakeDb }))
+
+vi.mock('./onboarding', () => ({ ensureOnboardingSchema: () => undefined }))
+
+vi.mock('./window-lifecycle', () => ({
+  getMainWindow: () => ({
+    webContents: {
+      send: (channel: string, payload: unknown) => {
+        sendCalls.push({ channel, payload })
+      },
+    },
+  }),
+}))
+
+let mockFetchResponse: { ok: boolean; status: number; text: () => Promise<string>; json: () => Promise<unknown> } = {
+  ok: true,
+  status: 200,
+  text: async () => '',
+  json: async () => ({
+    token: 'tok_abc',
+    device: { id: 'dev1', label: 'VoiceClaw Desktop', platform: 'desktop-macos' },
+    user: { id: 'usr1', email: 'test@example.com', name: 'Test User' },
+  }),
+}
+
+vi.mock('electron', () => ({
+  app: {
+    setAsDefaultProtocolClient: (scheme: string) => {
+      setAsDefaultProtocolClientCalls.push(scheme)
+    },
+    on: (event: string, handler: (event: { preventDefault: () => void }, url: string) => void) => {
+      if (event === 'open-url') openUrlHandlers.push(handler)
+    },
+    getPath: () => '/tmp/voiceclaw-auth-test',
+  },
+  net: {
+    fetch: (_url: string, _opts: unknown) => Promise.resolve(mockFetchResponse),
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (s: string) => Buffer.from(s),
+  },
+  shell: {
+    openExternal: (url: string) => {
+      openExternalCalls.push(url)
+      return Promise.resolve()
+    },
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('startSignInFlow', () => {
+  beforeEach(() => {
+    openExternalCalls.length = 0
+    delete process.env.VOICECLAW_AUTH_BASE_URL
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('opens the google start URL with target=desktop', async () => {
+    const { startSignInFlow } = await import('./auth')
+    startSignInFlow('google')
+    expect(openExternalCalls[0]).toBe(
+      'https://getvoiceclaw.com/api/auth/google/start?target=desktop',
+    )
+  })
+
+  it('respects VOICECLAW_AUTH_BASE_URL override', async () => {
+    process.env.VOICECLAW_AUTH_BASE_URL = 'http://localhost:3000'
+    const { startSignInFlow } = await import('./auth')
+    startSignInFlow('google')
+    expect(openExternalCalls[0]).toBe(
+      'http://localhost:3000/api/auth/google/start?target=desktop',
+    )
+  })
+})
+
+describe('registerAuthDeepLink + deep-link handling', () => {
+  beforeEach(() => {
+    openUrlHandlers.length = 0
+    sendCalls.length = 0
+    dbRuns.length = 0
+    setAsDefaultProtocolClientCalls.length = 0
+    mockFetchResponse = {
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => ({
+        token: 'tok_abc',
+        device: { id: 'dev1', label: 'VoiceClaw Desktop', platform: 'desktop-macos' },
+        user: { id: 'usr1', email: 'test@example.com', name: 'Test User' },
+      }),
+    }
+    delete process.env.VOICECLAW_AUTH_BASE_URL
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('registers the voiceclaw scheme with setAsDefaultProtocolClient', async () => {
+    const { registerAuthDeepLink } = await import('./auth')
+    registerAuthDeepLink()
+    expect(setAsDefaultProtocolClientCalls).toContain('voiceclaw')
+  })
+
+  it('sends auth-callback success when ticket redeems ok', async () => {
+    const { registerAuthDeepLink } = await import('./auth')
+    registerAuthDeepLink()
+
+    const handler = openUrlHandlers[0]
+    expect(handler).toBeDefined()
+    handler({ preventDefault: () => undefined }, 'voiceclaw://auth/callback?ticket=abc123')
+
+    await waitForCondition(() => expect(sendCalls).toHaveLength(1))
+    expect(sendCalls[0]).toEqual({
+      channel: 'onboarding:auth-callback',
+      payload: { ok: true, user: { id: 'usr1', email: 'test@example.com', name: 'Test User' } },
+    })
+  })
+
+  it('sends auth-callback error when server returns 501', async () => {
+    mockFetchResponse = {
+      ok: false,
+      status: 501,
+      text: async () => '{"error":"not_configured"}',
+      json: async () => ({ error: 'not_configured' }),
+    }
+
+    const { registerAuthDeepLink } = await import('./auth')
+    registerAuthDeepLink()
+
+    openUrlHandlers[0]!({ preventDefault: () => undefined }, 'voiceclaw://auth/callback?ticket=abc123')
+
+    await waitForCondition(() => expect(sendCalls).toHaveLength(1))
+    expect(sendCalls[0]).toMatchObject({
+      channel: 'onboarding:auth-callback',
+      payload: { ok: false, error: expect.stringContaining('redeem_failed_501') },
+    })
+  })
+
+  it('sends auth-callback error when ticket is missing from deep link', async () => {
+    const { registerAuthDeepLink } = await import('./auth')
+    registerAuthDeepLink()
+
+    openUrlHandlers[0]!({ preventDefault: () => undefined }, 'voiceclaw://auth/callback')
+
+    await waitForCondition(() => expect(sendCalls).toHaveLength(1))
+    expect(sendCalls[0]).toEqual({
+      channel: 'onboarding:auth-callback',
+      payload: { ok: false, error: 'missing_ticket' },
+    })
+  })
+
+  it('sends auth-callback error when deep link carries an error param', async () => {
+    const { registerAuthDeepLink } = await import('./auth')
+    registerAuthDeepLink()
+
+    openUrlHandlers[0]!(
+      { preventDefault: () => undefined },
+      'voiceclaw://auth/callback?error=state_mismatch',
+    )
+
+    await waitForCondition(() => expect(sendCalls).toHaveLength(1))
+    expect(sendCalls[0]).toEqual({
+      channel: 'onboarding:auth-callback',
+      payload: { ok: false, error: 'state_mismatch' },
+    })
+  })
+
+  it('silently ignores deep links on unrelated paths', async () => {
+    const { registerAuthDeepLink } = await import('./auth')
+    registerAuthDeepLink()
+
+    openUrlHandlers[0]!({ preventDefault: () => undefined }, 'voiceclaw://other/path?foo=bar')
+
+    await new Promise((r) => setTimeout(r, 30))
+    expect(sendCalls).toHaveLength(0)
+  })
+
+  it('silently ignores deep links with wrong scheme', async () => {
+    const { registerAuthDeepLink } = await import('./auth')
+    registerAuthDeepLink()
+
+    openUrlHandlers[0]!({ preventDefault: () => undefined }, 'https://getvoiceclaw.com/auth/callback?ticket=abc')
+
+    await new Promise((r) => setTimeout(r, 30))
+    expect(sendCalls).toHaveLength(0)
+  })
+})

--- a/desktop/src/renderer/src/pages/onboarding/StepSignIn.tsx
+++ b/desktop/src/renderer/src/pages/onboarding/StepSignIn.tsx
@@ -109,10 +109,24 @@ export function StepSignIn({
           </p>
 
           {state.kind === 'pending' ? (
-            <StatusLine
-              tone="info"
-              text={`Waiting for ${state.provider} sign-in to finish in your browser…`}
-            />
+            <div className="flex items-center gap-3">
+              <StatusLine
+                tone="info"
+                text={`Waiting for ${state.provider} sign-in to finish in your browser…`}
+              />
+              <button
+                onClick={() => setState({ kind: 'idle' })}
+                className="shrink-0 rounded-[10px] border px-3 py-2 text-[12px] transition-opacity hover:opacity-70"
+                style={{
+                  borderColor: 'var(--line-strong)',
+                  backgroundColor: 'var(--panel-strong)',
+                  color: 'var(--muted)',
+                  fontFamily: 'var(--font-sans)',
+                }}
+              >
+                Cancel
+              </button>
+            </div>
           ) : null}
           {state.kind === 'error' ? <StatusLine tone="error" text={state.error} /> : null}
           {state.kind === 'success' ? (
@@ -275,7 +289,7 @@ function StatusLine({ tone, text }: { tone: 'info' | 'ok' | 'error'; text: strin
 
 function humanizeAuthError(raw: string): string {
   if (raw.startsWith('redeem_failed_501')) {
-    return "Sign-in isn't fully wired in this build. Skip for now — your keys still work."
+    return 'Sign-in is temporarily unavailable — the server is not ready. Try again in a moment, or skip and use your API keys.'
   }
   if (raw.startsWith('redeem_failed_410')) return 'That sign-in link already expired. Try again.'
   if (raw.startsWith('redeem_failed_404')) return "That sign-in link wasn't found."

--- a/docs/src/content/docs/desktop/onboarding.mdx
+++ b/docs/src/content/docs/desktop/onboarding.mdx
@@ -13,7 +13,7 @@ The first time you open VoiceClaw on a Mac, a six-step wizard runs before the ma
 
 1. **Welcome.** A short pitch and a "let's set up" button. No data captured.
 
-2. **Sign in (optional).** Click *Continue with Google* and we open `https://getvoiceclaw.com/api/auth/google/start?target=desktop` in your browser. Google sends you back to a `voiceclaw://auth/callback?ticket=…` deep link. The desktop app POSTs that ticket to `/api/auth/ticket/redeem`, gets a device token back, and stores it encrypted (see *What gets saved* below). Sign-in is fully skippable for v0.1 — keys still work without an account.
+2. **Sign in (optional).** Click *Continue with Google* and we open `https://getvoiceclaw.com/api/auth/google/start?target=desktop` in your browser. Complete the Google sign-in, then your browser shows a "Signed in. Returning to VoiceClaw…" page and hands control back to the desktop app via a `voiceclaw://auth/callback?ticket=…` deep link. The desktop app exchanges that ticket for a device token and stores it encrypted in its local database (see *What gets saved* below). If you close the browser before finishing, tap *Cancel* in the app and try again. Sign-in is fully optional — your API keys work with or without an account.
 
 3. **Permissions.** Two rows: microphone and screen recording. The wizard reads current state via `systemPreferences.getMediaAccessStatus()`. Microphone can be requested in-app; screen recording opens the matching pane in System Settings (`x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture`). The wizard polls every second while you're on this step, so granting a permission in System Settings flips the row to a green check without you having to click anything else. (Accessibility will be asked for separately when the AX-based screen-text-reader feature lands; today nothing in the binary consumes that grant, so the wizard doesn't ask.)
 
@@ -77,7 +77,7 @@ The desktop app registers `voiceclaw://` as a URL handler at startup via `app.se
 voiceclaw://auth/callback?ticket=<opaque>
 ```
 
-The `ticket` query parameter is exchanged for a device token at `https://getvoiceclaw.com/api/auth/ticket/redeem`. If the redeem fails, the wizard surfaces the error inline on the sign-in step instead of silently advancing.
+The `ticket` query parameter is exchanged for a device token at `https://getvoiceclaw.com/api/auth/ticket/redeem`. Tickets expire after 90 seconds — if your browser takes unusually long on the callback page before the deep link fires, the redeem will fail with "That sign-in link already expired. Try again." Just click *Continue with Google* again; the flow is idempotent. If the redeem fails for any other reason, the wizard surfaces the error inline on the sign-in step instead of silently advancing.
 
 To override the auth host (useful for testing against a Vercel preview deploy), set `VOICECLAW_AUTH_BASE_URL=https://my-preview.vercel.app` before launching. The default is `https://getvoiceclaw.com`.
 


### PR DESCRIPTION
## Summary

- **Root cause:** `AUTH_JWT_SECRET` was missing from the Vercel production environment. The `/api/auth/ticket/redeem` endpoint guards behind `isSigningKeyConfigured()` and returned `501 not_configured` when the secret was absent. The desktop app mapped `redeem_failed_501` to the misleading user-facing message "Sign-in isn't fully wired in this build."
- **Server fix:** Generated `AUTH_JWT_SECRET` and added it to the Vercel production environment; triggered a redeploy. The endpoint now returns `404 unknown_ticket` for invalid tickets (correct behavior) instead of `501`.
- **Desktop fix:** Replace the inaccurate "not wired" message with "Sign-in is temporarily unavailable — the server is not ready." Add a Cancel button so users can exit the stuck-pending state if the browser tab is closed before the deep-link callback fires.
- **Tests:** New `auth.test.ts` covering the full deep-link path: success ticket redeem, 501 from server, missing ticket, error query param, wrong scheme.
- **Docs:** Updated `docs/src/content/docs/desktop/onboarding.mdx` — sign-in step description and deep-link section now accurately describe the flow and ticket-expiry behavior.

## Reproduction status

Reproduced via `curl` against production:
- Before: `POST /api/auth/ticket/redeem` → `501 {"error":"not_configured"}`
- After: `POST /api/auth/ticket/redeem` (invalid ticket) → `404 {"error":"unknown_ticket"}`

Full click-through not possible in this context (headless worktree, no GUI), but the root cause is confirmed by the live endpoint response.

## Test plan

- [ ] `yarn test` in `desktop/` — 41 tests pass, including 9 new auth tests
- [ ] `yarn typecheck` in `desktop/` — clean
- [ ] Walk through onboarding → Sign in with Google → complete browser flow → desktop shows "Signed in as …" and Continue button is active
- [ ] Click "Continue with Google" then close the browser tab → Cancel button appears and clicking it resets to idle state
- [ ] If auth server is temporarily unreachable, error message reads "Sign-in is temporarily unavailable — the server is not ready. Try again in a moment, or skip and use your API keys."

🤖 Generated with [Claude Code](https://claude.com/claude-code)