### PR TITLE
feat(desktop): move attach to inline composer icon (NAN-703)

### DIFF
--- a/desktop/src/renderer/src/components/ChatComposer.tsx
+++ b/desktop/src/renderer/src/components/ChatComposer.tsx
@@ -6,7 +6,7 @@ import {
   useState,
   type KeyboardEvent,
 } from 'react'
-import { Send } from 'lucide-react'
+import { Paperclip, Send } from 'lucide-react'
 import { Button } from './ui/Button'
 import {
   COMPOSER_LIMITS,
@@ -16,11 +16,12 @@ import {
 
 export interface ChatComposerProps {
   onSubmit: (text: string) => void
+  onAttach?: () => void
   disabled?: boolean
   placeholder?: string
 }
 
-export function ChatComposer({ onSubmit, disabled, placeholder }: ChatComposerProps) {
+export function ChatComposer({ onSubmit, onAttach, disabled, placeholder }: ChatComposerProps) {
   const [value, setValue] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
@@ -59,6 +60,18 @@ export function ChatComposer({ onSubmit, disabled, placeholder }: ChatComposerPr
   return (
     <div className="px-4 py-3 border-t border-border bg-background/80 backdrop-blur">
       <div className="flex items-end gap-2">
+        {onAttach && (
+          <Button
+            variant="default"
+            size="icon"
+            onClick={onAttach}
+            disabled={disabled}
+            aria-label="Attach an image"
+            title="Attach an image (PNG, JPG, WEBP, ≤10MB)"
+          >
+            <Paperclip size={18} />
+          </Button>
+        )}
         <textarea
           ref={textareaRef}
           value={value}

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -809,16 +809,6 @@ export function ChatPage() {
             : 'Start a conversation'}
         </div>
         <div className="flex items-center gap-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handlePickImage}
-            title="Attach an image (PNG, JPG, WEBP, ≤10MB)"
-            aria-label="Attach an image"
-          >
-            <ImagePlus size={16} className="mr-1" />
-            Attach
-          </Button>
           <Button variant="ghost" size="sm" onClick={newConversation}>
             <Plus size={16} className="mr-1" />
             New
@@ -944,7 +934,11 @@ export function ChatPage() {
       />
 
       {/* Typed text composer — always visible, works in and out of call */}
-      <ChatComposer onSubmit={handleComposerSubmit} disabled={isThinking || !!streamingText} />
+      <ChatComposer
+        onSubmit={handleComposerSubmit}
+        onAttach={handlePickImage}
+        disabled={isThinking || !!streamingText}
+      />
 
       {/* Call controls */}
       <div className="px-4 py-3 border-t border-border flex items-center justify-center gap-3">

--- a/docs/src/content/docs/desktop/attachments.mdx
+++ b/docs/src/content/docs/desktop/attachments.mdx
@@ -15,7 +15,7 @@ There are three ways to add an image to the current conversation:
 
 - **Drag and drop.** Drag an image file from Finder (or any other source that exposes a real file) onto the chat area. The window dims and shows a "Drop image to attach" hint while you're hovering — release the mouse to add the image to the pending tray.
 - **Paste from clipboard.** Copy an image — a screenshot taken with `Cmd+Shift+4`, an image you copied from a webpage, anything that lands on the system clipboard as an image — and paste with `Cmd+V` while the chat window has focus.
-- **The Attach button.** Click **Attach** in the top-right of the chat header. A native open-file dialog appears, filtered to PNG / JPG / WEBP.
+- **The attach icon.** Click the paperclip icon on the left side of the message composer (mirrors the send arrow on the right). A native open-file dialog appears, filtered to PNG / JPG / WEBP.
 
 In all three cases the image lands in a small **pending tray** at the bottom of the chat. You can drop several images in a row before sending; each shows a thumbnail with a small `×` you can click to remove it before it's committed. Click **Send** to attach all pending images to a new user message in the conversation.
 


### PR DESCRIPTION
## Why

The chat header was getting cluttered with two leading actions ("+ Attach" and "+ New"). Attaching is a per-message intent that belongs next to where you compose the message — same place mainstream chat apps put it. Moving it into the composer also matches the existing send-arrow on the right and frees the header for conversation-level actions only.

Linear: NAN-703

## What

- `ChatComposer` gains an optional `onAttach?: () => void` prop. When provided, a paperclip icon button renders to the LEFT of the textarea, styled as the same `variant="default" size="icon"` `<Button>` as the send arrow on the right (same focus-visible ring, same disabled behavior).
- `ChatPage` no longer renders the header "Attach" button; it now passes `onAttach={handlePickImage}` to `ChatComposer`. Header keeps "+ New" only.
- `ImagePlus` import in `ChatPage` is retained — still used by the drag-and-drop overlay.
- Docs page `desktop/attachments.mdx` updated to describe the new in-composer paperclip affordance instead of the old top-right header button.

## Screenshots

The user has not shared reference screenshots in the conversation for this ticket. The visual change is local to the chat header (Attach button removed) and the composer (paperclip icon added on the left, same size/style as the existing send arrow on the right).

## Test plan

- [x] `yarn workspace voiceclaw-desktop typecheck` — green
- [x] `yarn workspace voiceclaw-desktop test` — 100/100 passing
- [x] `yarn workspace voiceclaw-desktop build` — green
- [ ] Manual: open chat header — only "+ New" shown
- [ ] Manual: paperclip icon appears on left of composer; clicking opens the native image picker (PNG/JPG/WEBP filter)
- [ ] Manual: paperclip is disabled while composer is disabled (`isThinking` or active streaming)
- [ ] Manual: drag-and-drop, paste-from-clipboard paths still work (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)