### PR TITLE
feat(desktop): typed text input in chat composer (NAN-638)

### DIFF
--- a/desktop/src/renderer/src/components/ChatComposer.tsx
+++ b/desktop/src/renderer/src/components/ChatComposer.tsx
@@ -1,0 +1,110 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react'
+import { Send } from 'lucide-react'
+import { Button } from './ui/Button'
+import {
+  COMPOSER_LIMITS,
+  isSubmittable,
+  normalizeComposerText,
+} from '../lib/composer'
+
+export interface ChatComposerProps {
+  onSubmit: (text: string) => void
+  disabled?: boolean
+  placeholder?: string
+}
+
+export function ChatComposer({ onSubmit, disabled, placeholder }: ChatComposerProps) {
+  const [value, setValue] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const submit = useCallback(() => {
+    const cleaned = normalizeComposerText(value)
+    if (!cleaned) return
+    onSubmit(cleaned)
+    setValue('')
+  }, [value, onSubmit])
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault()
+        submit()
+      }
+    },
+    [submit],
+  )
+
+  useLayoutEffect(() => {
+    const el = textareaRef.current
+    if (!el) return
+    autosize(el)
+  }, [value])
+
+  useEffect(() => {
+    const el = textareaRef.current
+    if (!el) return
+    autosize(el)
+  }, [])
+
+  const canSubmit = !disabled && isSubmittable(value)
+
+  return (
+    <div className="px-4 py-3 border-t border-border bg-background/80 backdrop-blur">
+      <div className="flex items-end gap-2">
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          rows={1}
+          disabled={disabled}
+          placeholder={placeholder ?? 'Type a message — Enter sends, Shift+Enter for newline'}
+          aria-label="Type a message"
+          className="
+            flex-1 resize-none rounded-md border border-input bg-background px-3 py-2
+            text-sm text-foreground placeholder:text-muted-foreground leading-5
+            focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary/50
+            disabled:opacity-50 disabled:cursor-not-allowed
+            whitespace-pre-wrap
+          "
+          style={{ minHeight: minHeightPx(), maxHeight: maxHeightPx() }}
+        />
+        <Button
+          variant="default"
+          size="icon"
+          onClick={submit}
+          disabled={!canSubmit}
+          aria-label="Send message"
+          title="Send (Enter)"
+        >
+          <Send size={18} />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function minHeightPx() {
+  return COMPOSER_LIMITS.minRows * COMPOSER_LIMITS.lineHeightPx + COMPOSER_LIMITS.verticalPaddingPx
+}
+
+function maxHeightPx() {
+  return COMPOSER_LIMITS.maxRows * COMPOSER_LIMITS.lineHeightPx + COMPOSER_LIMITS.verticalPaddingPx
+}
+
+function autosize(el: HTMLTextAreaElement) {
+  el.style.height = 'auto'
+  const next = Math.min(el.scrollHeight, maxHeightPx())
+  el.style.height = `${Math.max(minHeightPx(), next)}px`
+}

--- a/desktop/src/renderer/src/components/ChatComposer.tsx
+++ b/desktop/src/renderer/src/components/ChatComposer.tsx
@@ -34,6 +34,7 @@ export function ChatComposer({ onSubmit, disabled, placeholder }: ChatComposerPr
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        if (e.nativeEvent.isComposing) return
         e.preventDefault()
         submit()
       }

--- a/desktop/src/renderer/src/components/MessageBubble.tsx
+++ b/desktop/src/renderer/src/components/MessageBubble.tsx
@@ -1,16 +1,18 @@
 import type { MouseEvent } from 'react'
+import { Keyboard } from 'lucide-react'
 import type { Message } from '../lib/db'
 
 interface MessageBubbleProps {
   message: Message
   showLatency?: boolean
+  typed?: boolean
   onContextMenu?: (event: MouseEvent<HTMLDivElement>, message: Message) => void
 }
 
 const MD_IMAGE_REGEX = /!\[([^\]]*)\]\(([^)]+)\)/g
 const URL_IMAGE_REGEX = /(?:^|\s)(https?:\/\/\S+\.(?:png|jpg|jpeg|gif|webp)(?:\?\S*)?)/gi
 
