### PR TITLE
fix(desktop): bundle openclaw templates + repair workspace sentinel-skip

### DIFF
--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -39,6 +39,7 @@ extraResources:
       - "**/*"
       - "!**/*.{md,LICENSE*,*.map,*.ts}"
       - "!**/CHANGELOG*"
+      - "openclaw/docs/reference/templates/**"
 
 mac:
   category: public.app-category.productivity

--- a/desktop/src/main/services/openclaw-gateway.ts
+++ b/desktop/src/main/services/openclaw-gateway.ts
@@ -143,10 +143,6 @@ async function ensureWorkspaceBootstrap(params: {
 }): Promise<void> {
   const sentinelPath = join(params.stateDir, 'workspace-bootstrapped')
   if (existsSync(sentinelPath)) return
-  if (existsSync(join(params.workspaceDir, 'IDENTITY.md'))) {
-    writeFileSync(sentinelPath, new Date().toISOString() + '\n')
-    return
-  }
   mkdirSync(params.workspaceDir, { recursive: true })
   const logStream = openLogStream('openclaw-setup.log')
   logStream.write(`\n[openclaw-setup] running setup at ${new Date().toISOString()}\n`)


### PR DESCRIPTION
## Summary

- **Bug 1 (template packaging):** `electron-builder.yml`'s `extraResources` filter excluded all `*.md` files via `!**/*.{md,...}`. The openclaw workspace templates (`AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`, `TOOLS.md`, `BOOTSTRAP.md`, `HEARTBEAT.md`, `BOOT.md`) are `.md` files living under `openclaw/docs/reference/templates/` — so they were stripped from every packaged build. Added `openclaw/docs/reference/templates/**` as an explicit allowlist entry after the exclusion glob so the runtime template files survive packaging. The `build-openclaw-bundle.mjs` script was already correct — templates arrive in the staging dir via `npm pack --ignore-scripts`; they were only lost at the electron-builder step.

- **Bug 2 (sentinel-skip):** `ensureWorkspaceBootstrap` fell back to `existsSync(IDENTITY.md)` when the sentinel file was absent, treating that as proof that bootstrap was complete. But the wizard writes `IDENTITY.md` (via `writeAgentIdentity`) before openclaw setup ever runs, so the fallback fired immediately and setup was skipped, leaving the workspace with only `IDENTITY.md`. Removed the 4-line fallback — sentinel-only is the correct contract: the sentinel is written only after a successful setup run. On next launch for affected users, setup will run; openclaw's `writeFileIfMissing` uses `flag: "wx"` so it will create the missing files without touching the wizard-written `IDENTITY.md`.

## Verification

- `npm pack --ignore-scripts --dry-run` from `vendor/openclaw` confirms all 13 template files are captured by the tarball.
- `node desktop/scripts/build-openclaw-bundle.mjs` run locally confirms templates land in `desktop/resources/openclaw/docs/reference/templates/`.
- `vendor/openclaw/src/agents/workspace.ts` `writeFileIfMissing` uses `fs.writeFile(..., { flag: 'wx' })` — exclusive create only, IDENTITY.md is safe.
- `yarn workspace voiceclaw-desktop typecheck` — clean.
- `yarn workspace voiceclaw-desktop test` — 100/100 pass.

## Test plan

- [ ] Build a packaged `.app` and verify `Contents/Resources/openclaw/docs/reference/templates/AGENTS.md` exists
- [ ] On a fresh device (or after deleting `~/Library/Application Support/VoiceClaw/openclaw/workspace-bootstrapped`), confirm brain calls succeed without "Missing workspace template" error
- [ ] Confirm a user who has only `IDENTITY.md` in their workspace gets the remaining files created on next launch without `IDENTITY.md` being overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)