### PR TITLE
docs: canvas-mode design spike (NAN-678)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -88,6 +88,7 @@ export default defineConfig({
             { slug: 'desktop/chat-actions', label: 'Desktop: chat actions (right-click menu)' },
             { slug: 'desktop/releasing', label: 'Desktop: releasing' },
             { slug: 'mobile-app' },
+            { slug: 'canvas-mode', label: 'Canvas mode (in design)', badge: { text: 'Preview', variant: 'note' } },
           ],
         },
         {

--- a/docs/src/content/docs/canvas-mode.mdx
+++ b/docs/src/content/docs/canvas-mode.mdx
@@ -1,0 +1,51 @@
+---
+title: Canvas mode
+description: A persistent collaborative surface that lives next to the voice call. Status — in design.
+---
+
+import { Aside } from '@astrojs/starlight/components'
+
+<Aside type="note" title="Status: in design">
+Canvas mode is being designed right now — none of this ships yet. Track the work on [NAN-678](https://linear.app/nano3labs/issue/NAN-678/explore-canvas-mode-for-voiceclaw-voice-chat-collaboration). What you read below is the intended feel, not a build log.
+</Aside>
+
+Today, every collaboration with VoiceClaw lives in chat bubbles. You speak, the AI speaks back, and the transcript scrolls. That is a great rhythm for thinking out loud, but it is the wrong shape for the moments when you actually want to *make* something — a plan, an outline, a doc, a draft email, a small interactive tool you reach for again tomorrow.
+
+Canvas mode adds a second surface alongside the call. The voice conversation stays where it is. To the right, a quiet workspace opens up — the kind of thing that feels like a sheet of paper, not a chat window — and the AI writes into it as you talk. You watch the document take shape. You can grab the keyboard and edit it yourself mid-call. The canvas is the artifact you keep when the call ends.
+
+## What it will feel like
+
+Picture the desktop app split in two. On the left, the familiar transcript and call controls. On the right, a cream page in the same warm editorial style as the rest of VoiceClaw — serif headings, generous margins, real typography — with the document the AI is helping you build.
+
+Say *"let's plan the talk for next week"* and a working outline appears, section by section, while you keep talking. Reorder a bullet by voice. Drop in a quote you read this morning. Ask the AI to tighten the intro. Close the call and the document is just there in your conversation history, ready to copy out, export, or pick up tomorrow.
+
+## Two flavours
+
+There are two kinds of canvas worth thinking about, and they answer different questions.
+
+**A writing canvas** — markdown-first, text-shaped. Notes, outlines, plans, specs, drafts, checklists. The thing most calls actually need. Edits are predictable, the format travels (paste it into Notion, into a PR description, into an email), and the AI can update it with surgical edits rather than rewriting the world every turn.
+
+**A free-form canvas** — the AI assembles a small UI surface for you. A dashboard for the numbers you just talked about. A form. A generated tool you use once and discard, or pin and keep. Closer in spirit to Anthropic's Artifacts or OpenAI's Canvas-with-React than to a doc.
+
+Both are interesting. They probably do not need to launch together. The first one — the quiet writing surface — is what the typical VoiceClaw call is missing today, so it is the most likely starting point.
+
+## What stays the same
+
+- **Voice is still primary.** The canvas is a companion to the call, not a replacement for it. You can ignore it entirely and VoiceClaw works exactly as it does today.
+- **Local-first.** Canvases live in the same local SQLite store as your transcripts. No cloud sync until you ask for it.
+- **One conversation, one canvas.** Each conversation in your history can carry a canvas alongside it. Open the conversation later and the canvas is right where you left it.
+
+## Open questions
+
+A few things are genuinely unsettled and worth flagging:
+
+- Whether the canvas should open automatically the moment the AI decides to write something down, or only when you explicitly ask for one.
+- Whether the writing canvas and the free-form UI canvas eventually merge into one surface, or stay deliberately separate.
+- How aggressive the AI should be about taking the keyboard from you — full rewrites are easy to reason about but disruptive; small targeted edits feel right but are harder to land predictably.
+
+If you have an opinion on any of these, drop it on the ticket — that is genuinely how this gets shaped.
+
+## Track the work
+
+- Feature ticket — [NAN-678 — Explore canvas mode for VoiceClaw voice chat collaboration](https://linear.app/nano3labs/issue/NAN-678/explore-canvas-mode-for-voiceclaw-voice-chat-collaboration)
+- Discussion — open a thread on the ticket or in the VoiceClaw repo

--- a/docs/src/content/docs/canvas-mode.mdx
+++ b/docs/src/content/docs/canvas-mode.mdx
@@ -25,7 +25,7 @@ There are two kinds of canvas worth thinking about, and they answer different qu
 
 **A writing canvas** — markdown-first, text-shaped. Notes, outlines, plans, specs, drafts, checklists. The thing most calls actually need. Edits are predictable, the format travels (paste it into Notion, into a PR description, into an email), and the AI can update it with surgical edits rather than rewriting the world every turn.
 
-**A free-form canvas** — the AI assembles a small UI surface for you. A dashboard for the numbers you just talked about. A form. A generated tool you use once and discard, or pin and keep. Closer in spirit to Anthropic's Artifacts or OpenAI's Canvas-with-React than to a doc.
+**A free-form canvas** — the AI assembles a small UI surface for you. A dashboard for the numbers you just talked about. A form. A generated tool you use once and discard, or pin and keep. Closer in spirit to Anthropic's Artifacts or OpenAI's Canvas than to a doc.
 
 Both are interesting. They probably do not need to launch together. The first one — the quiet writing surface — is what the typical VoiceClaw call is missing today, so it is the most likely starting point.
 


### PR DESCRIPTION
## Why

[NAN-678](https://linear.app/nano3labs/issue/NAN-678/explore-canvas-mode-for-voiceclaw-voice-chat-collaboration) — every collaboration in VoiceClaw lives in transient chat bubbles today. Calls that *make* something (a plan, an outline, a doc, a small generated tool) lack a persistent surface. This spike explores adding a canvas alongside the voice call, compares the two flavours called out in the ticket (markdown vs free-form UI), proposes an AI update protocol that fits the existing wire format, and recommends a path to MVP.

This PR ships:

- A short **user-facing** docs page at `docs/src/content/docs/canvas-mode.mdx` (under *Guides*) — what canvas mode will feel like, status flagged as "in design", links to the feature ticket. No implementer plumbing in the docs site (per `feedback_docs_audience.md`).
- The full design analysis below.

No production code changes. No follow-up tickets created — proposals are at the bottom for approval.

---

## Two modes compared

| Dimension | Markdown / writing canvas | Free-form UI canvas |
|---|---|---|
| Primary use | Notes, outlines, plans, drafts, specs, checklists | Dashboards, generated mini-tools, visual workflows, rich artifacts |
| Output shape | Plain markdown text | A typed component tree (or sandboxed HTML/JS bundle) |
| Editor | Tiptap / ProseMirror with markdown serialization (or CodeMirror 6 markdown mode) | Either (a) a constrained component DSL the renderer interprets, or (b) sandboxed iframe running model-authored React |
| User edits | Trivial — keyboard works, AI sees plain text on next turn | Hard — what does a user "edit" mean on a generated UI? Form values? Component props? |
| AI update protocol | Targeted edits (anchor-based or unified diff) — predictable, narrow blast radius | Practically full re-renders per update — model rewrites the whole tree because partial structural patches are too fragile |
| Persistence | One markdown blob + a small revisions table — trivially diffable | Full snapshot per version — large, harder to diff, harder to migrate |
| Travel | Pastes anywhere — Notion, PRs, email, Obsidian | Stuck inside VoiceClaw |
| Voice fit | Excellent — "tighten the intro", "add a bullet under risks" maps cleanly to text edits | Mixed — "make the chart bigger" works; "rewire the form to update the dashboard live" is a wall |
| Closest prior art | OpenAI Canvas, Granola notes, Cursor's chat panel | Anthropic Artifacts, Vercel v0, Claude Sonnet's tool-rendered UI |
| Risk | Low — well-understood editor stack | High — sandbox security, generated-code reliability, design quality, prop-stability across turns |
| MVP cost | ~1–2 weeks of focused work | ~4–6 weeks before it feels good |
| Reach | Useful in nearly every call | Useful in ~10–20% of calls (the "build me a tool" moments) |

**Closest prior art for VoiceClaw's needs is OpenAI Canvas** — markdown-first, lives next to a chat conversation, supports targeted AI edits, the user can take the keyboard whenever they want. Granola is the right *feel* (paper, serif, quiet) but they don't have a writeable AI agent in the page. Anthropic Artifacts and v0 are the right reference for the free-form mode, but they assume a code-savvy user reviewing generated React, which is not the average VoiceClaw caller.

## UX model

I think the right answer is **both surfaces visible at once, voice still primary**.

- **Default layout:** chat panel left, canvas right, ~55/45 split. On smaller windows the canvas collapses to a tab next to "Chat" / "History".
- **Trigger:** opens automatically the first time the AI calls a `canvas.*` tool in a conversation. Once open, it stays open for that conversation (and re-opens on next visit). User can collapse it manually.
- **Per-conversation:** each conversation has at most one canvas. New conversation = new canvas (or none, if the AI never reaches for it).
- **Voice barge-in still works while AI is writing.** Mid-write, if you interrupt, the in-flight edit is committed at whatever boundary it had reached and the AI yields the keyboard. (Same model as the current barge-in for audio.)
- **User edits** anytime — focus the canvas, type. The model sees the latest content on its next tool call. No locking; last write wins; we surface "AI wrote here" as a subtle margin note for the last AI-authored region so you know what changed.
- **No mode switcher between markdown and free-form.** Pick one for v1 and ship it.

Voice-only and canvas-only modes both fall out of the side-by-side: hide the canvas → voice-only; mute the mic → canvas-only (the AI takes text input via the existing `text.input` event, which the relay already supports).

## AI update protocol

This is the question that decides whether the feature feels predictable or maddening. Three options:

1. **Full rewrite per update.** Model returns the whole document each turn. Trivial to implement. Catastrophic for typing latency on a 2k-word doc, and any user edit mid-turn gets clobbered. **No.**
2. **Line-level / unified diff.** Model emits a patch. Narrow blast radius. Reliable for code editors (Cursor, Claude Code's `Edit` tool), but unstable when the document has been edited by a human in parallel — line numbers drift. Workable but fragile.
3. **Anchor-based structured edits.** Model targets *content anchors* (heading IDs, block IDs, or short unique-prefix matches) and emits structured operations: `insert_after`, `replace_block`, `append_to_section`, `delete_block`. This is what the Block-Note / Notion AI / OpenAI Canvas family does. Survives concurrent human edits because it doesn't depend on absolute line numbers, only on content the AI actually targeted.

**Recommendation: option 3 (anchor-based structured edits) for the markdown canvas, with full-rewrite as the fallback when the model returns something unparsable.**

Concrete tool surface I'd add to the relay (for proposal — not in this PR):

```ts
// New tools registered alongside ask_brain / web_search:
canvas.read()                                  // returns current markdown + block IDs
canvas.append({ markdown })                    // append to end
canvas.replace_block({ blockId, markdown })    // surgical edit
canvas.insert_after({ blockId, markdown })     // insert new block
canvas.delete_block({ blockId })
canvas.rewrite({ markdown })                   // escape hatch — full doc replace
```

These slot into the existing tool-call wire format (`tool.call` / `tool_call.completed`) — no new event types needed for v1. The renderer applies the patch to its Tiptap/ProseMirror doc, the same way it applies a remote collaborator's edit. The model never speaks raw HTML or React, only markdown. Each tool emits a `tool.progress` event with a one-line summary ("appended *Risks* section") so the transcript can show what the AI just did to the canvas.

For the free-form UI canvas (later, if we ship it): full-rewrite of a constrained component DSL is the only sane option. We do not let the model emit arbitrary React.

## Persistence

Three tables, mirroring the existing `conversations` / `messages` shape in `desktop/src/main/db.ts`:

```sql
canvases (
  id INTEGER PRIMARY KEY,
  conversation_id INTEGER NOT NULL UNIQUE REFERENCES conversations(id),
  format TEXT NOT NULL CHECK(format IN ('markdown')),  -- 'ui' added later if/when
  content TEXT NOT NULL,
  created_at INTEGER NOT NULL,
  updated_at INTEGER NOT NULL
)

canvas_revisions (
  id INTEGER PRIMARY KEY,
  canvas_id INTEGER NOT NULL REFERENCES canvases(id),
  content TEXT NOT NULL,
  author TEXT NOT NULL CHECK(author IN ('user', 'assistant')),
  tool_name TEXT,            -- which canvas.* tool, if AI-authored
  created_at INTEGER NOT NULL
)

canvas_blocks (              -- optional materialized view of block IDs
  canvas_id INTEGER NOT NULL,
  block_id TEXT NOT NULL,
  content_hash TEXT NOT NULL,
  PRIMARY KEY (canvas_id, block_id)
)
```

- **One canvas per conversation** — the `UNIQUE` on `conversation_id` enforces it.
- **Revision per turn** — every AI tool call and every user-debounced save (~2 s after typing stops) writes a revision. Cheap on disk; gives us undo and a session-media-style timeline view later.
- **Local-first**, like the rest of VoiceClaw. Same SQLite database, same `app.getPath('userData')` location, same migration path through `runMigrations()`.

Block IDs for anchor-based edits are derived from a short content hash of the block at write time and persisted on the markdown as Tiptap-style `<!-- block:abc123 -->` comments (invisible when rendered, survive markdown round-trip). This is the same trick BlockNote uses.

## Recommendation

**Ship the markdown canvas first, as a separate feature from any free-form UI canvas. Do not try to merge them under one abstraction.**

Why:

1. **It is the canvas the median VoiceClaw call actually wants.** Most calls are thinking-out-loud sessions that produce some kind of text artifact. A writing surface lets us keep that artifact without forcing the user to copy it out of the transcript afterward.
2. **The AI-update problem is *solved* for markdown.** Anchor-based block edits over a Tiptap/ProseMirror doc is a well-trodden path. Generated-React-in-an-iframe is still an active research problem in 2026 — sandbox security, prop stability across turns, accessible default styling — and shipping that as v1 burns a lot of calendar for a feature only a fraction of calls would use.
3. **It composes with everything we already have.** Tool calls flow through the existing `tool.call` / `tool_call.completed` wire format. Local-first storage looks identical to the existing `messages` table. Voice barge-in semantics carry over verbatim.
4. **Free-form UI is not abandoned — just deferred.** Once the markdown canvas ships and we know what users actually reach for, we can decide whether the free-form canvas is (a) a separate "Tool" canvas mode the user opts into, (b) a special block type *inside* the markdown canvas (a `<canvas-component id="...">` block the model can render into), or (c) not worth building because the writing canvas is already covering 90% of the demand. Today we don't know, and that is fine.

A unified abstraction sounds elegant but I think it's a trap: markdown editing and component-tree generation have genuinely different update protocols, different safety models, and different user-edit semantics. Forcing them under one type would make both worse. Two separate features, eventually sharing a layout shell and a persistence pattern, is the cheaper bet.

### Path to MVP (markdown canvas)

Roughly in order, ~1.5 weeks of focused work:

1. New `canvases` + `canvas_revisions` tables and migrations in `desktop/src/main/db.ts`. IPC handlers for read/write/list. (~½ day)
2. Tiptap markdown editor component in the renderer with block-ID comments. (~1 day)
3. New `canvas.*` tools registered in `relay-server/src/tools/` and surfaced through the existing tool-call protocol. (~1 day)
4. Renderer wires `onToolCallCompleted` for `canvas.*` tools to the editor. Existing `ToolCallRow` shows "appended *Risks*" rows in the transcript. (~½ day)
5. Split-pane layout in `ChatPage.tsx` — canvas opens on first `canvas.*` tool call per conversation, collapses on demand, persists open/closed in settings. (~1 day)
6. Brand pass — paper cream `#f1e8da`, serif headings, generous margins. Match the floating call bar's editorial language, not generic AI-cyan SaaS. (~½ day)
7. Onboarding — one-time modal first time canvas appears, pointing at the docs page. (~½ day)
8. Tracing — `canvas.*` tool spans land in the existing OTel pipeline for free; add a `canvas_id` attribute. (~¼ day)

## Proposed follow-up tickets

Not creating these yet — flagging for approval. Suggest 4 tickets, sized to land independently:

1. **NAN-XXX — Canvas: persistence layer + IPC**
   - DB schema (`canvases`, `canvas_revisions`), migrations, IPC handlers, tests.
   - Self-contained; lands without any UI.

2. **NAN-XXX — Canvas: relay tools (`canvas.read` / `append` / `replace_block` / `insert_after` / `delete_block` / `rewrite`)**
   - New tools in `relay-server/src/tools/`, registered alongside `ask_brain` / `web_search`.
   - Includes integration tests against Gemini Live + OpenAI Realtime adapters.

3. **NAN-XXX — Canvas: markdown editor + split-pane in ChatPage**
   - Tiptap-based markdown editor component, block-ID comment scheme, split-pane layout, open/close/persist behaviour.
   - Wires to IPC handlers from ticket 1; ignores AI tools for now (manual editing only).

4. **NAN-XXX — Canvas: wire AI updates end-to-end**
   - Renderer applies `canvas.*` tool results to the editor. Transcript surfaces canvas activity via existing `ToolCallRow`. Brand pass on the canvas surface (paper + serif).
   - Depends on tickets 1 + 2 + 3.

If we want to keep the door open to free-form UI:

5. **NAN-XXX — Spike: generated-component blocks inside the markdown canvas**
   - 1-week spike to evaluate embedding sandboxed component blocks inside the markdown canvas (versus a separate canvas mode). Output: another design doc, no code shipped.

## Open questions

- **Canvas auto-open trigger.** Open on first AI `canvas.*` tool call (my proposal), or only when the user explicitly says "open a canvas" / clicks a button? Auto-open feels right for discoverability but risks surprising people mid-call.
- **What happens to canvases on conversation deletion?** Cascade delete (matches existing `messages` behaviour) — but per `feedback_no_data_wipe.md` we should make sure delete is explicit and undoable.
- **Markdown dialect.** GFM (tables, task lists, strikethrough) is the safe default. Mermaid blocks would be lovely (we already use Mermaid in docs) but probably v2.
- **Mobile.** Out of scope for v1. The split-pane assumption breaks on phone — mobile likely gets a tab-based "Canvas" view, but we should not try to design that until the desktop version ships and we know what users reach for.
- **Export.** Copy-as-markdown for free; "Open in Notion / send as email" can wait until we see if anyone asks.

## Test plan

- [ ] `yarn workspace voiceclaw-docs build` — passes (verified locally, 28 pages built, `canvas-mode/index.html` present)
- [ ] Visually check canvas-mode page renders under *Guides* in the local Starlight dev server
- [ ] Verify the docs page contains zero implementer-facing plumbing (IPC handlers, tool names, schema, etc.) — design analysis lives in the PR body only
- [ ] Confirm linked feature ticket NAN-678 resolves correctly