-export function MessageBubble({ message, showLatency, onContextMenu }: MessageBubbleProps) {
+export function MessageBubble({ message, showLatency, typed, onContextMenu }: MessageBubbleProps) {
   const isUser = message.role === 'user'
   const parts = parseContent(message.content)
 
@@ -53,6 +55,12 @@ export function MessageBubble({ message, showLatency, onContextMenu }: MessageBu
             STT {Math.round(message.stt_latency_ms)}ms
             {message.llm_latency_ms != null && ` / LLM ${Math.round(message.llm_latency_ms)}ms`}
             {message.tts_latency_ms != null && ` / TTS ${Math.round(message.tts_latency_ms)}ms`}
+          </div>
+        )}
+        {typed && isUser && (
+          <div className="mt-1 flex items-center gap-1 text-[10px] opacity-60" title="Sent as typed text">
+            <Keyboard size={10} />
+            <span>typed</span>
           </div>
         )}
       </div>

--- a/desktop/src/renderer/src/lib/composer.test.ts
+++ b/desktop/src/renderer/src/lib/composer.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COMPOSER_LIMITS,
+  computeTextareaHeight,
+  isSubmittable,
+  normalizeComposerText,
+} from './composer'
+
+describe('normalizeComposerText', () => {
+  it('strips trailing spaces', () => {
+    expect(normalizeComposerText('hello   ')).toBe('hello')
+  })
+
+  it('strips trailing newlines and tabs', () => {
+    expect(normalizeComposerText('hello\n\t\n')).toBe('hello')
+  })
+
+  it('preserves leading whitespace', () => {
+    expect(normalizeComposerText('   indented')).toBe('   indented')
+  })
+
+  it('preserves internal whitespace and indentation', () => {
+    const code = 'function f() {\n    return 1\n}'
+    expect(normalizeComposerText(code + '\n\n')).toBe(code)
+  })
+
+  it('preserves URLs verbatim including query strings', () => {
+    const url = 'https://example.com/path?foo=bar&baz=1'
+    expect(normalizeComposerText(url + ' \n')).toBe(url)
+  })
+
+  it('preserves file paths with spaces', () => {
+    const path = '/Users/me/Library/Application Support/file.txt'
+    expect(normalizeComposerText(path + '   ')).toBe(path)
+  })
+
+  it('returns empty string for whitespace-only input', () => {
+    expect(normalizeComposerText('   \n\t  ')).toBe('')
+  })
+})
+
+describe('isSubmittable', () => {
+  it('rejects empty input', () => {
+    expect(isSubmittable('')).toBe(false)
+  })
+
+  it('rejects whitespace-only input', () => {
+    expect(isSubmittable('   \n  ')).toBe(false)
+  })
+
+  it('accepts a single character', () => {
+    expect(isSubmittable('a')).toBe(true)
+  })
+
+  it('accepts text with leading whitespace', () => {
+    expect(isSubmittable('   hello')).toBe(true)
+  })
+})
+
+describe('computeTextareaHeight', () => {
+  it('uses min rows for empty input', () => {
+    const h = computeTextareaHeight('')
+    expect(h).toBe(COMPOSER_LIMITS.minRows * COMPOSER_LIMITS.lineHeightPx + COMPOSER_LIMITS.verticalPaddingPx)
+  })
+
+  it('grows with newlines up to max rows', () => {
+    const six = computeTextareaHeight('a\nb\nc\nd\ne\nf')
+    const ten = computeTextareaHeight('a\nb\nc\nd\ne\nf\ng\nh\ni\nj')
+    expect(six).toBe(ten)
+    expect(six).toBe(COMPOSER_LIMITS.maxRows * COMPOSER_LIMITS.lineHeightPx + COMPOSER_LIMITS.verticalPaddingPx)
+  })
+})

--- a/desktop/src/renderer/src/lib/composer.ts
+++ b/desktop/src/renderer/src/lib/composer.ts
@@ -1,0 +1,30 @@
+// Pure helpers for the chat composer. Kept separate from the React
+// component so they're easy to unit-test.
+
+const MIN_ROWS = 1
+const MAX_ROWS = 6
+const LINE_HEIGHT_PX = 20
+const VERTICAL_PADDING_PX = 16
+
+export function normalizeComposerText(value: string): string {
+  // Trim trailing whitespace only — preserve leading and internal whitespace
+  // because pasted code, indented diffs, and file paths depend on it.
+  return value.replace(/[ \t\r\n]+$/u, '')
+}
+
+export function isSubmittable(value: string): boolean {
+  return normalizeComposerText(value).length > 0
+}
+
+export function computeTextareaHeight(value: string): number {
+  const lines = Math.max(MIN_ROWS, value.split('\n').length)
+  const clamped = Math.min(MAX_ROWS, lines)
+  return clamped * LINE_HEIGHT_PX + VERTICAL_PADDING_PX
+}
+
+export const COMPOSER_LIMITS = {
+  minRows: MIN_ROWS,
+  maxRows: MAX_ROWS,
+  lineHeightPx: LINE_HEIGHT_PX,
+  verticalPaddingPx: VERTICAL_PADDING_PX,
+}

