### PR TITLE
fix(desktop): remove hoverable phantom element on composer textarea border (NAN-705)

### DIFF
--- a/desktop/src/renderer/src/index.css
+++ b/desktop/src/renderer/src/index.css
@@ -157,7 +157,6 @@
   animation: thinking-bounce 1.4s ease-in-out infinite;
 }
 
-/* Custom scrollbar */
 ::-webkit-scrollbar {
   width: 6px;
 }
@@ -170,4 +169,12 @@
 }
 ::-webkit-scrollbar-thumb:hover {
   background: var(--muted-foreground);
+}
+
+textarea::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+textarea {
+  scrollbar-width: none;
 }


### PR DESCRIPTION
## Summary

The "stray artifact / empty button" between the chat composer textarea and the send button (NAN-705) is **not a DOM element** — it's the textarea's native scrollbar gutter being painted by the global `::-webkit-scrollbar` rules.

**Root cause:** `desktop/src/renderer/src/index.css:160-172` declares unscoped `::-webkit-scrollbar` / `::-webkit-scrollbar-thumb` / `::-webkit-scrollbar-thumb:hover` rules. In Chromium/Electron these apply to **every scrollable element**, including `<textarea>`. The `<textarea>` in `ChatComposer.tsx:62-79` has the browser default `overflow: auto`, so a 6px-wide scrollbar gutter is reserved on its right edge. The thumb is `var(--border)` (rgba ~0.2 alpha — semi-transparent) and the rule includes a `:hover` selector — which is why it's hoverable, why the cursor changes, and why clicking it does nothing.

That matches every symptom in the report and screenshot:
- Tall (matches textarea height)
- Semi-transparent
- On the right border of the textarea
- Hoverable (cursor change activates `:hover`)
- Click does nothing useful

The previous investigation looked only at JSX and ruled out a DOM cause — correct as far as it went, but a `::-webkit-scrollbar` pseudo-element behaves like a hoverable widget at the renderer level, which is exactly what was happening here.

## Fix

`desktop/src/renderer/src/index.css` — suppress the scrollbar on textareas:

```css
textarea::-webkit-scrollbar {
  width: 0;
  height: 0;
}
textarea {
  scrollbar-width: none;
}
```

The composer is JS-autosized (`autosize()` in `ChatComposer.tsx`), so a visible scrollbar is unnecessary at the common 1-row height. Wheel scrolling still works for content beyond `maxHeight`.

## Visual change the user will see

Before: 6px-wide tall semi-transparent rectangle on the right edge of the chat composer textarea, hoverable.
After: clean textarea right edge flush against the gap before the send button. No more phantom hover target.

## Test plan
- [x] `yarn workspace voiceclaw-desktop typecheck` — green
- [x] `yarn workspace voiceclaw-desktop test` — 100/100 passed
- [x] `yarn workspace voiceclaw-desktop build` — green; verified `textarea::-webkit-scrollbar{width:0;height:0}` is in the bundled `out/renderer/assets/src-*.css`
- [ ] Visual confirmation in running Electron app: phantom rectangle next to send button is gone; textarea still accepts long pasted text and scrolls via wheel when content exceeds max height

🤖 Generated with [Claude Code](https://claude.com/claude-code)