### PR TITLE
feat(desktop): allow typed-text interrupt of streaming reply (NAN-704)

### DIFF
--- a/desktop/src/renderer/src/lib/text-chat.ts
+++ b/desktop/src/renderer/src/lib/text-chat.ts
@@ -101,6 +101,8 @@ export function streamTextChat(
   }
 
   return () => {
-    if (!didFinish) finish('error', 'cancelled')
+    if (didFinish) return
+    didFinish = true
+    try { ws?.close() } catch {}
   }
 }

--- a/desktop/src/renderer/src/lib/text-chat.ts
+++ b/desktop/src/renderer/src/lib/text-chat.ts
@@ -71,12 +71,14 @@ export function streamTextChat(
         ws?.send(JSON.stringify({ type: 'text.input', text }))
         break
       case 'transcript.delta':
+        if (didFinish) break
         if (data.role === 'assistant' && typeof data.text === 'string') {
           fullText += data.text
           callbacks.onToken(fullText)
         }
         break
       case 'transcript.done':
+        if (didFinish) break
         if (data.role === 'assistant' && typeof data.text === 'string') {
           fullText = data.text
           sawDone = true
@@ -84,9 +86,11 @@ export function streamTextChat(
         }
         break
       case 'turn.ended':
+        if (didFinish) break
         if (!sawDone) finish('done', fullText)
         break
       case 'error':
+        if (didFinish) break
         finish('error', data.message || `relay error ${data.code ?? ''}`.trim())
         break
     }

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -476,6 +476,12 @@ export function ChatPage() {
   }, [toggleMute, endCall])
 
   const handleComposerSubmit = useCallback(async (text: string) => {
+    if (textChatCancelRef.current) {
+      textChatCancelRef.current()
+      textChatCancelRef.current = null
+      setStreamingText('')
+      setIsThinking(false)
+    }
     const convId = await ensureConversation()
     const persisted = await addMessage(convId, 'user', text)
     setTypedMessageIds((prev) => {
@@ -525,7 +531,6 @@ export function ChatPage() {
     setIsThinking(true)
     streamingRoleRef.current = 'assistant'
     setStreamingRole('assistant')
-    textChatCancelRef.current?.()
     textChatCancelRef.current = streamTextChat(text, {
       serverUrl,
       apiKey,
@@ -936,7 +941,6 @@ export function ChatPage() {
       <ChatComposer
         onSubmit={handleComposerSubmit}
         onAttach={handlePickImage}
-        disabled={isThinking || !!streamingText}
       />
 
       {/* Call controls */}

--- a/docs/src/content/docs/desktop/typing-messages.mdx
+++ b/docs/src/content/docs/desktop/typing-messages.mdx
@@ -64,8 +64,8 @@ The chat window's existing shortcuts still work alongside the composer:
 
 The composer respects the OS clipboard. Cmd+V pastes the exact text from your clipboard, including hidden characters like tabs and newlines — there's no normalization, sanitization, or auto-formatting between the clipboard and the assistant.
 
-## When the composer goes quiet
+## Interrupting a streaming reply
 
-The composer can disable itself temporarily — for example while a previous typed message is still streaming a reply. The send button greys out and the field rejects Enter until the reply finishes. This prevents two parallel turns from racing each other in the same conversation.
+Sometimes the assistant is halfway through a long reply and you already know you want to take it in a different direction. You can. Just type the new message and press Enter — the in-flight reply stops mid-sentence and the new turn takes over. The half-finished text disappears from the chat and isn't saved to history; only the new exchange lands in the conversation.
 
-If you want to interrupt a long reply, end the call (Cmd+E) or start a new conversation (Cmd+N). Both wipe the in-flight state and let you start fresh.
+This mirrors how voice already works. Speaking over the assistant cuts it off and starts your turn; typing now does the same. The composer stays enabled the whole time, so there's no waiting for the reply to finish before you can redirect.


### PR DESCRIPTION
## Why

Voice already supports interrupting the assistant mid-reply by speaking. Typed text didn't — the composer disabled itself while a reply was streaming, forcing the user to wait for the assistant to finish before they could redirect. This brings text parity with voice: type, press Enter, the in-flight reply stops, and the new turn takes over.

Linear: [NAN-704](https://linear.app/nano3labs/issue/NAN-704)

## What

- **`desktop/src/renderer/src/pages/ChatPage.tsx`**: drop `disabled={isThinking || !!streamingText}` from `<ChatComposer>`. In `handleComposerSubmit`, cancel any in-flight text stream up front and clear `streamingText` / `isThinking` before starting the new turn. The half-reply is not persisted to SQLite — `onDone` only writes when it actually fires.
- **`desktop/src/renderer/src/lib/text-chat.ts`**: the cancel fn returned from `streamTextChat` is now silent. It flips the `didFinish` guard and closes the websocket, without firing `onError('cancelled')`. This is what makes the existing `onToken` / `onDone` callbacks safe no-ops after cancel and prevents an "Error: cancelled" assistant message from landing in history.
- **`docs/src/content/docs/desktop/typing-messages.mdx`**: removed the "When the composer goes quiet" section that promised the composer would disable itself. Replaced with a section describing the new interrupt behavior, in the warm editorial voice the rest of the page uses.

## Test plan

- [ ] Outside a call, with the assistant offline, send a message that triggers a long reply.
- [ ] While the reply is streaming, type a different message and press Enter.
- [ ] Confirm: the partial reply disappears from the chat, the new user message appears, and the assistant streams a fresh reply for the second prompt.
- [ ] Confirm in History (or by reloading the conversation) that no half-reply or "Error: cancelled" assistant message was persisted — only the two user messages and the final assistant reply.
- [ ] Confirm the composer never greys out while a reply is streaming.
- [ ] `yarn workspace voiceclaw-desktop typecheck` — green
- [ ] `yarn workspace voiceclaw-desktop test` — green (100/100)
- [ ] `yarn workspace voiceclaw-desktop build` — green
- [ ] `yarn workspace voiceclaw-docs build` — green

Generated with [Claude Code](https://claude.com/claude-code)