--- a/desktop/src/renderer/src/lib/composer.ts
+++ b/desktop/src/renderer/src/lib/composer.ts
@@ -1,14 +1,9 @@
-// Pure helpers for the chat composer. Kept separate from the React
-// component so they're easy to unit-test.
-
 const MIN_ROWS = 1
 const MAX_ROWS = 6
 const LINE_HEIGHT_PX = 20
 const VERTICAL_PADDING_PX = 16
 
 export function normalizeComposerText(value: string): string {
-  // Trim trailing whitespace only — preserve leading and internal whitespace
-  // because pasted code, indented diffs, and file paths depend on it.
   return value.replace(/[ \t\r\n]+$/u, '')
 }
 

--- a/desktop/src/renderer/src/lib/text-chat.ts
+++ b/desktop/src/renderer/src/lib/text-chat.ts
@@ -1,0 +1,111 @@
+// One-shot text turn over the relay WebSocket. Used when the chat
+// composer submits while no realtime call is active — opens a fresh ws,
+// sends session.config + text.input, streams the assistant transcript,
+// closes when the relay reports the turn is done.
+
+export interface TextChatOptions {
+  serverUrl: string
+  apiKey: string
+  provider: 'gemini' | 'openai' | 'xai'
+  model: string
+  voice: string
+  sessionKey?: string
+  tavilyApiKey?: string
+  instructionsOverride?: string
+  conversationHistory?: { role: 'user' | 'assistant', text: string }[]
+  deviceContext?: { timezone?: string, locale?: string, deviceModel?: string }
+}
+
+export interface TextChatCallbacks {
+  onToken: (fullText: string) => void
+  onDone: (fullText: string) => void
+  onError: (error: string) => void
+}
+
+export function streamTextChat(
+  text: string,
+  opts: TextChatOptions,
+  callbacks: TextChatCallbacks,
+): () => void {
+  let didFinish = false
+  let fullText = ''
+  let sawDone = false
+  let ws: WebSocket | null = null
+
+  const finish = (kind: 'done' | 'error', payload: string) => {
+    if (didFinish) return
+    didFinish = true
+    try { ws?.close() } catch {}
+    if (kind === 'done') callbacks.onDone(payload)
+    else callbacks.onError(payload)
+  }
+
+  try {
+    ws = new WebSocket(opts.serverUrl)
+  } catch (e) {
+    callbacks.onError(e instanceof Error ? e.message : 'failed to open relay websocket')
+    return () => {}
+  }
+
+  ws.onopen = () => {
+    ws?.send(JSON.stringify({
+      type: 'session.config',
+      provider: opts.provider,
+      voice: opts.voice,
+      model: opts.model,
+      brainAgent: 'enabled',
+      apiKey: opts.apiKey,
+      tavilyApiKey: opts.tavilyApiKey,
+      sessionKey: opts.sessionKey,
+      deviceContext: opts.deviceContext,
+      instructionsOverride: opts.instructionsOverride,
+      conversationHistory: opts.conversationHistory,
+    }))
+  }
+
+  ws.onmessage = (event: MessageEvent) => {
+    let data: { type?: string, text?: string, role?: string, message?: string, code?: number }
+    try {
+      data = JSON.parse(event.data as string)
+    } catch {
+      return
+    }
+
+    switch (data.type) {
+      case 'session.ready':
+        ws?.send(JSON.stringify({ type: 'text.input', text }))
+        break
+      case 'transcript.delta':
+        if (data.role === 'assistant' && typeof data.text === 'string') {
+          fullText += data.text
+          callbacks.onToken(fullText)
+        }
+        break
+      case 'transcript.done':
+        if (data.role === 'assistant' && typeof data.text === 'string') {
+          fullText = data.text
+          sawDone = true
+          finish('done', fullText)
+        }
+        break
+      case 'turn.ended':
+        if (!sawDone) finish('done', fullText)
+        break
+      case 'error':
+        finish('error', data.message || `relay error ${data.code ?? ''}`.trim())
+        break
+    }
+  }
+
+  ws.onerror = () => {
+    if (!didFinish) finish('error', 'relay connection failed')
+  }
+
+  ws.onclose = () => {
+    if (!didFinish) finish('done', fullText)
+  }
+
+  return () => {
+    if (!didFinish) finish('error', 'cancelled')
+  }
+}

