### PR TITLE
fix(desktop): openclaw subprocess exits on startup due to invalid config schema and port parsed as subcommand

### DIFF
--- a/desktop/src/main/services/openclaw-gateway.test.ts
+++ b/desktop/src/main/services/openclaw-gateway.test.ts
@@ -25,6 +25,10 @@ vi.mock('fs', () => ({
   },
 }))
 
+vi.mock('../provider-keys', () => ({
+  getProviderKey: () => null,
+}))
+
 describe('resolveBundledOpenClawScript', () => {
   beforeEach(() => {
     originalResourcesPath = process.resourcesPath
@@ -128,7 +132,7 @@ describe('applyGeminiKeyToOpenClawConfig', () => {
     vi.resetModules()
   })
 
-  it('writes provider key, primary model, and plugin enable when no config exists', async () => {
+  it('writes primary model and plugin enable when no config exists', async () => {
     existsRef.fn = () => false
     const { applyGeminiKeyToOpenClawConfig, BUNDLED_GOOGLE_PRIMARY_MODEL } = await import(
       './openclaw-gateway'
@@ -137,7 +141,7 @@ describe('applyGeminiKeyToOpenClawConfig', () => {
     expect(changed).toBe(true)
     expect(writes.length).toBe(1)
     const written = JSON.parse(writes[0].content)
-    expect(written.models.providers.google.apiKey).toBe('AIzaTESTKEY')
+    expect(written.models?.providers?.google).toBeUndefined()
     expect(written.agents.defaults.model.primary).toBe(BUNDLED_GOOGLE_PRIMARY_MODEL)
     expect(written.plugins.entries.google.enabled).toBe(true)
   })
@@ -164,14 +168,10 @@ describe('applyGeminiKeyToOpenClawConfig', () => {
     expect(written.agents.defaults.model.fallbacks).toEqual(['claude-cli/claude-haiku-4-5'])
   })
 
-  it('returns false (no write) when the same key is already in place', async () => {
+  it('returns false (no write) when agent model and plugin are already correct', async () => {
     existsRef.fn = () => true
     readFileRef.fn = () =>
       JSON.stringify({
-        models: {
-          mode: 'merge',
-          providers: { google: { apiKey: 'samekey' } },
-        },
         agents: {
           defaults: {
             model: { primary: 'google/gemini-3.1-pro-preview' },
@@ -180,7 +180,7 @@ describe('applyGeminiKeyToOpenClawConfig', () => {
         plugins: { entries: { google: { enabled: true } } },
       })
     const { applyGeminiKeyToOpenClawConfig } = await import('./openclaw-gateway')
-    const changed = applyGeminiKeyToOpenClawConfig('samekey')
+    const changed = applyGeminiKeyToOpenClawConfig('anykey')
     expect(changed).toBe(false)
     expect(writes.length).toBe(0)
   })

--- a/desktop/src/main/services/openclaw-gateway.ts
+++ b/desktop/src/main/services/openclaw-gateway.ts
@@ -5,6 +5,7 @@ import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from
 import { dirname, join } from 'path'
 import { allocatePort } from '../ports'
 import { openLogStream } from '../logs'
+import { getProviderKey } from '../provider-keys'
 import { resolveBundledNode } from './node-runtime'
 import { serviceManager } from './service-manager'
 
@@ -25,6 +26,7 @@ export async function startBundledOpenClaw(): Promise<void> {
   const workspaceDir = join(stateDir, 'workspace')
   ensureSeededConfig(configPath)
   ensureGatewayAuthToken(configPath)
+  migrateInvalidGoogleProviderConfig(configPath)
   await ensureWorkspaceBootstrap({
     nodePath,
     scriptPath,
@@ -39,10 +41,7 @@ export async function startBundledOpenClaw(): Promise<void> {
     name: 'openclawGateway',
     command: nodePath,
     args: [scriptPath, 'gateway', '--port', String(port)],
-    env: {
-      OPENCLAW_STATE_DIR: stateDir,
-      OPENCLAW_CONFIG_PATH: configPath,
-    },
+    env: buildOpenClawEnv({ stateDir, configPath }),
     port,
     healthCheckUrl: `http://127.0.0.1:${port}/health`,
     healthCheckTimeoutMs: 30_000,
@@ -91,15 +90,6 @@ export function applyGeminiKeyToOpenClawConfig(geminiKey: string): boolean {
   }
 
   const before = JSON.stringify(parsed)
-
-  const models = (parsed.models as Record<string, unknown> | undefined) ?? {}
-  const providers = (models.providers as Record<string, unknown> | undefined) ?? {}
-  const google = (providers.google as Record<string, unknown> | undefined) ?? {}
-  google.apiKey = geminiKey
-  providers.google = google
-  models.providers = providers
-  if (typeof models.mode !== 'string') models.mode = 'merge'
-  parsed.models = models
 
   const agents = (parsed.agents as Record<string, unknown> | undefined) ?? {}
   const defaults = (agents.defaults as Record<string, unknown> | undefined) ?? {}
@@ -209,6 +199,49 @@ function resolveConfigTemplate(): string | null {
   }
   const dev = join(__dirname, '..', '..', 'resources', relative)
   return existsSync(dev) ? dev : null
+}
+
+function buildOpenClawEnv(params: {
+  stateDir: string
+  configPath: string
+}): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    OPENCLAW_STATE_DIR: params.stateDir,
+    OPENCLAW_CONFIG_PATH: params.configPath,
+  }
+  if (!env.GEMINI_API_KEY) {
+    const stored = getProviderKey('gemini')
+    if (stored) env.GEMINI_API_KEY = stored
+  }
+  return env
+}
+
+function migrateInvalidGoogleProviderConfig(configPath: string): void {
+  if (!existsSync(configPath)) return
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>
+  } catch {
+    return
+  }
+  const models = parsed.models as Record<string, unknown> | undefined
+  if (!models) return
+  const providers = models.providers as Record<string, unknown> | undefined
+  if (!providers) return
+  const google = providers.google as Record<string, unknown> | undefined
+  if (!google) return
+  const hasOnlyApiKey =
+    Object.keys(google).length === 1 && typeof google.apiKey === 'string'
+  if (!hasOnlyApiKey) return
+  delete providers.google
+  if (Object.keys(providers).length === 0) {
+    delete models.providers
+  }
+  if (Object.keys(models).length === 0) {
+    delete parsed.models
+  }
+  writeFileSync(configPath, JSON.stringify(parsed, null, 2) + '\n', { mode: 0o600 })
 }
 
 // Mints a random gateway token on first launch and persists it under


### PR DESCRIPTION
## Root cause

Two independent failures both prevent the bundled openclaw gateway from binding on fresh installs.

**Root cause 1 — schema-invalid config written on first run**

`applyGeminiKeyToOpenClawConfig` wrote `models.providers.google: { apiKey: "..." }` to the openclaw config JSON. OpenClaw's `ModelProviderSchema` (Zod, strict) requires `baseUrl` (non-optional `string`) and `models` (non-optional array) alongside `apiKey`. A provider entry with only `apiKey` is always schema-invalid.

On every subsequent launch: `snapshot.exists = true`, `snapshot.valid = false`. The config guard calls `exit(1)` before the gateway run function executes.

**Root cause 2 — stripped env + port number parsed as subcommand**

The `serviceManager.start()` call received `env: { OPENCLAW_STATE_DIR, OPENCLAW_CONFIG_PATH }` — no `HOME`, `PATH`, `TMPDIR`, or other inherited env. OpenClaw's argv parser (`getCommandPathWithRootOptions`) skips flag names like `--port` but adds their values as subcommand path elements. For `openclaw gateway --port 18789` it produces `commandPath = ["gateway", "18789"]`. The `isBareGatewayForegroundRun` bypass only fires when `subcommandName === undefined`; with `subcommandName = "18789"` it stays `false`, so `allowInvalid = false`, and any invalid config still triggers `exit(1)`.

## Probe results

| Probe | Env | Config | Result |
|-------|-----|--------|--------|
| A | `STATE_DIR + CONFIG_PATH` only | invalid (`models.providers.google: {apiKey}`) | DOWN — exit 1 |
| B | A + `HOME + PATH` | invalid | DOWN — same |
| E | A + `--allow-unconfigured` flag | invalid | DOWN — config guard exits before gateway run |
| G | spread `process.env` + `GEMINI_API_KEY` | valid (no `models.providers`) | UP — `/health` returns `{"ok":true,"status":"live"}` |

## What changed

- **Removed** `models.providers.google.apiKey` write from `applyGeminiKeyToOpenClawConfig`. The Gemini key is now delivered exclusively via `GEMINI_API_KEY` env var, which openclaw reads natively through its Google plugin registration.
- **Added** `buildOpenClawEnv()`: spreads `process.env` first (HOME, PATH, TMPDIR, …) then overlays `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, and `GEMINI_API_KEY` sourced from the keychain.
- **Added** `migrateInvalidGoogleProviderConfig()`: repairs existing user configs that have the schema-invalid `models.providers.google: {apiKey}` entry from previous builds. Called in `startBundledOpenClaw` before the workspace bootstrap.
- **Tests**: mocked `getProviderKey`, removed assertions on the deleted `models.providers.google` block, asserted it is absent in written output. All 91 desktop tests pass.

## Test plan

- [ ] `yarn workspace voiceclaw-desktop test --run` → 91 tests pass
- [ ] `npx tsc --noEmit` in desktop workspace → no errors
- [ ] On a fresh install (or after deleting `~/Library/Application Support/voiceclaw-desktop/openclaw/openclaw.json`): open app, connect Gemini key in settings, verify brain calls succeed (no "fetch failed")
- [ ] On an existing install with the old schema-invalid config: verify `migrateInvalidGoogleProviderConfig` removes the bad entry and gateway starts successfully