### PR TITLE
fix(release): drop draft:true so release-please pushes desktop tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,8 +25,7 @@
       "package-name": "voiceclaw-desktop",
       "component": "desktop",
       "include-component-in-tag": true,
-      "changelog-path": "CHANGELOG.md",
-      "draft": true
+      "changelog-path": "CHANGELOG.md"
     },
     "mobile": {
       "package-name": "voiceclaw-mobile",


### PR DESCRIPTION
## Why

After PR #320 added `"draft": true` to the desktop package config in `release-please-config.json`, every release v0.10.5 → v0.10.36 got stuck:

- release-please created the GitHub Release entry as a draft
- **release-please does not push a tag when the release is a draft** — tags are only pushed on publish
- The desktop build workflow (`release-desktop.yml`) fires on `push: tags: desktop-v*` — it never ran
- DMG never built → release never published → website (which reads from GitHub Releases API) showed no DMG link

Classic chicken-and-egg, compounded with an auto-merge feedback loop that produced 16 stuck draft releases in 17 minutes.

## What

Revert the `draft: true` line on the desktop package only. release-please will now publish releases on creation; the release-desktop workflow fires on the tag push, builds the DMG, and uploads the artifacts to the now-published release.

The release will be live (empty) for ~10 min while the macOS runner builds + signs + notarizes + uploads. Acceptable — the website's "latest published" lookup will keep returning the previous version's DMG until the new one publishes with assets.

## Follow-up (separate PRs)

- The auto-merge feedback loop on release-please PRs needs to be addressed (16 PRs in 17 min).
- The 15 stuck draft releases (v0.10.21 → v0.10.35) should be deleted; v0.10.36 was tagged manually and is currently building.
- If we want "no public release until DMG attached," the right pattern is `prerelease: true` + flip to `prerelease: false` at the end of release-desktop.yml (prereleases ARE tagged).

## Test plan

- [ ] Merge this PR.
- [ ] Wait for next release-please PR to be created with a real version bump.
- [ ] On merge, confirm the tag `desktop-vX.Y.Z` is pushed (visible in `gh api repos/yagudaev/voiceclaw/git/refs/tags/desktop-vX.Y.Z`).
- [ ] Confirm `release-desktop` workflow fires automatically on the tag.
- [ ] Confirm the DMG + `.blockmap` + `latest-mac.yml` end up on the release page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)