--- a/desktop/src/renderer/src/lib/text-chat.ts
+++ b/desktop/src/renderer/src/lib/text-chat.ts
@@ -1,8 +1,3 @@
-// One-shot text turn over the relay WebSocket. Used when the chat
-// composer submits while no realtime call is active — opens a fresh ws,
-// sends session.config + text.input, streams the assistant transcript,
-// closes when the relay reports the turn is done.
-
 export interface TextChatOptions {
   serverUrl: string
   apiKey: string

--- a/desktop/src/renderer/src/lib/use-realtime.ts
+++ b/desktop/src/renderer/src/lib/use-realtime.ts
@@ -67,6 +67,7 @@ export interface RealtimeControls {
   setOutputVolume: (volume: number) => void
   setOutputMuted: (muted: boolean) => void
   sendFrame: (base64Jpeg: string) => void
+  sendUserText: (text: string) => boolean
   getInputLevel: () => number
   getOutputLevel: () => number
   isConnected: boolean
@@ -385,6 +386,13 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
     }
   }, [])
 
+  const sendUserText = useCallback((text: string) => {
+    if (!text) return false
+    if (wsRef.current?.readyState !== WebSocket.OPEN) return false
+    wsRef.current.send(JSON.stringify({ type: 'text.input', text }))
+    return true
+  }, [])
+
   const getInputLevel = useCallback(() => {
     return engineRef.current?.getInputLevel() ?? 0
   }, [])
@@ -400,6 +408,7 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
     setOutputVolume,
     setOutputMuted,
     sendFrame,
+    sendUserText,
     getInputLevel,
     getOutputLevel,
     isConnected,

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react'
 import { Copy, Mic, MicOff, PhoneOff, Plus, Phone, Monitor, MonitorOff, Trash2 } from 'lucide-react'
 import { Button } from '../components/ui/Button'
+import { ChatComposer } from '../components/ChatComposer'
 import { MessageBubble } from '../components/MessageBubble'
 import { MessageContextMenu, type MessageContextMenuItem } from '../components/MessageContextMenu'
 import { ThinkingDots } from '../components/ThinkingDots'
@@ -32,6 +33,7 @@ import {
   type Message,
 } from '../lib/db'
 import { getVoiceForProvider, providerForModel } from '../lib/voice-prefs'
+import { streamTextChat } from '../lib/text-chat'
 
 const DEFAULT_REALTIME_MODEL = 'gemini-3.1-flash-live-preview'
 const REALTIME_MODELS = ['gemini-3.1-flash-live-preview', 'grok-voice-think-fast-1.0'] as const
@@ -65,6 +67,7 @@ export function ChatPage() {
   const activeRelayUrlRef = useRef<string>('')
   const brainCallStartRef = useRef<Map<string, number>>(new Map())
   const [messageMenu, setMessageMenu] = useState<{ x: number; y: number; message: Message } | null>(null)
+  const [typedMessageIds, setTypedMessageIds] = useState<Set<number>>(() => new Set())
   const { selectedConversationId, selectConversation } = useConversationContext()
 
   // Reload messages from DB — single source of truth, prevents duplicates.
@@ -402,12 +405,99 @@ export function ChatPage() {
     }
   }, [toggleMute, endCall])
 
