### PR TITLE
fix(release): draft desktop releases until DMG actually uploads

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -189,6 +189,15 @@ jobs:
           git commit -m "chore(desktop): update release feed for ${TAG}"
           git push origin main
 
+      - name: Publish release (flip from draft)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh release edit "$TAG" --repo "$REPO" --draft=false --latest
+
       - name: Upload DMG as workflow artifact
         if: always()
         uses: actions/upload-artifact@v7

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,7 +25,8 @@
       "package-name": "voiceclaw-desktop",
       "component": "desktop",
       "include-component-in-tag": true,
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "draft": true
     },
     "mobile": {
       "package-name": "voiceclaw-mobile",


### PR DESCRIPTION
## Why

Empty desktop releases keep appearing on the GitHub Releases page with no DMG asset for ~15 min after each tag push. Cause: release-please publishes the GitHub release synchronously with the tag push; then the release-desktop workflow takes 14-17 min to build/sign/notarize/upload the DMG. During that window the release exists publicly with only Source code zip/tar.gz — looks broken to anyone who lands on it.

This is exactly what happened with v0.10.3 and v0.10.4 just now — both visible publicly with no DMG.

## Fix

Two changes:

1. **\`release-please-config.json\`**: set \`draft: true\` on the desktop package only. Mobile keeps draft: false since it doesn't have a CI asset upload — TestFlight is its own delivery channel.

2. **\`release-desktop.yml\`**: after the DMG upload step succeeds, add \`gh release edit \"\$TAG\" --draft=false --latest\` to flip the release from draft to public.

## Result

Pipeline becomes: tag pushed → release created as DRAFT (invisible to public) → workflow builds + signs + notarizes + uploads DMG → workflow flips draft to public → release appears publicly with the DMG already attached.

If the build fails, the draft stays as a draft (invisible). No more empty public releases.

## Test plan

- [ ] Auto-merge after CI green
- [ ] Next desktop release: verify the GH release appears as Draft initially, then flips to public after the DMG uploads
- [ ] Verify mobile releases (e.g. mobile-v1.x.y) are NOT drafts (only desktop is)

🤖 Generated with [Claude Code](https://claude.com/claude-code)