+  const handleComposerSubmit = useCallback(async (text: string) => {
+    const convId = await ensureConversation()
+    const persisted = await addMessage(convId, 'user', text)
+    setTypedMessageIds((prev) => {
+      const next = new Set(prev)
+      next.add(persisted.id)
+      return next
+    })
+    await loadMessages()
+
+    if (!titleGeneratedRef.current) {
+      titleGeneratedRef.current = true
+      const title = generateTitle(text)
+      updateConversationTitle(convId, title).catch((err) =>
+        console.warn('[ChatPage] Failed to update title:', err),
+      )
+    }
+
+    if (realtimeRef.current?.isConnected) {
+      const ok = realtimeRef.current.sendUserText(text)
+      if (!ok) console.warn('[ChatPage] sendUserText failed — websocket not open')
+      return
+    }
+
+    const serverUrl = (await getSetting('realtime_server_url')) || (await defaultRelayUrl())
+    const apiKey = (await getSetting('realtime_api_key')) || ''
+    if (!apiKey) {
+      await addMessage(
+        convId,
+        'assistant',
+        'Add a Brain Gateway URL and API key in Settings to chat with the assistant.',
+      )
+      await loadMessages()
+      return
+    }
+    const model = normalizeRealtimeModel(await getSetting('realtime_model'))
+    const provider = providerForModel(model)
+    const voice = await getVoiceForProvider(provider)
+    const tavilyEnabled = (await getSetting('tavily_enabled')) !== 'false'
+    const tavilyApiKey = tavilyEnabled
+      ? ((await getSetting('tavily_api_key')) || undefined)
+      : undefined
+    const recent = (await getMessages(convId))
+      .filter((m) => m.role === 'user' || m.role === 'assistant')
+      .slice(-20, -1)
+      .map((m) => ({ role: m.role as 'user' | 'assistant', text: m.content }))
+
+    setIsThinking(true)
+    streamingRoleRef.current = 'assistant'
+    setStreamingRole('assistant')
+    streamTextChat(text, {
+      serverUrl,
+      apiKey,
+      provider: provider === 'gemini' ? 'gemini' : provider === 'xai' ? 'xai' : 'openai',
+      model,
+      voice,
+      tavilyApiKey,
+      sessionKey: `voiceclaw-desktop:${convId}`,
+      conversationHistory: recent.length > 0 ? recent : undefined,
+      deviceContext: {
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        locale: navigator.language,
+        deviceModel: 'Desktop (Electron)',
+      },
+    }, {
+      onToken: (full) => {
+        setIsThinking(false)
+        setStreamingText(full)
+      },
+      onDone: async (full) => {
+        setStreamingText('')
+        setIsThinking(false)
+        if (full.trim()) {
+          await addMessage(convId, 'assistant', full)
+          await loadMessages()
+        }
+      },
+      onError: async (err) => {
+        setStreamingText('')
+        setIsThinking(false)
+        await addMessage(convId, 'assistant', `Error: ${err}`)
+        await loadMessages()
+      },
+    })
+  }, [loadMessages])
+
   const newConversation = useCallback(() => {
     if (isCallActive) endCall()
     conversationIdRef.current = null
     setConversationId(null)
     setMessages([])
     setToolCalls([])
+    setTypedMessageIds(new Set())
     titleGeneratedRef.current = false
   }, [isCallActive, endCall])
 
@@ -513,6 +603,7 @@ export function ChatPage() {
               key={`msg-${item.data.id}`}
               message={item.data}
               showLatency={showLatency}
+              typed={typedMessageIds.has(item.data.id)}
               onContextMenu={handleMessageContextMenu}
             />
           ) : (
@@ -574,6 +665,9 @@ export function ChatPage() {
           {connectionError}
         </div>
       )}
+
+      {/* Typed text composer — always visible, works in and out of call */}
+      <ChatComposer onSubmit={handleComposerSubmit} />
 
       {/* Call controls */}
       <div className="px-4 py-3 border-t border-border flex items-center justify-center gap-3">

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -66,6 +66,7 @@ export function ChatPage() {
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const activeRelayUrlRef = useRef<string>('')
   const brainCallStartRef = useRef<Map<string, number>>(new Map())
+  const textChatCancelRef = useRef<(() => void) | null>(null)
   const [messageMenu, setMessageMenu] = useState<{ x: number; y: number; message: Message } | null>(null)
   const [typedMessageIds, setTypedMessageIds] = useState<Set<number>>(() => new Set())
   const { selectedConversationId, selectConversation } = useConversationContext()
@@ -455,7 +456,8 @@ export function ChatPage() {
     setIsThinking(true)
     streamingRoleRef.current = 'assistant'
     setStreamingRole('assistant')
-    streamTextChat(text, {
+    textChatCancelRef.current?.()
+    textChatCancelRef.current = streamTextChat(text, {
       serverUrl,
       apiKey,
       provider: provider === 'gemini' ? 'gemini' : provider === 'xai' ? 'xai' : 'openai',
@@ -477,6 +479,7 @@ export function ChatPage() {
       onDone: async (full) => {
         setStreamingText('')
         setIsThinking(false)
+        textChatCancelRef.current = null
         if (full.trim()) {
           await addMessage(convId, 'assistant', full)
           await loadMessages()
@@ -485,11 +488,19 @@ export function ChatPage() {
       onError: async (err) => {
         setStreamingText('')
         setIsThinking(false)
+        textChatCancelRef.current = null
         await addMessage(convId, 'assistant', `Error: ${err}`)
         await loadMessages()
       },
     })
   }, [loadMessages])
+
+  useEffect(() => {
+    return () => {
+      textChatCancelRef.current?.()
+      textChatCancelRef.current = null
+    }
+  }, [])
 
   const newConversation = useCallback(() => {
     if (isCallActive) endCall()
@@ -667,7 +678,7 @@ export function ChatPage() {
       )}
 
       {/* Typed text composer — always visible, works in and out of call */}
-      <ChatComposer onSubmit={handleComposerSubmit} />
+      <ChatComposer onSubmit={handleComposerSubmit} disabled={isThinking || !!streamingText} />
 
       {/* Call controls */}
       <div className="px-4 py-3 border-t border-border flex items-center justify-center gap-3">

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -86,6 +86,7 @@ export default defineConfig({
             { slug: 'desktop/call-bar', label: 'Desktop: floating call bar' },
             { slug: 'desktop/volume-control', label: 'Desktop: agent volume control' },
             { slug: 'desktop/chat-actions', label: 'Desktop: chat actions (right-click menu)' },
+            { slug: 'desktop/typing-messages', label: 'Desktop: typing messages' },
             { slug: 'desktop/releasing', label: 'Desktop: releasing' },
             { slug: 'mobile-app' },
           ],

--- a/docs/src/content/docs/desktop/typing-messages.mdx
+++ b/docs/src/content/docs/desktop/typing-messages.mdx
@@ -1,0 +1,71 @@
+---
+title: Typing messages in the chat
+description: How to send typed messages to your VoiceClaw assistant from the desktop chat composer — for links, file paths, code, and anything else that voice gets wrong.
+---
+
+import { Aside } from '@astrojs/starlight/components'
+
+Voice is great when you want to think out loud, but it's the wrong tool for sharing a URL, pasting a stack trace, or naming a file path with three slashes and a dash. The desktop chat window has a typed-text composer at the bottom that's always available — during a call and outside one — so you can drop in the precise text you have in your clipboard and let the assistant respond.
+
+## Where it lives
+
+Open the **Chat** tab. At the bottom of the window, just above the call controls, there's a single-row text field with a send button on the right. It's persistent — it doesn't hide behind a button or a slash command. You can use it as your primary input, mix it with voice, or only reach for it when voice fails.
+
+The placeholder reminds you of the keys that matter:
+
+> Type a message — Enter sends, Shift+Enter for newline
+
+## How it works
+
+Type into the field and press **Enter** to send. The composer:
+
+- **Sends on Enter.** Press Enter and the message goes immediately. No need to click the send button (though you can).
+- **Inserts a newline on Shift+Enter.** Hold Shift and press Enter to add a line break — useful when you want to paste multi-line code or a list.
+- **Auto-resizes from 1 to 6 lines.** As you type or paste content, the field grows downward up to six lines, then becomes scrollable. It shrinks back as you delete.
+- **Preserves your text exactly.** Whatever you paste arrives at the assistant character-for-character: indentation, internal whitespace, query strings, fragment identifiers. The composer only trims trailing whitespace on submit so empty lines at the end don't bloat the prompt.
+- **Treats whitespace-only input as a no-op.** Press Enter on an empty field — nothing happens. The send button is disabled until you've typed something meaningful.
+
+A small **typed** label appears beneath any message you sent through the composer (a subtle keyboard glyph plus the word). Voice messages don't get the label. It's a quiet way to remind you, when reading back later, which exchanges came from speech and which from typing.
+
+## During a call vs outside one
+
+The composer works in both states. The path your message takes is different, but the result feels the same.
+
+**During a realtime call.** The typed text is delivered to the live session as a text input alongside whatever you're saying. The assistant treats it as a user turn — the realtime model sees the text, can call tools (including `ask_brain`), and responds with voice and a transcript exactly like a spoken turn. You'll hear the answer if your speakers are on, and it lands in the chat history. Useful when you want to drop the assistant a URL mid-conversation without breaking the flow.
+
+**Outside a call.** Typing a message opens a one-shot relay session, sends your text, streams the assistant's reply into the chat as text, and closes. No microphone access, no speaker output — pure text-in / text-out. Your message and the reply are both saved to the conversation, so the next time you start a call the model has the full context.
+
+In both modes the assistant has access to the same brain agent and the same tools. The only difference is whether you hear the reply or just read it.
+
+<Aside type="note">
+The typed-text path uses your existing relay server URL and API key. If those aren't configured in **Settings → Relay**, the composer will reply with a setup hint instead of trying to send the message.
+</Aside>
+
+## Practical examples
+
+A few things the composer is good at that voice tends to mangle:
+
+- **Links.** Paste a URL — `https://example.com/page?id=42&lang=en` — and the assistant sees the exact string. Voice transcription often drops query params, swaps slashes for "slash", and turns hyphens into pauses.
+- **File paths.** `/Users/jane/Library/Application Support/Voiceclaw/voiceclaw.sqlite` is a typing job, not a speaking job. Drop it into the composer and ask the assistant what's in it.
+- **Code snippets.** Paste a 40-line function and ask "what's wrong with this?" — the indentation, brackets, and identifiers all survive intact. Press Shift+Enter between paragraphs if you want to add context above and below the snippet.
+- **Precise messages you've already drafted.** Sometimes you've got the exact phrasing you want in another window. Copy it, paste it, send. No interpretation layer.
+
+## Keyboard shortcuts
+
+The chat window's existing shortcuts still work alongside the composer:
+
+| Shortcut | What it does |
+| --- | --- |
+| **Enter** (composer focused) | Send the typed message |
+| **Shift+Enter** (composer focused) | Insert a newline in the composer |
+| **Cmd+N** | Start a new conversation |
+| **Cmd+M** | Mute the microphone (during a call) |
+| **Cmd+E** | End the current call |
+
+The composer respects the OS clipboard. Cmd+V pastes the exact text from your clipboard, including hidden characters like tabs and newlines — there's no normalization, sanitization, or auto-formatting between the clipboard and the assistant.
+
+## When the composer goes quiet
+
+The composer can disable itself temporarily — for example while a previous typed message is still streaming a reply. The send button greys out and the field rejects Enter until the reply finishes. This prevents two parallel turns from racing each other in the same conversation.
+
+If you want to interrupt a long reply, end the call (Cmd+E) or start a new conversation (Cmd+N). Both wipe the in-flight state and let you start fresh.

--- a/docs/src/content/docs/desktop/typing-messages.mdx
+++ b/docs/src/content/docs/desktop/typing-messages.mdx
@@ -31,14 +31,14 @@ A small **typed** label appears beneath any message you sent through the compose
 
 The composer works in both states. The path your message takes is different, but the result feels the same.
 
-**During a realtime call.** The typed text is delivered to the live session as a text input alongside whatever you're saying. The assistant treats it as a user turn — the realtime model sees the text, can call tools (including `ask_brain`), and responds with voice and a transcript exactly like a spoken turn. You'll hear the answer if your speakers are on, and it lands in the chat history. Useful when you want to drop the assistant a URL mid-conversation without breaking the flow.
+**During a call.** The typed text is delivered into the live conversation alongside whatever you're saying. The assistant treats it as a user turn — it sees the text, has access to all the same tools, and responds with voice and a transcript exactly like a spoken turn. You'll hear the answer if your speakers are on, and it lands in the chat history. Useful when you want to drop the assistant a URL mid-conversation without breaking the flow.
 
-**Outside a call.** Typing a message opens a one-shot relay session, sends your text, streams the assistant's reply into the chat as text, and closes. No microphone access, no speaker output — pure text-in / text-out. Your message and the reply are both saved to the conversation, so the next time you start a call the model has the full context.
+**Outside a call.** Typing a message sends your text, streams the assistant's reply into the chat as text, and stops there. No microphone access, no speaker output — pure text-in / text-out. Your message and the reply are both saved to the conversation, so the next time you start a call the assistant has the full context.
 
-In both modes the assistant has access to the same brain agent and the same tools. The only difference is whether you hear the reply or just read it.
+In both modes the assistant has access to the same tools. The only difference is whether you hear the reply or just read it.
 
 <Aside type="note">
-The typed-text path uses your existing relay server URL and API key. If those aren't configured in **Settings → Relay**, the composer will reply with a setup hint instead of trying to send the message.
+The composer needs your VoiceClaw connection settings. If those aren't configured yet, the composer will reply with a setup hint instead of trying to send the message — open **Settings** to finish setup.
 </Aside>
 
 ## Practical examples


### PR DESCRIPTION
## Why

Voice-only is a poor fit for sharing exact strings — links, file paths, code snippets, file system paths with non-ASCII characters. Transcription mangles URLs, drops query params, and renames slashes. This PR adds a persistent typed-text composer at the bottom of the desktop chat window so users can drop in precise text and let the assistant respond, both during a call and outside one.

Linear: NAN-638

## What

- **`<ChatComposer>`** at the bottom of `ChatPage` — single-row textarea that grows 1–6 rows, send button on the right, persistent (no hidden-behind-button mode).
- **Enter sends, Shift+Enter inserts newline.** No modifier keys send by accident.
- **Trim-trailing-only normalization** (`normalizeComposerText`): preserves leading whitespace and internal indentation so pasted code, file paths, and query strings survive intact.
- **Empty / whitespace-only is a no-op.** Send button disables until input is meaningful.
- **In-call delivery via `useRealtime.sendUserText(text)`** — emits the existing relay `text.input` event. Both Gemini and OpenAI adapters already accept `injectContext` / `input_text` so the model treats it as a normal user turn.
- **Out-of-call delivery via `streamTextChat`** — opens a one-shot WebSocket to the relay (mirrors the mobile `streamRealtimeText` pattern), sends `session.config` + `text.input`, streams the assistant reply, persists both messages to local SQLite. Same brain agent + tools as voice.
- **Subtle "typed" indicator** on user bubbles created via the composer (small keyboard glyph + "typed" label). Voice messages are unmarked. Indicator is session-scoped (no DB schema change).
- **Vitest coverage** for the pure helpers (`composer.test.ts`, 13 cases).
- **Starlight docs** at `docs/src/content/docs/desktop/typing-messages.mdx`, added to the sidebar in `docs/astro.config.mjs`.

## Key decisions

- **Text user messages are persisted client-side at submit time, not via `transcript.done`.** The relay forwards `text.input` to the model but does not echo a user-side transcript. Persisting at submit makes the bubble appear immediately and survives if the network drops before the assistant replies.
- **Out-of-call uses a fresh one-shot relay session, not a separate `ask_brain` IPC.** There's no existing `ask_brain` IPC handler in `desktop/src/main/`; the relay's text-input pipeline already runs through the brain agent (and tavily web_search). Reusing it keeps text and voice on the exact same backend.
- **No DB migration.** "Typed" cue is stored in component state (`Set<number>` of message IDs from this session). If we ever need it cross-restart we can add a `kind` column later.
- **No semicolons; helpers at file bottom; no ticket IDs in source comments** per the project's `CLAUDE.md`.

## Test plan

- [x] `yarn workspace voiceclaw-desktop typecheck` — passes
- [x] `yarn workspace voiceclaw-desktop test src/renderer/src/lib/composer.test.ts` — 13/13 pass
- [x] `yarn workspace voiceclaw-desktop build` — passes (electron-vite, all 3 entry points)
- [x] `yarn workspace voiceclaw-docs build` — passes; `/desktop/typing-messages/` page generated
- [ ] Manual: launch desktop, type "hello" outside a call → assistant replies in chat
- [ ] Manual: start a call, type a URL with query string → assistant references the exact URL in its spoken reply
- [ ] Manual: paste indented code snippet → indentation preserved in user bubble
- [ ] Manual: press Enter on empty composer → no-op, send button disabled
- [ ] Manual: press Shift+Enter → newline inserted, composer grows to 2 rows

## Pre-existing test failure (not from this PR)

`src/main/services/diagnostic-bundle.test.ts` fails because the `archiver` package isn't in `desktop/package.json`. That file was added before this branch and the failure reproduces on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)