### PR TITLE
feat(desktop): on-screen drawing during screen-share (experimental)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -22,6 +22,7 @@
     "archiver": "^7.0.1",
     "better-sqlite3": "^12.9.0",
     "electron-updater": "^6.6.2",
+    "get-windows": "^9.3.0",
     "posthog-js": "^1.372.1",
     "posthog-node": "^5.30.4",
     "react": "^19.1.0",

--- a/desktop/src/main/call-bar.ts
+++ b/desktop/src/main/call-bar.ts
@@ -26,6 +26,7 @@ let callBar: BrowserWindow | null = null
 let hideTimer: ReturnType<typeof setTimeout> | null = null
 let isReady = false
 let queuedVisibility: boolean | null = null
+let queuedMuted: boolean | null = null
 let levelTimer: ReturnType<typeof setInterval> | null = null
 let pendingLevels = { input: 0, output: 0 }
 
@@ -168,6 +169,10 @@ export function markCallBarReady(): void {
     broadcastVisibility(queuedVisibility)
     queuedVisibility = null
   }
+  if (queuedMuted !== null) {
+    broadcastMuted(queuedMuted)
+    queuedMuted = null
+  }
 }
 
 // Accept raw input/output RMS levels from the main renderer and let
@@ -175,6 +180,15 @@ export function markCallBarReady(): void {
 // renderer calls this on a ~30 Hz interval while a session is live.
 export function setAudioLevels(input: number, output: number): void {
   pendingLevels = { input, output }
+}
+
+export function broadcastMuted(muted: boolean): void {
+  if (!callBar || callBar.isDestroyed()) return
+  if (!isReady) {
+    queuedMuted = muted
+    return
+  }
+  callBar.webContents.send('call-bar:muted', muted)
 }
 
 export function showCallBarContextMenu(): void {

--- a/desktop/src/main/draw-overlay.ts
+++ b/desktop/src/main/draw-overlay.ts
@@ -1,0 +1,302 @@
+import { BrowserWindow, ipcMain, screen, type Display } from 'electron'
+import { join } from 'node:path'
+
+// Transparent always-on-top overlay used for on-screen annotations during
+// screen-share. Sized to the full bounds of a single display, click-through
+// by default, switches to interactive when the user enables draw mode.
+//
+// Two cooperating processes own its state:
+//   - The chat renderer (main window) decides when sharing is active and
+//     which display the share covers, and toggles draw mode in response to
+//     the call-bar buttons.
+//   - The overlay renderer (this window's webContents) draws strokes on a
+//     canvas and reports them back so the chat renderer can composite the
+//     strokes into outgoing video frames.
+
+type CreateOptions = {
+  isDev: boolean
+  rendererUrl?: string
+}
+
+type StrokePoint = { x: number; y: number }
+export type Stroke = {
+  id: string
+  color: string
+  width: number
+  points: StrokePoint[]
+}
+
+let overlayWindow: BrowserWindow | null = null
+let isReady = false
+let pendingMode: 'idle' | 'draw' | null = null
+let pendingDisplayId: number | null = null
+let currentDisplayId: number | null = null
+let currentMode: 'idle' | 'draw' = 'idle'
+
+let onStrokesChanged: ((strokes: Stroke[], displayBounds: DisplayBounds) => void) | null = null
+let onDisplayBoundsChanged: ((displayBounds: DisplayBounds) => void) | null = null
+let onModeChanged: ((mode: 'idle' | 'draw') => void) | null = null
+
+export type DisplayBounds = {
+  x: number
+  y: number
+  width: number
+  height: number
+  scaleFactor: number
+}
+
+export function createDrawOverlay(options: CreateOptions): BrowserWindow {
+  if (overlayWindow && !overlayWindow.isDestroyed()) return overlayWindow
+
+  const primary = screen.getPrimaryDisplay()
+  const { x, y, width, height } = primary.bounds
+
+  overlayWindow = new BrowserWindow({
+    x,
+    y,
+    width,
+    height,
+    frame: false,
+    transparent: true,
+    resizable: false,
+    movable: false,
+    minimizable: false,
+    maximizable: false,
+    skipTaskbar: true,
+    alwaysOnTop: true,
+    hasShadow: false,
+    focusable: false,
+    enableLargerThanScreen: true,
+    show: false,
+    webPreferences: {
+      preload: join(__dirname, '../preload/index.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  })
+
+  overlayWindow.setAlwaysOnTop(true, 'screen-saver')
+  overlayWindow.setVisibleOnAllWorkspaces(true, {
+    visibleOnFullScreen: true,
+    skipTransformProcessType: true,
+  })
+  overlayWindow.setIgnoreMouseEvents(true, { forward: true })
+
+  overlayWindow.on('closed', () => {
+    overlayWindow = null
+    isReady = false
+    pendingMode = null
+    pendingDisplayId = null
+    currentDisplayId = null
+    currentMode = 'idle'
+  })
+
+  const rendererUrl =
+    options.isDev && options.rendererUrl
+      ? `${options.rendererUrl.replace(/\/$/, '')}/?view=draw-overlay`
+      : undefined
+
+  if (rendererUrl) {
+    overlayWindow.loadURL(rendererUrl)
+  } else {
+    overlayWindow.loadFile(join(__dirname, '../renderer/index.html'), {
+      search: 'view=draw-overlay',
+    })
+  }
+
+  return overlayWindow
+}
+
+export function destroyDrawOverlay(): void {
+  if (overlayWindow && !overlayWindow.isDestroyed()) {
+    overlayWindow.destroy()
+  }
+  overlayWindow = null
+  isReady = false
+  pendingMode = null
+  pendingDisplayId = null
+  currentDisplayId = null
+  currentMode = 'idle'
+}
+
+export function showDrawOverlay(displayId?: number): void {
+  if (!overlayWindow || overlayWindow.isDestroyed()) return
+  if (!isReady) {
+    pendingDisplayId = displayId ?? null
+    return
+  }
+  applyShow(displayId)
+}
+
+export function hideDrawOverlay(): void {
+  pendingDisplayId = null
+  pendingMode = null
+  if (!overlayWindow || overlayWindow.isDestroyed()) return
+  setMode('idle')
+  if (overlayWindow.isVisible()) overlayWindow.hide()
+}
+
+export function setDrawOverlayMode(mode: 'idle' | 'draw'): void {
+  if (!overlayWindow || overlayWindow.isDestroyed()) return
+  if (!isReady) {
+    pendingMode = mode
+    return
+  }
+  setMode(mode)
+}
+
+export function clearDrawOverlay(): void {
+  if (!overlayWindow || overlayWindow.isDestroyed() || !isReady) return
+  overlayWindow.webContents.send('draw-overlay:clear')
+}
+
+export function getDrawOverlayWindow(): BrowserWindow | null {
+  return overlayWindow && !overlayWindow.isDestroyed() ? overlayWindow : null
+}
+
+export function onDrawOverlayStrokesChanged(
+  handler: (strokes: Stroke[], bounds: DisplayBounds) => void,
+): void {
+  onStrokesChanged = handler
+}
+
+export function onDrawOverlayDisplayBounds(
+  handler: (bounds: DisplayBounds) => void,
+): void {
+  onDisplayBoundsChanged = handler
+}
+
+export function onDrawOverlayModeChanged(
+  handler: (mode: 'idle' | 'draw') => void,
+): void {
+  onModeChanged = handler
+}
+
+export function registerDrawOverlayHandlers(): void {
+  ipcMain.handle('draw-overlay:ready', (e) => {
+    if (!isFromOverlay(e.sender.id)) return
+    isReady = true
+    if (pendingDisplayId !== null) {
+      applyShow(pendingDisplayId)
+      pendingDisplayId = null
+    }
+    if (pendingMode !== null) {
+      setMode(pendingMode)
+      pendingMode = null
+    }
+  })
+
+  ipcMain.on('draw-overlay:strokes', (e, payload: unknown) => {
+    if (!isFromOverlay(e.sender.id)) return
+    if (!isStrokesPayload(payload)) return
+    if (!onStrokesChanged) return
+    const bounds = currentDisplayBounds()
+    if (!bounds) return
+    onStrokesChanged(payload.strokes, bounds)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function applyShow(displayId?: number | null): void {
+  if (!overlayWindow || overlayWindow.isDestroyed()) return
+  const display = resolveDisplay(displayId ?? undefined)
+  currentDisplayId = display.id
+  const { x, y, width, height } = display.bounds
+  overlayWindow.setBounds({ x, y, width, height })
+  overlayWindow.setAlwaysOnTop(true, 'screen-saver')
+  overlayWindow.setVisibleOnAllWorkspaces(true, {
+    visibleOnFullScreen: true,
+    skipTransformProcessType: true,
+  })
+  if (!overlayWindow.isVisible()) {
+    overlayWindow.showInactive()
+  }
+  const bounds = boundsFromDisplay(display)
+  overlayWindow.webContents.send('draw-overlay:bounds', bounds)
+  if (onDisplayBoundsChanged) onDisplayBoundsChanged(bounds)
+}
+
+function setMode(mode: 'idle' | 'draw'): void {
+  if (!overlayWindow || overlayWindow.isDestroyed()) return
+  currentMode = mode
+  if (mode === 'draw') {
+    overlayWindow.setIgnoreMouseEvents(false)
+    // Make the overlay key-window-eligible so the renderer receives
+    // keydown events (Esc to exit draw mode). Without this, focusable:false
+    // means macOS never routes keyboard events here.
+    overlayWindow.setFocusable(true)
+    overlayWindow.focus()
+  } else {
+    overlayWindow.setIgnoreMouseEvents(true, { forward: true })
+    overlayWindow.setFocusable(false)
+  }
+  overlayWindow.webContents.send('draw-overlay:mode', mode)
+  if (onModeChanged) onModeChanged(mode)
+}
+
+function resolveDisplay(displayId?: number): Display {
+  if (typeof displayId === 'number') {
+    const found = screen.getAllDisplays().find((d) => d.id === displayId)
+    if (found) return found
+  }
+  return screen.getPrimaryDisplay()
+}
+
+function currentDisplayBounds(): DisplayBounds | null {
+  const display =
+    screen.getAllDisplays().find((d) => d.id === currentDisplayId) ??
+    screen.getPrimaryDisplay()
+  if (!display) return null
+  return boundsFromDisplay(display)
+}
+
+function boundsFromDisplay(display: Display): DisplayBounds {
+  return {
+    x: display.bounds.x,
+    y: display.bounds.y,
+    width: display.bounds.width,
+    height: display.bounds.height,
+    scaleFactor: display.scaleFactor,
+  }
+}
+
+function isFromOverlay(senderId: number): boolean {
+  return Boolean(
+    overlayWindow &&
+      !overlayWindow.isDestroyed() &&
+      overlayWindow.webContents.id === senderId,
+  )
+}
+
+function isStrokesPayload(payload: unknown): payload is { strokes: Stroke[] } {
+  if (!payload || typeof payload !== 'object') return false
+  const strokes = (payload as { strokes?: unknown }).strokes
+  if (!Array.isArray(strokes)) return false
+  return strokes.every(isStroke)
+}
+
+function isStroke(value: unknown): value is Stroke {
+  if (!value || typeof value !== 'object') return false
+  const v = value as { id?: unknown; color?: unknown; width?: unknown; points?: unknown }
+  if (typeof v.id !== 'string') return false
+  if (typeof v.color !== 'string') return false
+  if (typeof v.width !== 'number' || !Number.isFinite(v.width)) return false
+  if (!Array.isArray(v.points)) return false
+  return v.points.every((p) => {
+    if (!p || typeof p !== 'object') return false
+    const point = p as { x?: unknown; y?: unknown }
+    return (
+      typeof point.x === 'number' &&
+      typeof point.y === 'number' &&
+      Number.isFinite(point.x) &&
+      Number.isFinite(point.y)
+    )
+  })
+}
+
+export function getCurrentMode(): 'idle' | 'draw' {
+  return currentMode
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -13,6 +13,7 @@ import {
   showMainWindow,
 } from './window-lifecycle'
 import {
+  broadcastMuted,
   createCallBar,
   destroyCallBar,
   focusMainFromCallBar,
@@ -219,6 +220,10 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('call-bar:open-context-menu', () => {
     showCallBarContextMenu()
+  })
+
+  ipcMain.on('call-bar:muted', (_e, muted: unknown) => {
+    broadcastMuted(Boolean(muted))
   })
 
   ipcMain.on('call-bar:audio-levels', (_e, payload: { input: number; output: number }) => {

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -23,6 +23,19 @@ import {
   showCallBar,
   showCallBarContextMenu,
 } from './call-bar'
+import {
+  clearDrawOverlay,
+  createDrawOverlay,
+  destroyDrawOverlay,
+  getDrawOverlayWindow,
+  hideDrawOverlay,
+  onDrawOverlayDisplayBounds,
+  onDrawOverlayModeChanged,
+  onDrawOverlayStrokesChanged,
+  registerDrawOverlayHandlers,
+  setDrawOverlayMode,
+  showDrawOverlay,
+} from './draw-overlay'
 import { serviceManager } from './services/service-manager'
 import {
   applyGeminiKeyToOpenClawConfig,
@@ -91,6 +104,7 @@ app.whenReady().then(async () => {
   registerAuthDeepLink()
   registerIpcHandlers()
   registerScreenCaptureHandlers()
+  registerDrawOverlayHandlers()
   registerTelemetryHandlers()
   const firstLaunch = isFirstLaunch()
   telemetryIdentify()
@@ -132,6 +146,39 @@ app.whenReady().then(async () => {
   // Create the window up front so show/hide is instant when a session
   // opens. The window is hidden until setCallActive(true) fires.
   createCallBar({ isDev, rendererUrl: process.env.ELECTRON_RENDERER_URL })
+
+  createDrawOverlay({ isDev, rendererUrl: process.env.ELECTRON_RENDERER_URL })
+  onDrawOverlayStrokesChanged((strokes, bounds) => {
+    getMainWindow()?.webContents.send('draw-overlay:strokes', { strokes, bounds })
+  })
+  onDrawOverlayDisplayBounds((bounds) => {
+    getMainWindow()?.webContents.send('draw-overlay:display-bounds', bounds)
+  })
+  onDrawOverlayModeChanged((mode) => {
+    getMainWindow()?.webContents.send('draw-overlay:mode', mode)
+  })
+
+  ipcMain.handle('draw-overlay:show', (e, displayId?: number) => {
+    if (e.sender !== getMainWindow()?.webContents) return
+    showDrawOverlay(typeof displayId === 'number' ? displayId : undefined)
+  })
+  ipcMain.handle('draw-overlay:hide', (e) => {
+    if (e.sender !== getMainWindow()?.webContents) return
+    hideDrawOverlay()
+  })
+  ipcMain.handle('draw-overlay:setMode', (e, mode: unknown) => {
+    const main = getMainWindow()?.webContents
+    const overlay = getDrawOverlayWindow()?.webContents
+    if (e.sender !== main && e.sender !== overlay) return
+    if (mode !== 'idle' && mode !== 'draw') return
+    setDrawOverlayMode(mode)
+  })
+  ipcMain.handle('draw-overlay:clear', (e) => {
+    const main = getMainWindow()?.webContents
+    const overlay = getDrawOverlayWindow()?.webContents
+    if (e.sender !== main && e.sender !== overlay) return
+    clearDrawOverlay()
+  })
 
   registerCallBarHooks({
     onFocusMain: () => {
@@ -241,6 +288,7 @@ app.on('before-quit', async (event) => {
 app.on('will-quit', () => {
   serviceManager.stopAll()
   destroyCallBar()
+  destroyDrawOverlay()
   destroyTray()
   closeDb()
 })

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -103,9 +103,15 @@ app.whenReady().then(async () => {
     resetOnboarding()
   }
 
+  // Predicate shared across handlers that should only accept calls from the
+  // chat / settings renderer — never from the call-bar, draw-overlay, or any
+  // future webview.
+  const isMainRendererSender = (sender: Electron.WebContents) =>
+    sender === getMainWindow()?.webContents
+
   registerAuthDeepLink()
   registerIpcHandlers()
-  registerScreenCaptureHandlers()
+  registerScreenCaptureHandlers(isMainRendererSender)
   registerDrawOverlayHandlers()
   registerShortcutHandlers((action) => {
     // Actions whose visible feedback lives inside the main window need it
@@ -115,7 +121,7 @@ app.whenReady().then(async () => {
       showMainWindow()
     }
     getMainWindow()?.webContents.send('shortcuts:triggered', action)
-  })
+  }, isMainRendererSender)
   registerTelemetryHandlers()
   const firstLaunch = isFirstLaunch()
   telemetryIdentify()
@@ -222,13 +228,15 @@ app.whenReady().then(async () => {
     showCallBarContextMenu()
   })
 
-  ipcMain.on('call-bar:muted', (_e, muted: unknown) => {
+  ipcMain.on('call-bar:muted', (e, muted: unknown) => {
+    if (e.sender !== getMainWindow()?.webContents) return
     broadcastMuted(Boolean(muted))
   })
 
-  ipcMain.on('call-bar:audio-levels', (_e, payload: { input: number; output: number }) => {
+  ipcMain.on('call-bar:audio-levels', (e, payload: { input: number; output: number }) => {
     // Use .on instead of .handle — we don't need a reply, and this
     // fires up to 30 Hz.
+    if (e.sender !== getMainWindow()?.webContents) return
     setAudioLevels(
       typeof payload?.input === 'number' ? payload.input : 0,
       typeof payload?.output === 'number' ? payload.output : 0,

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -107,6 +107,13 @@ app.whenReady().then(async () => {
   registerScreenCaptureHandlers()
   registerDrawOverlayHandlers()
   registerShortcutHandlers((action) => {
+    // Screen-share toggles the picker modal which lives in the main window.
+    // If VoiceClaw is in the background when the shortcut fires, the modal
+    // would render off-screen — bring the window forward first so the user
+    // can actually pick a source.
+    if (action === 'screenShare') {
+      showMainWindow()
+    }
     getMainWindow()?.webContents.send('shortcuts:triggered', action)
   })
   registerTelemetryHandlers()

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -36,6 +36,7 @@ import {
   setDrawOverlayMode,
   showDrawOverlay,
 } from './draw-overlay'
+import { registerShortcutHandlers, unregisterAllShortcuts } from './shortcuts'
 import { serviceManager } from './services/service-manager'
 import {
   applyGeminiKeyToOpenClawConfig,
@@ -105,6 +106,9 @@ app.whenReady().then(async () => {
   registerIpcHandlers()
   registerScreenCaptureHandlers()
   registerDrawOverlayHandlers()
+  registerShortcutHandlers((action) => {
+    getMainWindow()?.webContents.send('shortcuts:triggered', action)
+  })
   registerTelemetryHandlers()
   const firstLaunch = isFirstLaunch()
   telemetryIdentify()
@@ -286,6 +290,7 @@ app.on('before-quit', async (event) => {
 })
 
 app.on('will-quit', () => {
+  unregisterAllShortcuts()
   serviceManager.stopAll()
   destroyCallBar()
   destroyDrawOverlay()

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -107,11 +107,10 @@ app.whenReady().then(async () => {
   registerScreenCaptureHandlers()
   registerDrawOverlayHandlers()
   registerShortcutHandlers((action) => {
-    // Screen-share toggles the picker modal which lives in the main window.
-    // If VoiceClaw is in the background when the shortcut fires, the modal
-    // would render off-screen — bring the window forward first so the user
-    // can actually pick a source.
-    if (action === 'screenShare') {
+    // Actions whose visible feedback lives inside the main window need it
+    // forward when the shortcut fires from another app — e.g. screen-share's
+    // source-picker modal, and the chat surface that shows call state.
+    if (action === 'screenShare' || action === 'toggleCall') {
       showMainWindow()
     }
     getMainWindow()?.webContents.send('shortcuts:triggered', action)

--- a/desktop/src/main/screen-capture.ts
+++ b/desktop/src/main/screen-capture.ts
@@ -15,7 +15,11 @@ export type WindowBoundsIPC = {
   height: number
 }
 
-export function registerScreenCaptureHandlers() {
+type SenderPredicate = (sender: Electron.WebContents) => boolean
+
+export function registerScreenCaptureHandlers(
+  isTrustedSender: SenderPredicate = () => true,
+) {
   ipcMain.handle('screen:getSources', async (): Promise<ScreenSourceIPC[]> => {
     if (process.platform === 'darwin') {
       const status = systemPreferences.getMediaAccessStatus('screen')
@@ -66,7 +70,11 @@ export function registerScreenCaptureHandlers() {
 
   ipcMain.handle(
     'screen:getWindowBounds',
-    async (_e, windowId: unknown): Promise<WindowBoundsIPC | null> => {
+    async (e, windowId: unknown): Promise<WindowBoundsIPC | null> => {
+      // Window geometry is sensitive enough that we don't want any preload-
+      // exposed renderer (e.g. an embedded webview, or a future overlay
+      // window with a third-party iframe) calling this.
+      if (!isTrustedSender(e.sender)) return null
       if (typeof windowId !== 'number' || !Number.isFinite(windowId)) return null
       try {
         const all = await openWindows()

--- a/desktop/src/main/screen-capture.ts
+++ b/desktop/src/main/screen-capture.ts
@@ -1,10 +1,18 @@
 import { ipcMain, desktopCapturer, systemPreferences, shell, session } from 'electron'
+import { openWindows } from 'get-windows'
 
 export type ScreenSourceIPC = {
   id: string
   name: string
   thumbnailDataURL: string | null
   appIconDataURL: string | null
+}
+
+export type WindowBoundsIPC = {
+  x: number
+  y: number
+  width: number
+  height: number
 }
 
 export function registerScreenCaptureHandlers() {
@@ -54,5 +62,25 @@ export function registerScreenCaptureHandlers() {
         .catch(() => callback({}))
     },
     { useSystemPicker: false }
+  )
+
+  ipcMain.handle(
+    'screen:getWindowBounds',
+    async (_e, windowId: unknown): Promise<WindowBoundsIPC | null> => {
+      if (typeof windowId !== 'number' || !Number.isFinite(windowId)) return null
+      try {
+        const all = await openWindows()
+        const found = all.find((w) => w.id === windowId)
+        if (!found) return null
+        return {
+          x: found.bounds.x,
+          y: found.bounds.y,
+          width: found.bounds.width,
+          height: found.bounds.height,
+        }
+      } catch {
+        return null
+      }
+    },
   )
 }

--- a/desktop/src/main/shortcuts.ts
+++ b/desktop/src/main/shortcuts.ts
@@ -6,15 +6,21 @@ import { getDb } from './db'
 // screen-share. Defaults are seeded on first launch; the Settings UI lets the
 // user rebind or clear each one.
 
-export type ShortcutAction = 'mute' | 'annotate' | 'screenShare'
+export type ShortcutAction = 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare'
 
-export const SHORTCUT_ACTIONS: ShortcutAction[] = ['mute', 'annotate', 'screenShare']
+export const SHORTCUT_ACTIONS: ShortcutAction[] = [
+  'mute',
+  'annotate',
+  'clearAnnotations',
+  'screenShare',
+]
 
 const SETTING_PREFIX = 'shortcut_accelerator_'
 
 const DEFAULTS: Record<ShortcutAction, string> = {
   mute: 'Control+M',
   annotate: 'Control+A',
+  clearAnnotations: 'Control+Shift+A',
   screenShare: 'Control+S',
 }
 

--- a/desktop/src/main/shortcuts.ts
+++ b/desktop/src/main/shortcuts.ts
@@ -6,9 +6,15 @@ import { getDb } from './db'
 // screen-share. Defaults are seeded on first launch; the Settings UI lets the
 // user rebind or clear each one.
 
-export type ShortcutAction = 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare'
+export type ShortcutAction =
+  | 'toggleCall'
+  | 'mute'
+  | 'annotate'
+  | 'clearAnnotations'
+  | 'screenShare'
 
 export const SHORTCUT_ACTIONS: ShortcutAction[] = [
+  'toggleCall',
   'mute',
   'annotate',
   'clearAnnotations',
@@ -18,6 +24,7 @@ export const SHORTCUT_ACTIONS: ShortcutAction[] = [
 const SETTING_PREFIX = 'shortcut_accelerator_'
 
 const DEFAULTS: Record<ShortcutAction, string> = {
+  toggleCall: 'Control+J',
   mute: 'Control+M',
   annotate: 'Control+A',
   clearAnnotations: 'Control+Shift+A',

--- a/desktop/src/main/shortcuts.ts
+++ b/desktop/src/main/shortcuts.ts
@@ -36,31 +36,49 @@ let registered: Partial<Record<ShortcutAction, string>> = {}
 
 export function registerShortcutHandlers(
   onTriggeredCallback: (action: ShortcutAction) => void,
+  isTrustedSender: (sender: Electron.WebContents) => boolean = () => true,
 ): void {
   onTriggered = onTriggeredCallback
   seedDefaults()
   applyAll()
 
-  ipcMain.handle('shortcuts:list', () => listShortcuts())
+  // shortcuts:* handlers mutate global OS shortcut state. Restrict to the
+  // trusted (settings/main) renderer so an embedded webview or compromised
+  // overlay can't rebind keys system-wide.
+  const denyUntrusted = (sender: Electron.WebContents) =>
+    isTrustedSender(sender) ? null : { ok: false as const, error: 'not allowed' }
 
-  ipcMain.handle('shortcuts:set', (_e, action: ShortcutAction, accelerator: string) => {
+  ipcMain.handle('shortcuts:list', (e) => {
+    if (!isTrustedSender(e.sender)) return []
+    return listShortcuts()
+  })
+
+  ipcMain.handle('shortcuts:set', (e, action: ShortcutAction, accelerator: string) => {
+    const denied = denyUntrusted(e.sender)
+    if (denied) return denied
     if (!SHORTCUT_ACTIONS.includes(action)) return { ok: false, error: 'unknown action' }
     if (!isPlausibleAccelerator(accelerator)) {
       return { ok: false, error: 'invalid accelerator' }
     }
-    saveAccelerator(action, accelerator)
+    // Register first; only persist on success so a failed binding never
+    // leaves the DB pointing at an unregistered accelerator.
     const result = applyOne(action, accelerator)
-    return result.ok ? { ok: true, accelerator } : result
+    if (!result.ok) return result
+    saveAccelerator(action, accelerator)
+    return { ok: true, accelerator }
   })
 
-  ipcMain.handle('shortcuts:clear', (_e, action: ShortcutAction) => {
+  ipcMain.handle('shortcuts:clear', (e, action: ShortcutAction) => {
+    const denied = denyUntrusted(e.sender)
+    if (denied) return denied
     if (!SHORTCUT_ACTIONS.includes(action)) return { ok: false, error: 'unknown action' }
     saveAccelerator(action, '')
     unregisterOne(action)
     return { ok: true }
   })
 
-  ipcMain.handle('shortcuts:resetDefaults', () => {
+  ipcMain.handle('shortcuts:resetDefaults', (e) => {
+    if (!isTrustedSender(e.sender)) return []
     for (const action of SHORTCUT_ACTIONS) {
       saveAccelerator(action, DEFAULTS[action])
     }
@@ -162,12 +180,33 @@ function listShortcuts(): Array<{
   }))
 }
 
+const MODIFIER_TOKENS = new Set([
+  'control',
+  'ctrl',
+  'command',
+  'cmd',
+  'commandorcontrol',
+  'cmdorctrl',
+  'alt',
+  'option',
+  'altgr',
+  'shift',
+  'meta',
+  'super',
+])
+
 function isPlausibleAccelerator(s: string): boolean {
   if (typeof s !== 'string') return false
-  if (s.length === 0 || s.length > 64) return false
-  // Loose validation: at least one '+' separator implies a modifier+key combo,
-  // which is what Electron's globalShortcut expects. Single function keys
-  // (F1..F24) are also acceptable.
-  if (/^F\d{1,2}$/i.test(s.trim())) return true
-  return /\+/.test(s)
+  const trimmed = s.trim()
+  if (trimmed.length === 0 || trimmed.length > 64) return false
+  // Lone function key (F1..F24) — no modifier required.
+  if (/^F([1-9]|1\d|2[0-4])$/i.test(trimmed)) return true
+  const parts = trimmed.split('+').map((p) => p.trim())
+  // Reject trailing/leading '+', empty segments, and modifier-only combos
+  // like "Command+" or "Shift+". The final token must be a real key, not a
+  // modifier name.
+  if (parts.some((p) => p.length === 0)) return false
+  const last = parts[parts.length - 1]
+  if (MODIFIER_TOKENS.has(last.toLowerCase())) return false
+  return parts.length >= 1 && last.length > 0
 }

--- a/desktop/src/main/shortcuts.ts
+++ b/desktop/src/main/shortcuts.ts
@@ -1,0 +1,160 @@
+import { globalShortcut, ipcMain } from 'electron'
+import { getDb } from './db'
+
+// Global keyboard shortcuts that fire even when the app isn't focused, so the
+// user can mute or toggle annotation while working in another app during a
+// screen-share. Defaults are seeded on first launch; the Settings UI lets the
+// user rebind or clear each one.
+
+export type ShortcutAction = 'mute' | 'annotate' | 'screenShare'
+
+export const SHORTCUT_ACTIONS: ShortcutAction[] = ['mute', 'annotate', 'screenShare']
+
+const SETTING_PREFIX = 'shortcut_accelerator_'
+
+const DEFAULTS: Record<ShortcutAction, string> = {
+  mute: 'Control+M',
+  annotate: 'Control+A',
+  screenShare: 'Control+S',
+}
+
+let onTriggered: ((action: ShortcutAction) => void) | null = null
+let registered: Partial<Record<ShortcutAction, string>> = {}
+
+export function registerShortcutHandlers(
+  onTriggeredCallback: (action: ShortcutAction) => void,
+): void {
+  onTriggered = onTriggeredCallback
+  seedDefaults()
+  applyAll()
+
+  ipcMain.handle('shortcuts:list', () => listShortcuts())
+
+  ipcMain.handle('shortcuts:set', (_e, action: ShortcutAction, accelerator: string) => {
+    if (!SHORTCUT_ACTIONS.includes(action)) return { ok: false, error: 'unknown action' }
+    if (!isPlausibleAccelerator(accelerator)) {
+      return { ok: false, error: 'invalid accelerator' }
+    }
+    saveAccelerator(action, accelerator)
+    const result = applyOne(action, accelerator)
+    return result.ok ? { ok: true, accelerator } : result
+  })
+
+  ipcMain.handle('shortcuts:clear', (_e, action: ShortcutAction) => {
+    if (!SHORTCUT_ACTIONS.includes(action)) return { ok: false, error: 'unknown action' }
+    saveAccelerator(action, '')
+    unregisterOne(action)
+    return { ok: true }
+  })
+
+  ipcMain.handle('shortcuts:resetDefaults', () => {
+    for (const action of SHORTCUT_ACTIONS) {
+      saveAccelerator(action, DEFAULTS[action])
+    }
+    applyAll()
+    return listShortcuts()
+  })
+}
+
+export function unregisterAllShortcuts(): void {
+  globalShortcut.unregisterAll()
+  registered = {}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function seedDefaults(): void {
+  for (const action of SHORTCUT_ACTIONS) {
+    if (loadAccelerator(action) === null) {
+      saveAccelerator(action, DEFAULTS[action])
+    }
+  }
+}
+
+function applyAll(): void {
+  unregisterAllShortcuts()
+  for (const action of SHORTCUT_ACTIONS) {
+    const accel = loadAccelerator(action) ?? ''
+    if (accel) applyOne(action, accel)
+  }
+}
+
+function applyOne(
+  action: ShortcutAction,
+  accelerator: string,
+): { ok: true } | { ok: false; error: string } {
+  // Free whatever was previously bound for this action so a rebind doesn't
+  // leave a stale registration behind.
+  unregisterOne(action)
+  // If another action holds this accelerator, releasing it on a new bind keeps
+  // the global registry consistent.
+  for (const [otherAction, otherAccel] of Object.entries(registered)) {
+    if (otherAccel === accelerator) {
+      globalShortcut.unregister(otherAccel)
+      delete registered[otherAction as ShortcutAction]
+    }
+  }
+  try {
+    const ok = globalShortcut.register(accelerator, () => onTriggered?.(action))
+    if (!ok) return { ok: false, error: 'registration failed (system or another app may own this combo)' }
+    registered[action] = accelerator
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+function unregisterOne(action: ShortcutAction): void {
+  const existing = registered[action]
+  if (existing) {
+    globalShortcut.unregister(existing)
+    delete registered[action]
+  }
+}
+
+function loadAccelerator(action: ShortcutAction): string | null {
+  try {
+    const db = getDb()
+    const row = db
+      .prepare('SELECT value FROM settings WHERE key = ?')
+      .get(SETTING_PREFIX + action) as { value: string } | undefined
+    return row?.value ?? null
+  } catch {
+    return null
+  }
+}
+
+function saveAccelerator(action: ShortcutAction, accelerator: string): void {
+  try {
+    const db = getDb()
+    db.prepare(
+      'INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?',
+    ).run(SETTING_PREFIX + action, accelerator, accelerator)
+  } catch {
+    // Settings persistence is best-effort — runtime registration still works.
+  }
+}
+
+function listShortcuts(): Array<{
+  action: ShortcutAction
+  accelerator: string
+  defaultAccelerator: string
+}> {
+  return SHORTCUT_ACTIONS.map((action) => ({
+    action,
+    accelerator: loadAccelerator(action) ?? '',
+    defaultAccelerator: DEFAULTS[action],
+  }))
+}
+
+function isPlausibleAccelerator(s: string): boolean {
+  if (typeof s !== 'string') return false
+  if (s.length === 0 || s.length > 64) return false
+  // Loose validation: at least one '+' separator implies a modifier+key combo,
+  // which is what Electron's globalShortcut expects. Single function keys
+  // (F1..F24) are also acceptable.
+  if (/^F\d{1,2}$/i.test(s.trim())) return true
+  return /\+/.test(s)
+}

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -405,26 +405,39 @@ const electronAPI = {
   shortcuts: {
     list: () =>
       ipcRenderer.invoke('shortcuts:list') as Promise<
-        Array<{ action: 'mute' | 'annotate' | 'screenShare'; accelerator: string; defaultAccelerator: string }>
+        Array<{
+          action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare'
+          accelerator: string
+          defaultAccelerator: string
+        }>
       >,
-    set: (action: 'mute' | 'annotate' | 'screenShare', accelerator: string) =>
+    set: (
+      action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare',
+      accelerator: string,
+    ) =>
       ipcRenderer.invoke('shortcuts:set', action, accelerator) as Promise<
         { ok: true; accelerator: string } | { ok: false; error: string }
       >,
-    clear: (action: 'mute' | 'annotate' | 'screenShare') =>
+    clear: (action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare') =>
       ipcRenderer.invoke('shortcuts:clear', action) as Promise<
         { ok: true } | { ok: false; error: string }
       >,
     resetDefaults: () =>
       ipcRenderer.invoke('shortcuts:resetDefaults') as Promise<
-        Array<{ action: 'mute' | 'annotate' | 'screenShare'; accelerator: string; defaultAccelerator: string }>
+        Array<{
+          action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare'
+          accelerator: string
+          defaultAccelerator: string
+        }>
       >,
     onTriggered: (
-      handler: (action: 'mute' | 'annotate' | 'screenShare') => void,
+      handler: (
+        action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare',
+      ) => void,
     ) => {
       const wrapped = (
         _e: IpcRendererEvent,
-        action: 'mute' | 'annotate' | 'screenShare',
+        action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare',
       ) => handler(action)
       ipcRenderer.on('shortcuts:triggered', wrapped)
       return () => ipcRenderer.removeListener('shortcuts:triggered', wrapped)

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -250,6 +250,88 @@ const electronAPI = {
           appIconDataURL: string | null
         }>
       >,
+    getWindowBounds: (windowId: number) =>
+      ipcRenderer.invoke('screen:getWindowBounds', windowId) as Promise<{
+        x: number
+        y: number
+        width: number
+        height: number
+      } | null>,
+  },
+  drawOverlay: {
+    show: (displayId?: number) =>
+      ipcRenderer.invoke('draw-overlay:show', displayId) as Promise<void>,
+    hide: () => ipcRenderer.invoke('draw-overlay:hide') as Promise<void>,
+    setMode: (mode: 'idle' | 'draw') =>
+      ipcRenderer.invoke('draw-overlay:setMode', mode) as Promise<void>,
+    clear: () => ipcRenderer.invoke('draw-overlay:clear') as Promise<void>,
+    onStrokes: (
+      handler: (payload: {
+        strokes: Array<{
+          id: string
+          color: string
+          width: number
+          points: Array<{ x: number; y: number }>
+        }>
+        bounds: { x: number; y: number; width: number; height: number; scaleFactor: number }
+      }) => void,
+    ) => {
+      const wrapped = (_e: IpcRendererEvent, p: Parameters<typeof handler>[0]) => handler(p)
+      ipcRenderer.on('draw-overlay:strokes', wrapped)
+      return () => ipcRenderer.removeListener('draw-overlay:strokes', wrapped)
+    },
+    onDisplayBounds: (
+      handler: (bounds: {
+        x: number
+        y: number
+        width: number
+        height: number
+        scaleFactor: number
+      }) => void,
+    ) => {
+      const wrapped = (_e: IpcRendererEvent, b: Parameters<typeof handler>[0]) => handler(b)
+      ipcRenderer.on('draw-overlay:display-bounds', wrapped)
+      return () => ipcRenderer.removeListener('draw-overlay:display-bounds', wrapped)
+    },
+    onModeChanged: (handler: (mode: 'idle' | 'draw') => void) => {
+      const wrapped = (_e: IpcRendererEvent, mode: 'idle' | 'draw') => handler(mode)
+      ipcRenderer.on('draw-overlay:mode', wrapped)
+      return () => ipcRenderer.removeListener('draw-overlay:mode', wrapped)
+    },
+
+    // Overlay-renderer side ------------------------------------------------
+    ready: () => ipcRenderer.invoke('draw-overlay:ready') as Promise<void>,
+    sendStrokes: (
+      strokes: Array<{
+        id: string
+        color: string
+        width: number
+        points: Array<{ x: number; y: number }>
+      }>,
+    ) => ipcRenderer.send('draw-overlay:strokes', { strokes }),
+    onMode: (handler: (mode: 'idle' | 'draw') => void) => {
+      const wrapped = (_e: IpcRendererEvent, mode: 'idle' | 'draw') => handler(mode)
+      ipcRenderer.on('draw-overlay:mode', wrapped)
+      return () => ipcRenderer.removeListener('draw-overlay:mode', wrapped)
+    },
+    onClear: (handler: () => void) => {
+      const wrapped = () => handler()
+      ipcRenderer.on('draw-overlay:clear', wrapped)
+      return () => ipcRenderer.removeListener('draw-overlay:clear', wrapped)
+    },
+    onBounds: (
+      handler: (bounds: {
+        x: number
+        y: number
+        width: number
+        height: number
+        scaleFactor: number
+      }) => void,
+    ) => {
+      const wrapped = (_e: IpcRendererEvent, b: Parameters<typeof handler>[0]) => handler(b)
+      ipcRenderer.on('draw-overlay:bounds', wrapped)
+      return () => ipcRenderer.removeListener('draw-overlay:bounds', wrapped)
+    },
   },
   logs: {
     reveal: () => ipcRenderer.invoke('logs:reveal') as Promise<{ ok: boolean, path: string }>,

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -402,6 +402,34 @@ const electronAPI = {
   shell: {
     openExternal: (url: string) => ipcRenderer.invoke('shell:openExternal', url) as Promise<void>,
   },
+  shortcuts: {
+    list: () =>
+      ipcRenderer.invoke('shortcuts:list') as Promise<
+        Array<{ action: 'mute' | 'annotate' | 'screenShare'; accelerator: string; defaultAccelerator: string }>
+      >,
+    set: (action: 'mute' | 'annotate' | 'screenShare', accelerator: string) =>
+      ipcRenderer.invoke('shortcuts:set', action, accelerator) as Promise<
+        { ok: true; accelerator: string } | { ok: false; error: string }
+      >,
+    clear: (action: 'mute' | 'annotate' | 'screenShare') =>
+      ipcRenderer.invoke('shortcuts:clear', action) as Promise<
+        { ok: true } | { ok: false; error: string }
+      >,
+    resetDefaults: () =>
+      ipcRenderer.invoke('shortcuts:resetDefaults') as Promise<
+        Array<{ action: 'mute' | 'annotate' | 'screenShare'; accelerator: string; defaultAccelerator: string }>
+      >,
+    onTriggered: (
+      handler: (action: 'mute' | 'annotate' | 'screenShare') => void,
+    ) => {
+      const wrapped = (
+        _e: IpcRendererEvent,
+        action: 'mute' | 'annotate' | 'screenShare',
+      ) => handler(action)
+      ipcRenderer.on('shortcuts:triggered', wrapped)
+      return () => ipcRenderer.removeListener('shortcuts:triggered', wrapped)
+    },
+  },
 }
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI)

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -406,38 +406,38 @@ const electronAPI = {
     list: () =>
       ipcRenderer.invoke('shortcuts:list') as Promise<
         Array<{
-          action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare'
+          action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare' | 'toggleCall'
           accelerator: string
           defaultAccelerator: string
         }>
       >,
     set: (
-      action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare',
+      action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare' | 'toggleCall',
       accelerator: string,
     ) =>
       ipcRenderer.invoke('shortcuts:set', action, accelerator) as Promise<
         { ok: true; accelerator: string } | { ok: false; error: string }
       >,
-    clear: (action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare') =>
+    clear: (action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare' | 'toggleCall') =>
       ipcRenderer.invoke('shortcuts:clear', action) as Promise<
         { ok: true } | { ok: false; error: string }
       >,
     resetDefaults: () =>
       ipcRenderer.invoke('shortcuts:resetDefaults') as Promise<
         Array<{
-          action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare'
+          action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare' | 'toggleCall'
           accelerator: string
           defaultAccelerator: string
         }>
       >,
     onTriggered: (
       handler: (
-        action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare',
+        action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare' | 'toggleCall',
       ) => void,
     ) => {
       const wrapped = (
         _e: IpcRendererEvent,
-        action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare',
+        action: 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare' | 'toggleCall',
       ) => handler(action)
       ipcRenderer.on('shortcuts:triggered', wrapped)
       return () => ipcRenderer.removeListener('shortcuts:triggered', wrapped)

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -90,6 +90,10 @@ const electronAPI = {
     sendAudioLevels: (input: number, output: number) =>
       ipcRenderer.send('call-bar:audio-levels', { input, output }),
 
+    // Main-renderer side: notify call-bar of mute state changes so the
+    // bar can render a visible indicator and zero its input meter.
+    sendMuted: (muted: boolean) => ipcRenderer.send('call-bar:muted', muted),
+
     // Main-renderer side: listen for UX requests forwarded from the
     // call-bar context menu so the main UI can actually mute / hang up.
     onMuteToggleRequest: (handler: () => void) => {
@@ -119,6 +123,11 @@ const electronAPI = {
       ) => handler(payload)
       ipcRenderer.on('call-bar:audio-levels', wrapped)
       return () => ipcRenderer.removeListener('call-bar:audio-levels', wrapped)
+    },
+    onMuted: (handler: (muted: boolean) => void) => {
+      const wrapped = (_e: IpcRendererEvent, muted: boolean) => handler(muted)
+      ipcRenderer.on('call-bar:muted', wrapped)
+      return () => ipcRenderer.removeListener('call-bar:muted', wrapped)
     },
   },
   db: {

--- a/desktop/src/renderer/src/call-bar/CallBar.tsx
+++ b/desktop/src/renderer/src/call-bar/CallBar.tsx
@@ -218,8 +218,8 @@ function MicOffGlyph() {
   // and the glyph color can inherit from CSS.
   return (
     <svg
-      width="12"
-      height="12"
+      width="14"
+      height="14"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"

--- a/desktop/src/renderer/src/call-bar/CallBar.tsx
+++ b/desktop/src/renderer/src/call-bar/CallBar.tsx
@@ -16,6 +16,7 @@ declare global {
         onAudioLevels?: (
           handler: (payload: { input: number; output: number }) => void,
         ) => () => void
+        onMuted?: (handler: (muted: boolean) => void) => () => void
       }
     }
   }
@@ -31,12 +32,17 @@ export function CallBar() {
   const [visible, setVisible] = useState(previewMode)
   const [speaker, setSpeaker] = useState<Speaker>(previewMode ? 'user' : 'idle')
   const [levels, setLevels] = useState<number[]>([0, 0, 0])
+  const [muted, setMuted] = useState(false)
 
   // Ref mirror for the IPC handler — React 19 setters can't be read
   // synchronously, and we need the previous levels to feed a small IIR
   // decay so bars fall gracefully instead of snapping to zero.
   const levelsRef = useRef(levels)
   levelsRef.current = levels
+  // Same reason: the audio-levels IPC handler runs ~30 Hz and needs to
+  // read the current muted state without waiting for a re-render.
+  const mutedRef = useRef(muted)
+  mutedRef.current = muted
 
   // Mark the document so the scoped call-bar styles (transparent bg,
   // token overrides, no-overflow) apply without clobbering the main
@@ -74,8 +80,16 @@ export function CallBar() {
     })
 
     const unsubLevels = api.onAudioLevels?.((payload) => {
-      setSpeaker(resolveSpeaker(payload.input, payload.output))
-      setLevels(spreadLevel(levelsRef.current, payload.input, payload.output))
+      // While muted, the mic might still register RMS energy on the renderer
+      // side, but Gemini isn't hearing it — collapse input to 0 so the bar
+      // doesn't imply the user is being heard when they're not.
+      const input = mutedRef.current ? 0 : payload.input
+      setSpeaker(resolveSpeaker(input, payload.output))
+      setLevels(spreadLevel(levelsRef.current, input, payload.output))
+    })
+
+    const unsubMuted = api.onMuted?.((m) => {
+      setMuted(m)
     })
 
     // Tell main we're ready — it may have queued a visibility event
@@ -85,6 +99,7 @@ export function CallBar() {
     return () => {
       unsubVisibility?.()
       unsubLevels?.()
+      unsubMuted?.()
     }
   }, [])
 
@@ -103,6 +118,7 @@ export function CallBar() {
     speaker === 'user' ? 'is-user-speaking' : '',
     speaker === 'ai' ? 'is-ai-speaking' : '',
     speaker === 'idle' ? 'is-idle' : '',
+    muted ? 'is-muted' : '',
   ]
     .filter(Boolean)
     .join(' ')
@@ -119,6 +135,12 @@ export function CallBar() {
       />
 
       <VoiceClawMark className="call-bar__mark" />
+
+      {muted && (
+        <div className="call-bar__mute-badge" aria-label="Microphone muted">
+          <MicOffGlyph />
+        </div>
+      )}
 
       <div className="call-bar__waveform">
         {levels.map((lvl, i) => (
@@ -189,4 +211,29 @@ function clampHeight(level: number): number {
 function isPreview(): boolean {
   if (typeof window === 'undefined') return false
   return new URLSearchParams(window.location.search).get('preview') === '1'
+}
+
+function MicOffGlyph() {
+  // Inline SVG so the call-bar bundle stays free of any icon-pack import
+  // and the glyph color can inherit from CSS.
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <line x1="2" y1="2" x2="22" y2="22" />
+      <path d="M9 9v3a3 3 0 0 0 5.12 2.12" />
+      <path d="M15 9.34V4a3 3 0 0 0-5.94-.6" />
+      <path d="M5 10v2a7 7 0 0 0 12 4.95" />
+      <path d="M19 10v2a7 7 0 0 1-.11 1.23" />
+      <line x1="12" y1="19" x2="12" y2="23" />
+    </svg>
+  )
 }

--- a/desktop/src/renderer/src/call-bar/call-bar.css
+++ b/desktop/src/renderer/src/call-bar/call-bar.css
@@ -129,18 +129,19 @@ body.call-bar-preview .call-bar {
   cursor: pointer;
 }
 
-.call-bar.is-muted .call-bar__mark {
-  color: var(--brand-ink-muted);
-}
-
 /* Mute badge --------------------------------------------------------- */
 
+/* Sits centered over the waveform region — that's the "energy" the user
+   is most likely to glance at, and replacing it with a static muted mic
+   makes the off-air state unambiguous. The brand mark above it stays at
+   normal color so the bar still reads as "on a call". */
 .call-bar__mute-badge {
   position: absolute;
-  top: 4px;
-  right: 4px;
-  width: 14px;
-  height: 14px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 18px;
+  height: 18px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -148,6 +149,14 @@ body.call-bar-preview .call-bar {
   background: var(--brand-accent);
   color: var(--brand-paper);
   pointer-events: none;
+  z-index: 2;
+}
+
+/* Hide the waveform completely while muted so the badge doesn't sit on
+   top of bouncing bars (output activity still reads through the mark
+   color shift if needed). */
+.call-bar.is-muted .call-bar__waveform {
+  visibility: hidden;
 }
 
 /* Waveform pips ------------------------------------------------------- */

--- a/desktop/src/renderer/src/call-bar/call-bar.css
+++ b/desktop/src/renderer/src/call-bar/call-bar.css
@@ -129,6 +129,27 @@ body.call-bar-preview .call-bar {
   cursor: pointer;
 }
 
+.call-bar.is-muted .call-bar__mark {
+  color: var(--brand-ink-muted);
+}
+
+/* Mute badge --------------------------------------------------------- */
+
+.call-bar__mute-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 14px;
+  height: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--brand-accent);
+  color: var(--brand-paper);
+  pointer-events: none;
+}
+
 /* Waveform pips ------------------------------------------------------- */
 
 .call-bar__waveform {

--- a/desktop/src/renderer/src/components/ShortcutsCard.tsx
+++ b/desktop/src/renderer/src/components/ShortcutsCard.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Card } from './ui/Card'
 import { Button } from './ui/Button'
 
-type ShortcutAction = 'mute' | 'annotate' | 'screenShare'
+type ShortcutAction = 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare'
 
 type ShortcutEntry = {
   action: ShortcutAction
@@ -13,12 +13,14 @@ type ShortcutEntry = {
 const ACTION_LABEL: Record<ShortcutAction, string> = {
   mute: 'Toggle mute',
   annotate: 'Toggle annotate (drawing)',
+  clearAnnotations: 'Clear annotations',
   screenShare: 'Toggle screen share',
 }
 
 const ACTION_DESCRIPTION: Record<ShortcutAction, string> = {
   mute: 'Mute or unmute the microphone during an active call.',
   annotate: 'Enter or leave drawing mode while screen-sharing.',
+  clearAnnotations: 'Erase every stroke currently drawn on the overlay.',
   screenShare: 'Start or stop screen-sharing during an active call.',
 }
 

--- a/desktop/src/renderer/src/components/ShortcutsCard.tsx
+++ b/desktop/src/renderer/src/components/ShortcutsCard.tsx
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Card } from './ui/Card'
 import { Button } from './ui/Button'
 
-type ShortcutAction = 'mute' | 'annotate' | 'clearAnnotations' | 'screenShare'
+type ShortcutAction =
+  | 'toggleCall'
+  | 'mute'
+  | 'annotate'
+  | 'clearAnnotations'
+  | 'screenShare'
 
 type ShortcutEntry = {
   action: ShortcutAction
@@ -11,6 +16,7 @@ type ShortcutEntry = {
 }
 
 const ACTION_LABEL: Record<ShortcutAction, string> = {
+  toggleCall: 'Start or end a call',
   mute: 'Toggle mute',
   annotate: 'Toggle annotate (drawing)',
   clearAnnotations: 'Clear annotations',
@@ -18,6 +24,7 @@ const ACTION_LABEL: Record<ShortcutAction, string> = {
 }
 
 const ACTION_DESCRIPTION: Record<ShortcutAction, string> = {
+  toggleCall: 'Start a new realtime call when idle, or end the active call.',
   mute: 'Mute or unmute the microphone during an active call.',
   annotate: 'Enter or leave drawing mode while screen-sharing.',
   clearAnnotations: 'Erase every stroke currently drawn on the overlay.',

--- a/desktop/src/renderer/src/components/ShortcutsCard.tsx
+++ b/desktop/src/renderer/src/components/ShortcutsCard.tsx
@@ -1,0 +1,212 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Card } from './ui/Card'
+import { Button } from './ui/Button'
+
+type ShortcutAction = 'mute' | 'annotate' | 'screenShare'
+
+type ShortcutEntry = {
+  action: ShortcutAction
+  accelerator: string
+  defaultAccelerator: string
+}
+
+const ACTION_LABEL: Record<ShortcutAction, string> = {
+  mute: 'Toggle mute',
+  annotate: 'Toggle annotate (drawing)',
+  screenShare: 'Toggle screen share',
+}
+
+const ACTION_DESCRIPTION: Record<ShortcutAction, string> = {
+  mute: 'Mute or unmute the microphone during an active call.',
+  annotate: 'Enter or leave drawing mode while screen-sharing.',
+  screenShare: 'Start or stop screen-sharing during an active call.',
+}
+
+export function ShortcutsCard() {
+  const [entries, setEntries] = useState<ShortcutEntry[]>([])
+  const [recordingFor, setRecordingFor] = useState<ShortcutAction | null>(null)
+  const [statusMessage, setStatusMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    void refresh()
+  }, [])
+
+  const refresh = useCallback(async () => {
+    const list = await window.electronAPI.shortcuts.list()
+    setEntries(list)
+  }, [])
+
+  async function setAccelerator(action: ShortcutAction, accelerator: string) {
+    setStatusMessage(null)
+    const result = await window.electronAPI.shortcuts.set(action, accelerator)
+    if (!result.ok) {
+      setStatusMessage(`Couldn't bind ${formatAccelerator(accelerator)} — ${result.error}`)
+    }
+    await refresh()
+  }
+
+  async function clearAccelerator(action: ShortcutAction) {
+    setStatusMessage(null)
+    await window.electronAPI.shortcuts.clear(action)
+    await refresh()
+  }
+
+  async function resetDefaults() {
+    setStatusMessage(null)
+    const list = await window.electronAPI.shortcuts.resetDefaults()
+    setEntries(list)
+  }
+
+  function startRecording(action: ShortcutAction) {
+    setStatusMessage(null)
+    setRecordingFor(action)
+  }
+
+  function cancelRecording() {
+    setRecordingFor(null)
+  }
+
+  function onRecorded(accelerator: string) {
+    if (!recordingFor) return
+    const action = recordingFor
+    setRecordingFor(null)
+    void setAccelerator(action, accelerator)
+  }
+
+  return (
+    <Card className="p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-foreground">Keyboard Shortcuts</h3>
+        <Button variant="ghost" size="sm" onClick={resetDefaults}>
+          Reset defaults
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Global shortcuts work even when VoiceClaw is in the background. Click a binding to
+        record a new combination, or clear it to unbind.
+      </p>
+
+      <div className="space-y-2">
+        {entries.map((entry) => (
+          <div
+            key={entry.action}
+            className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2"
+          >
+            <div className="min-w-0">
+              <p className="text-sm text-foreground">{ACTION_LABEL[entry.action]}</p>
+              <p className="text-xs text-muted-foreground">{ACTION_DESCRIPTION[entry.action]}</p>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              {recordingFor === entry.action ? (
+                <RecordingChip onRecorded={onRecorded} onCancel={cancelRecording} />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => startRecording(entry.action)}
+                  className="font-mono text-xs px-2 py-1 rounded border border-border hover:bg-accent transition-colors min-w-[7rem] text-center"
+                  title="Click to record a new combination"
+                >
+                  {entry.accelerator
+                    ? formatAccelerator(entry.accelerator)
+                    : <span className="text-muted-foreground">unbound</span>}
+                </button>
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => clearAccelerator(entry.action)}
+                disabled={!entry.accelerator}
+              >
+                Clear
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {statusMessage && (
+        <p className="text-xs text-destructive">{statusMessage}</p>
+      )}
+    </Card>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function RecordingChip(props: {
+  onRecorded: (accelerator: string) => void
+  onCancel: () => void
+}) {
+  const ref = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    ref.current?.focus()
+  }, [])
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    e.preventDefault()
+    e.stopPropagation()
+    if (e.key === 'Escape') {
+      props.onCancel()
+      return
+    }
+    const accelerator = buildAccelerator(e)
+    if (!accelerator) return
+    props.onRecorded(accelerator)
+  }
+
+  return (
+    <div
+      ref={ref}
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+      onBlur={props.onCancel}
+      className="font-mono text-xs px-2 py-1 rounded border border-[var(--brand-rust)] bg-[var(--brand-rust)]/10 min-w-[7rem] text-center cursor-text outline-none"
+    >
+      Press combo…
+    </div>
+  )
+}
+
+function buildAccelerator(e: React.KeyboardEvent): string | null {
+  const parts: string[] = []
+  if (e.ctrlKey) parts.push('Control')
+  if (e.metaKey) parts.push('Command')
+  if (e.altKey) parts.push('Alt')
+  if (e.shiftKey) parts.push('Shift')
+  const key = normalizeKey(e.key)
+  if (!key) return null
+  // Ignore pure modifier presses — wait for a real key.
+  if (key === 'Control' || key === 'Command' || key === 'Alt' || key === 'Shift' || key === 'Meta') {
+    return null
+  }
+  parts.push(key)
+  return parts.join('+')
+}
+
+function normalizeKey(raw: string): string {
+  if (raw.length === 1) return raw.toUpperCase()
+  if (raw === ' ') return 'Space'
+  if (/^F\d{1,2}$/i.test(raw)) return raw.toUpperCase()
+  if (raw === 'ArrowUp') return 'Up'
+  if (raw === 'ArrowDown') return 'Down'
+  if (raw === 'ArrowLeft') return 'Left'
+  if (raw === 'ArrowRight') return 'Right'
+  if (raw === 'Meta') return 'Command'
+  return raw
+}
+
+function formatAccelerator(s: string): string {
+  return s
+    .split('+')
+    .map((part) => {
+      if (part === 'Control') return 'Ctrl'
+      if (part === 'Command') return '⌘'
+      if (part === 'Alt') return '⌥'
+      if (part === 'Shift') return '⇧'
+      return part
+    })
+    .join(' ')
+}

--- a/desktop/src/renderer/src/draw-overlay/DrawCanvas.tsx
+++ b/desktop/src/renderer/src/draw-overlay/DrawCanvas.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useRef, useState } from 'react'
+
+const STROKE_COLOR = '#FF6B3D'
+const STROKE_WIDTH_CSS = 4
+
+export function DrawCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const strokesRef = useRef<Stroke[]>([])
+  const activeStrokeRef = useRef<Stroke | null>(null)
+  const [mode, setMode] = useState<'idle' | 'draw'>('idle')
+
+  useEffect(() => {
+    void window.electronAPI.drawOverlay.ready()
+
+    const offMode = window.electronAPI.drawOverlay.onMode((next) => {
+      setMode(next)
+    })
+
+    const offClear = window.electronAPI.drawOverlay.onClear(() => {
+      strokesRef.current = []
+      activeStrokeRef.current = null
+      paint()
+      window.electronAPI.drawOverlay.sendStrokes([])
+    })
+
+    const offBounds = window.electronAPI.drawOverlay.onBounds(() => {
+      sizeCanvasToWindow()
+      paint()
+    })
+
+    const onResize = () => {
+      sizeCanvasToWindow()
+      paint()
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        void window.electronAPI.drawOverlay.setMode('idle')
+      }
+    }
+    window.addEventListener('resize', onResize)
+    window.addEventListener('keydown', onKeyDown)
+    sizeCanvasToWindow()
+
+    return () => {
+      offMode()
+      offClear()
+      offBounds()
+      window.removeEventListener('resize', onResize)
+      window.removeEventListener('keydown', onKeyDown)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  function sizeCanvasToWindow() {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const dpr = window.devicePixelRatio || 1
+    canvas.width = Math.round(window.innerWidth * dpr)
+    canvas.height = Math.round(window.innerHeight * dpr)
+    canvas.style.width = `${window.innerWidth}px`
+    canvas.style.height = `${window.innerHeight}px`
+    const ctx = canvas.getContext('2d')
+    if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  }
+
+  function paint() {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    ctx.lineCap = 'round'
+    ctx.lineJoin = 'round'
+    const all = activeStrokeRef.current
+      ? [...strokesRef.current, activeStrokeRef.current]
+      : strokesRef.current
+    for (const stroke of all) {
+      drawStroke(ctx, stroke)
+    }
+  }
+
+  function onPointerDown(e: React.PointerEvent<HTMLCanvasElement>) {
+    if (mode !== 'draw') return
+    const canvas = canvasRef.current
+    if (!canvas) return
+    canvas.setPointerCapture(e.pointerId)
+    const stroke: Stroke = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      color: STROKE_COLOR,
+      width: STROKE_WIDTH_CSS,
+      points: [{ x: e.clientX, y: e.clientY }],
+    }
+    activeStrokeRef.current = stroke
+    paint()
+  }
+
+  function onPointerMove(e: React.PointerEvent<HTMLCanvasElement>) {
+    if (mode !== 'draw') return
+    const stroke = activeStrokeRef.current
+    if (!stroke) return
+    stroke.points.push({ x: e.clientX, y: e.clientY })
+    paint()
+  }
+
+  function onPointerUp() {
+    if (mode !== 'draw') return
+    const stroke = activeStrokeRef.current
+    if (!stroke) return
+    activeStrokeRef.current = null
+    if (stroke.points.length >= 2) {
+      strokesRef.current.push(stroke)
+      window.electronAPI.drawOverlay.sendStrokes(strokesRef.current)
+    }
+    paint()
+  }
+
+  function onClearClick() {
+    strokesRef.current = []
+    activeStrokeRef.current = null
+    paint()
+    void window.electronAPI.drawOverlay.clear()
+    window.electronAPI.drawOverlay.sendStrokes([])
+  }
+
+  function onDoneClick() {
+    void window.electronAPI.drawOverlay.setMode('idle')
+  }
+
+  return (
+    <>
+      <canvas
+        ref={canvasRef}
+        className={`draw-overlay__canvas ${mode === 'draw' ? 'draw-overlay__canvas--drawing' : ''}`}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+      />
+      {mode === 'draw' && (
+        <div className="draw-overlay__toolbar">
+          <button type="button" className="draw-overlay__button" onClick={onClearClick}>
+            Clear
+          </button>
+          <button
+            type="button"
+            className="draw-overlay__button draw-overlay__button--primary"
+            onClick={onDoneClick}
+          >
+            Done (Esc)
+          </button>
+        </div>
+      )}
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Stroke = {
+  id: string
+  color: string
+  width: number
+  points: { x: number; y: number }[]
+}
+
+function drawStroke(ctx: CanvasRenderingContext2D, stroke: Stroke) {
+  if (stroke.points.length < 1) return
+  ctx.strokeStyle = stroke.color
+  ctx.lineWidth = stroke.width
+  ctx.beginPath()
+  const [first, ...rest] = stroke.points
+  ctx.moveTo(first.x, first.y)
+  for (const p of rest) {
+    ctx.lineTo(p.x, p.y)
+  }
+  ctx.stroke()
+}

--- a/desktop/src/renderer/src/draw-overlay/DrawCanvas.tsx
+++ b/desktop/src/renderer/src/draw-overlay/DrawCanvas.tsx
@@ -126,6 +126,12 @@ export function DrawCanvas() {
     void window.electronAPI.drawOverlay.setMode('idle')
   }
 
+  function onContextMenu(e: React.MouseEvent<HTMLCanvasElement>) {
+    if (mode !== 'draw') return
+    e.preventDefault()
+    void window.electronAPI.drawOverlay.setMode('idle')
+  }
+
   return (
     <>
       <canvas
@@ -135,6 +141,7 @@ export function DrawCanvas() {
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
         onPointerCancel={onPointerUp}
+        onContextMenu={onContextMenu}
       />
       {mode === 'draw' && (
         <div className="draw-overlay__toolbar">
@@ -146,7 +153,7 @@ export function DrawCanvas() {
             className="draw-overlay__button draw-overlay__button--primary"
             onClick={onDoneClick}
           >
-            Done (Esc)
+            Done (Esc / right-click)
           </button>
         </div>
       )}

--- a/desktop/src/renderer/src/draw-overlay/draw-overlay.css
+++ b/desktop/src/renderer/src/draw-overlay/draw-overlay.css
@@ -1,0 +1,71 @@
+html,
+body,
+#root {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  overflow: hidden;
+  cursor: default;
+}
+
+.draw-overlay__canvas {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  display: block;
+  background: transparent;
+  pointer-events: auto;
+}
+
+.draw-overlay__canvas--drawing {
+  cursor: crosshair;
+}
+
+.draw-overlay__toolbar {
+  position: fixed;
+  top: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  background: rgba(20, 16, 12, 0.85);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.32);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  font-size: 13px;
+  pointer-events: auto;
+  z-index: 10;
+}
+
+.draw-overlay__button {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.85);
+  padding: 6px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  font: inherit;
+  transition: background-color 120ms ease;
+}
+
+.draw-overlay__button:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+}
+
+.draw-overlay__button--primary {
+  background: #FF6B3D;
+  color: #fff;
+}
+
+.draw-overlay__button--primary:hover {
+  background: #ff5a26;
+  color: #fff;
+}

--- a/desktop/src/renderer/src/lib/screen-capture.ts
+++ b/desktop/src/renderer/src/lib/screen-capture.ts
@@ -8,6 +8,50 @@ export type ScreenSource = {
   appIconDataURL: string | null
 }
 
+export type StrokePoint = { x: number; y: number }
+
+export type Stroke = {
+  id: string
+  color: string
+  width: number
+  points: StrokePoint[]
+}
+
+export type DisplayBounds = {
+  x: number
+  y: number
+  width: number
+  height: number
+  scaleFactor: number
+}
+
+export type WindowBounds = {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export type SourceContext =
+  | { kind: 'display'; displayBounds: DisplayBounds }
+  | {
+      kind: 'window'
+      displayBounds: DisplayBounds
+      windowBounds: WindowBounds | null
+    }
+
+export type AnnotationProvider = {
+  getStrokes: () => Stroke[]
+  getSourceContext: () => SourceContext | null
+}
+
+export type FrameWithAnnotations = {
+  composite: string
+  original: string
+  strokesPng: string | null
+  hasStrokes: boolean
+}
+
 declare global {
   interface Window {
     electronAPI: Window['electronAPI'] & {
@@ -18,20 +62,13 @@ declare global {
   }
 }
 
-// 1536 keeps small terminal text legible on Retina captures while staying within
-// Gemini's HIGH-resolution video tokenizer envelope. 768 was too aggressive —
-// 11pt monospace fonts blurred to the point Gemini misread "warp" as "warn",
-// command output as garbled glyphs, etc.
+// 1536 keeps small terminal text legible on Retina captures while staying
+// within Gemini's HIGH-resolution video tokenizer envelope. 768 was too
+// aggressive — 11pt monospace fonts blurred to the point Gemini misread
+// "warp" as "warn", command output as garbled glyphs, etc.
 const MAX_DIMENSION = 1536
 const CAPTURE_INTERVAL_MS = 1000 // 1 FPS
-// 0.85 preserves anti-aliased text edges through chroma subsampling. 0.7 was
-// dropping enough high-frequency luma detail that ligatures and thin glyph
-// strokes (i, l, |, /) became unreadable after JPEG.
 const JPEG_QUALITY = 0.85
-// Upper bound for the source stream so Chromium doesn't silently cap the
-// desktop capture at its 1280x720 default. We downscale to MAX_DIMENSION
-// after the fact — this just prevents pre-canvas downsampling. 4K covers
-// nearly every Retina/HiDPI display we care about.
 const SOURCE_MAX_WIDTH = 3840
 const SOURCE_MAX_HEIGHT = 2160
 
@@ -40,14 +77,17 @@ export class ScreenCapture {
   private video: HTMLVideoElement | null = null
   private canvas: HTMLCanvasElement | null = null
   private ctx: CanvasRenderingContext2D | null = null
+  private strokesCanvas: HTMLCanvasElement | null = null
+  private strokesCtx: CanvasRenderingContext2D | null = null
   private intervalId: ReturnType<typeof setInterval> | null = null
   private sourceName = ''
+  private annotationProvider: AnnotationProvider | null = null
 
-  async start(sourceId: string, onFrame: (base64Jpeg: string) => void) {
-    // Request screen capture stream using Electron's chromeMediaSource.
-    // The legacy `mandatory` constraint shape is required when combining
-    // chromeMediaSource: 'desktop' with size hints — modern width/height
-    // constraints are ignored on this path in Chromium.
+  setAnnotationProvider(provider: AnnotationProvider | null) {
+    this.annotationProvider = provider
+  }
+
+  async start(sourceId: string, onFrame: (frame: FrameWithAnnotations) => void) {
     this.stream = await navigator.mediaDevices.getUserMedia({
       audio: false,
       video: {
@@ -61,18 +101,17 @@ export class ScreenCapture {
       } as any,
     })
 
-    // Set up hidden video element to receive stream
     this.video = document.createElement('video')
     this.video.srcObject = this.stream
     this.video.style.display = 'none'
     document.body.appendChild(this.video)
     await this.video.play()
 
-    // Set up canvas for frame extraction
     this.canvas = document.createElement('canvas')
     this.ctx = this.canvas.getContext('2d')
+    this.strokesCanvas = document.createElement('canvas')
+    this.strokesCtx = this.strokesCanvas.getContext('2d')
 
-    // Start capturing at 1 FPS
     this.intervalId = setInterval(() => {
       this.captureFrame(onFrame)
     }, CAPTURE_INTERVAL_MS)
@@ -93,6 +132,8 @@ export class ScreenCapture {
     }
     this.canvas = null
     this.ctx = null
+    this.strokesCanvas = null
+    this.strokesCtx = null
   }
 
   getSourceName(): string {
@@ -103,11 +144,10 @@ export class ScreenCapture {
     this.sourceName = name
   }
 
-  private captureFrame(onFrame: (base64Jpeg: string) => void) {
+  private captureFrame(onFrame: (frame: FrameWithAnnotations) => void) {
     if (!this.video || !this.canvas || !this.ctx) return
     if (this.video.videoWidth === 0 || this.video.videoHeight === 0) return
 
-    // Resize to fit within MAX_DIMENSION, preserving aspect ratio
     const { videoWidth, videoHeight } = this.video
     const scale = Math.min(MAX_DIMENSION / videoWidth, MAX_DIMENSION / videoHeight, 1)
     const w = Math.round(videoWidth * scale)
@@ -117,15 +157,113 @@ export class ScreenCapture {
     this.canvas.height = h
     this.ctx.drawImage(this.video, 0, 0, w, h)
 
-    // Export as JPEG base64 (strip the data:image/jpeg;base64, prefix)
-    const dataUrl = this.canvas.toDataURL('image/jpeg', JPEG_QUALITY)
-    const base64 = dataUrl.split(',')[1]
-    if (base64) {
-      onFrame(base64)
+    const originalDataUrl = this.canvas.toDataURL('image/jpeg', JPEG_QUALITY)
+    const originalBase64 = originalDataUrl.split(',')[1] ?? ''
+
+    const strokes = this.annotationProvider?.getStrokes() ?? []
+    const ctx = this.annotationProvider?.getSourceContext() ?? null
+    const transformedStrokes =
+      strokes.length > 0 && ctx ? transformStrokes(strokes, ctx, w, h) : []
+
+    if (transformedStrokes.length === 0) {
+      onFrame({
+        composite: originalBase64,
+        original: originalBase64,
+        strokesPng: null,
+        hasStrokes: false,
+      })
+      return
     }
+
+    paintStrokes(this.ctx, transformedStrokes)
+    const compositeDataUrl = this.canvas.toDataURL('image/jpeg', JPEG_QUALITY)
+    const compositeBase64 = compositeDataUrl.split(',')[1] ?? ''
+
+    let strokesPngBase64: string | null = null
+    if (this.strokesCanvas && this.strokesCtx) {
+      this.strokesCanvas.width = w
+      this.strokesCanvas.height = h
+      this.strokesCtx.clearRect(0, 0, w, h)
+      paintStrokes(this.strokesCtx, transformedStrokes)
+      const dataUrl = this.strokesCanvas.toDataURL('image/png')
+      strokesPngBase64 = dataUrl.split(',')[1] ?? null
+    }
+
+    onFrame({
+      composite: compositeBase64,
+      original: originalBase64,
+      strokesPng: strokesPngBase64,
+      hasStrokes: true,
+    })
   }
 }
 
 export async function getScreenSources(): Promise<ScreenSource[]> {
   return window.electronAPI.screen.getSources()
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ScaledStroke = {
+  color: string
+  width: number
+  points: StrokePoint[]
+}
+
+function transformStrokes(
+  strokes: Stroke[],
+  context: SourceContext,
+  frameWidth: number,
+  frameHeight: number,
+): ScaledStroke[] {
+  // Strokes arrive in display-CSS-px (overlay window sits at the display
+  // origin). Captured frame px depends on the source:
+  //   - display: frame = whole display, scale = frame_w / display_w
+  //   - window with bounds known: subtract the window's screen-origin and
+  //     scale by frame_w / window_w; points outside the window's rect
+  //     fall outside the canvas and get clipped on draw.
+  //   - window with bounds unknown: best-effort fall back to display
+  //     scaling. The strokes will be wrong, but we don't crash.
+  if (context.kind === 'window' && context.windowBounds) {
+    const win = context.windowBounds
+    const scaleX = frameWidth / win.width
+    const scaleY = frameHeight / win.height
+    const widthScale = (scaleX + scaleY) / 2
+    return strokes.map((s) => ({
+      color: s.color,
+      width: Math.max(1, s.width * widthScale),
+      points: s.points.map((p) => ({
+        x: (p.x - win.x) * scaleX,
+        y: (p.y - win.y) * scaleY,
+      })),
+    }))
+  }
+  const display = context.displayBounds
+  const scaleX = frameWidth / display.width
+  const scaleY = frameHeight / display.height
+  const widthScale = (scaleX + scaleY) / 2
+  return strokes.map((s) => ({
+    color: s.color,
+    width: Math.max(1, s.width * widthScale),
+    points: s.points.map((p) => ({ x: p.x * scaleX, y: p.y * scaleY })),
+  }))
+}
+
+function paintStrokes(ctx: CanvasRenderingContext2D, strokes: ScaledStroke[]) {
+  ctx.lineCap = 'round'
+  ctx.lineJoin = 'round'
+  for (const stroke of strokes) {
+    if (stroke.points.length < 1) continue
+    ctx.strokeStyle = stroke.color
+    ctx.lineWidth = stroke.width
+    ctx.beginPath()
+    const [first, ...rest] = stroke.points
+    ctx.moveTo(first.x, first.y)
+    for (const p of rest) {
+      ctx.lineTo(p.x, p.y)
+    }
+    ctx.stroke()
+  }
 }

--- a/desktop/src/renderer/src/lib/screen-capture.ts
+++ b/desktop/src/renderer/src/lib/screen-capture.ts
@@ -218,14 +218,16 @@ function transformStrokes(
   frameWidth: number,
   frameHeight: number,
 ): ScaledStroke[] {
-  // Strokes arrive in display-CSS-px (overlay window sits at the display
-  // origin). Captured frame px depends on the source:
-  //   - display: frame = whole display, scale = frame_w / display_w
-  //   - window with bounds known: subtract the window's screen-origin and
-  //     scale by frame_w / window_w; points outside the window's rect
-  //     fall outside the canvas and get clipped on draw.
-  //   - window with bounds unknown: best-effort fall back to display
-  //     scaling. The strokes will be wrong, but we don't crash.
+  // Strokes arrive in overlay-CSS-px relative to the overlay window's top-
+  // left, which sits at displayBounds.x/y in screen-coordinate space. To get
+  // absolute screen-px we add the display origin first; then per source kind:
+  //   - display: scale = frame_w / display_w (origin cancels)
+  //   - window with bounds known: subtract the window's absolute screen-origin
+  //     and scale by frame_w / window_w; points outside the window's rect fall
+  //     outside the canvas and get clipped on draw.
+  //   - window with bounds unknown: best-effort fall back to display scaling.
+  //     The strokes will be wrong, but we don't crash.
+  const display = context.displayBounds
   if (context.kind === 'window' && context.windowBounds) {
     const win = context.windowBounds
     const scaleX = frameWidth / win.width
@@ -235,12 +237,11 @@ function transformStrokes(
       color: s.color,
       width: Math.max(1, s.width * widthScale),
       points: s.points.map((p) => ({
-        x: (p.x - win.x) * scaleX,
-        y: (p.y - win.y) * scaleY,
+        x: (p.x + display.x - win.x) * scaleX,
+        y: (p.y + display.y - win.y) * scaleY,
       })),
     }))
   }
-  const display = context.displayBounds
   const scaleX = frameWidth / display.width
   const scaleY = frameHeight / display.height
   const widthScale = (scaleX + scaleY) / 2

--- a/desktop/src/renderer/src/lib/use-realtime.ts
+++ b/desktop/src/renderer/src/lib/use-realtime.ts
@@ -67,6 +67,15 @@ export interface RealtimeCallbacks {
   onSessionEnded?: (summary: string) => void
   onDisconnect?: () => void
   onError?: (message: string, code: number, payload?: AdapterErrorPayload) => void
+  onUsage?: (usage: UsageSnapshot) => void
+}
+
+export interface UsageSnapshot {
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+  inputAudioTokens?: number
+  outputAudioTokens?: number
 }
 
 export interface RealtimeControls {
@@ -240,6 +249,16 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
 
         case 'session.rotated':
           if (typeof data.sessionId === 'string') setSessionId(data.sessionId)
+          break
+
+        case 'usage.metrics':
+          cb.onUsage?.({
+            promptTokens: data.promptTokens,
+            completionTokens: data.completionTokens,
+            totalTokens: data.totalTokens,
+            inputAudioTokens: data.inputAudioTokens,
+            outputAudioTokens: data.outputAudioTokens,
+          })
           break
 
         case 'error':

--- a/desktop/src/renderer/src/lib/use-realtime.ts
+++ b/desktop/src/renderer/src/lib/use-realtime.ts
@@ -75,7 +75,10 @@ export interface RealtimeControls {
   setMuted: (muted: boolean) => void
   setOutputVolume: (volume: number) => void
   setOutputMuted: (muted: boolean) => void
-  sendFrame: (base64Jpeg: string) => void
+  sendFrame: (
+    base64Jpeg: string,
+    annotation?: { original: string; strokesPng: string },
+  ) => void
   sendUserText: (text: string) => boolean
   getInputLevel: () => number
   getOutputLevel: () => number
@@ -403,11 +406,23 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
     engineRef.current?.setOutputMuted(muted)
   }, [])
 
-  const sendFrame = useCallback((base64Jpeg: string) => {
-    if (wsRef.current?.readyState === WebSocket.OPEN) {
-      wsRef.current.send(JSON.stringify({ type: 'frame.append', data: base64Jpeg }))
-    }
-  }, [])
+  const sendFrame = useCallback(
+    (
+      base64Jpeg: string,
+      annotation?: { original: string; strokesPng: string },
+    ) => {
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        wsRef.current.send(
+          JSON.stringify({
+            type: 'frame.append',
+            data: base64Jpeg,
+            ...(annotation ? { annotation } : {}),
+          }),
+        )
+      }
+    },
+    [],
+  )
 
   const sendUserText = useCallback((text: string) => {
     if (!text) return false

--- a/desktop/src/renderer/src/main.tsx
+++ b/desktop/src/renderer/src/main.tsx
@@ -27,6 +27,19 @@ void (async () => {
     return
   }
 
+  if (view === 'draw-overlay') {
+    const [{ DrawCanvas }] = await Promise.all([
+      import('./draw-overlay/DrawCanvas'),
+      import('./draw-overlay/draw-overlay.css'),
+    ])
+    root.render(
+      <StrictMode>
+        <DrawCanvas />
+      </StrictMode>,
+    )
+    return
+  }
+
   const [{ App }, { initTelemetry }] = await Promise.all([
     import('./App'),
     import('./lib/telemetry'),

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -34,7 +34,14 @@ import { ScreenSharePicker } from '../components/ScreenSharePicker'
 import { VolumeControl } from '../components/VolumeControl'
 import { ToolCallRow } from '../components/ToolCallRow'
 import { AdapterErrorBanner } from '../components/AdapterErrorBanner'
-import { ScreenCapture, type ScreenSource } from '../lib/screen-capture'
+import {
+  ScreenCapture,
+  type DisplayBounds,
+  type ScreenSource,
+  type SourceContext,
+  type Stroke,
+  type WindowBounds,
+} from '../lib/screen-capture'
 import { useRealtime, type RealtimeCallbacks, type AdapterErrorPayload } from '../lib/use-realtime'
 import { captureRenderer } from '../lib/telemetry'
 import { useConversationContext } from '../lib/conversation-context'
@@ -103,6 +110,12 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
   const [isScreenSharing, setIsScreenSharing] = useState(false)
   const [screenSourceName, setScreenSourceName] = useState('')
   const screenCaptureRef = useRef<ScreenCapture | null>(null)
+  const overlayStrokesRef = useRef<Stroke[]>([])
+  const overlayDisplayBoundsRef = useRef<DisplayBounds | null>(null)
+  const sourceContextRef = useRef<SourceContext | null>(null)
+  const windowBoundsPollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const [drawMode, setDrawMode] = useState(false)
+  const [hasStrokes, setHasStrokes] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const activeRelayUrlRef = useRef<string>('')
   const brainCallStartRef = useRef<Map<string, number>>(new Map())
@@ -603,15 +616,36 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
   const startScreenShare = useCallback(async (source: ScreenSource) => {
     if (activeRealtimeModel.startsWith('grok-voice-')) return
     setShowScreenPicker(false)
+    const sourceKind: 'display' | 'window' = source.id.startsWith('screen:')
+      ? 'display'
+      : 'window'
     const capture = new ScreenCapture()
     capture.setSourceName(source.name)
+    capture.setAnnotationProvider({
+      getStrokes: () => overlayStrokesRef.current,
+      getSourceContext: () => sourceContextRef.current,
+    })
     screenCaptureRef.current = capture
     try {
-      await capture.start(source.id, (base64Jpeg) => {
-        realtime.sendFrame(base64Jpeg)
+      await capture.start(source.id, (frame) => {
+        if (frame.hasStrokes && frame.strokesPng) {
+          realtime.sendFrame(frame.composite, {
+            original: frame.original,
+            strokesPng: frame.strokesPng,
+          })
+        } else {
+          realtime.sendFrame(frame.composite)
+        }
       })
       setIsScreenSharing(true)
       setScreenSourceName(source.name)
+      void window.electronAPI.drawOverlay.show()
+      if (sourceKind === 'window') {
+        const windowId = parseWindowIdFromSourceId(source.id)
+        if (windowId !== null) {
+          startWindowBoundsPolling(windowId)
+        }
+      }
     } catch (err) {
       console.error('[ChatPage] Screen capture failed:', err)
       screenCaptureRef.current = null
@@ -623,6 +657,82 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
     screenCaptureRef.current = null
     setIsScreenSharing(false)
     setScreenSourceName('')
+    setDrawMode(false)
+    setHasStrokes(false)
+    overlayStrokesRef.current = []
+    overlayDisplayBoundsRef.current = null
+    sourceContextRef.current = null
+    if (windowBoundsPollRef.current) {
+      clearInterval(windowBoundsPollRef.current)
+      windowBoundsPollRef.current = null
+    }
+    void window.electronAPI.drawOverlay.hide()
+  }, [])
+
+  const toggleDrawMode = useCallback(() => {
+    void window.electronAPI.drawOverlay.setMode(drawMode ? 'idle' : 'draw')
+  }, [drawMode])
+
+  const clearStrokes = useCallback(() => {
+    overlayStrokesRef.current = []
+    setHasStrokes(false)
+    void window.electronAPI.drawOverlay.clear()
+  }, [])
+
+  function startWindowBoundsPolling(windowId: number) {
+    if (windowBoundsPollRef.current) {
+      clearInterval(windowBoundsPollRef.current)
+    }
+    const refresh = async () => {
+      const display = overlayDisplayBoundsRef.current
+      if (!display) return
+      const bounds = await window.electronAPI.screen.getWindowBounds(windowId)
+      const winBounds: WindowBounds | null = bounds
+        ? { x: bounds.x, y: bounds.y, width: bounds.width, height: bounds.height }
+        : null
+      sourceContextRef.current = {
+        kind: 'window',
+        displayBounds: display,
+        windowBounds: winBounds,
+      }
+    }
+    void refresh()
+    windowBoundsPollRef.current = setInterval(() => void refresh(), 1000)
+  }
+
+  useEffect(() => {
+    const offStrokes = window.electronAPI.drawOverlay.onStrokes(({ strokes, bounds }) => {
+      overlayStrokesRef.current = strokes
+      overlayDisplayBoundsRef.current = bounds
+      setHasStrokes(strokes.length > 0)
+      if (sourceContextRef.current?.kind === 'window') {
+        sourceContextRef.current = {
+          ...sourceContextRef.current,
+          displayBounds: bounds,
+        }
+      } else {
+        sourceContextRef.current = { kind: 'display', displayBounds: bounds }
+      }
+    })
+    const offBounds = window.electronAPI.drawOverlay.onDisplayBounds((bounds) => {
+      overlayDisplayBoundsRef.current = bounds
+      if (sourceContextRef.current?.kind === 'window') {
+        sourceContextRef.current = {
+          ...sourceContextRef.current,
+          displayBounds: bounds,
+        }
+      } else {
+        sourceContextRef.current = { kind: 'display', displayBounds: bounds }
+      }
+    })
+    const offMode = window.electronAPI.drawOverlay.onModeChanged((mode) => {
+      setDrawMode(mode === 'draw')
+    })
+    return () => {
+      offStrokes()
+      offBounds()
+      offMode()
+    }
   }, [])
 
   // Clean up screen capture when call ends
@@ -908,12 +1018,35 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
         <div className="px-4 py-1.5 flex items-center gap-2 text-xs text-[var(--brand-sage)]">
           <Monitor size={14} />
           <span className="truncate">Sharing: {screenSourceName}</span>
-          <button
-            onClick={stopScreenShare}
-            className="ml-auto text-muted-foreground hover:text-destructive transition-colors"
-          >
-            Stop
-          </button>
+          <div className="ml-auto flex items-center gap-3">
+            <button
+              type="button"
+              onClick={toggleDrawMode}
+              className={`transition-colors ${
+                drawMode
+                  ? 'text-[var(--brand-rust)]'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+              title={drawMode ? 'Stop drawing' : 'Draw on screen'}
+            >
+              {drawMode ? 'Drawing' : 'Draw'}
+            </button>
+            <button
+              type="button"
+              onClick={clearStrokes}
+              disabled={!hasStrokes}
+              className="text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Clear strokes"
+            >
+              Clear
+            </button>
+            <button
+              onClick={stopScreenShare}
+              className="text-muted-foreground hover:text-destructive transition-colors"
+            >
+              Stop
+            </button>
+          </div>
         </div>
       )}
 
@@ -1175,4 +1308,13 @@ async function defaultRelayUrl(): Promise<string> {
     // fall through
   }
   return 'ws://localhost:8080/ws'
+}
+
+function parseWindowIdFromSourceId(sourceId: string): number | null {
+  // chromeMediaSourceId for windows is "window:<CGWindowID>:<displayId>" on
+  // macOS. We need the CGWindowID to look up live screen-rect via get-windows.
+  const match = /^window:(\d+):/.exec(sourceId)
+  if (!match) return null
+  const id = Number.parseInt(match[1], 10)
+  return Number.isFinite(id) ? id : null
 }

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -693,12 +693,21 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
         if (isCallActive) toggleMute()
       } else if (action === 'annotate') {
         if (isScreenSharing) toggleDrawMode()
+      } else if (action === 'clearAnnotations') {
+        if (isScreenSharing) clearStrokes()
       } else if (action === 'screenShare') {
         if (isCallActive) toggleScreenShare()
       }
     })
     return off
-  }, [isCallActive, isScreenSharing, toggleMute, toggleDrawMode, toggleScreenShare])
+  }, [
+    isCallActive,
+    isScreenSharing,
+    toggleMute,
+    toggleDrawMode,
+    clearStrokes,
+    toggleScreenShare,
+  ])
 
   function startWindowBoundsPolling(windowId: number) {
     if (windowBoundsPollRef.current) {

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -103,6 +103,13 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
   // current role outside of a setState updater since updaters must stay pure.
   const streamingRoleRef = useRef<'user' | 'assistant'>('assistant')
   const [showLatency, setShowLatency] = useState(false)
+  const [showContextUsage, setShowContextUsage] = useState(false)
+  const [usage, setUsage] = useState<{
+    promptTokens?: number
+    totalTokens?: number
+    inputAudioTokens?: number
+    outputAudioTokens?: number
+  } | null>(null)
   const [connectionError, setConnectionError] = useState('')
   const [adapterError, setAdapterError] = useState<AdapterErrorPayload | null>(null)
   const [activeRealtimeModel, setActiveRealtimeModel] = useState('')
@@ -211,6 +218,7 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
   useEffect(() => {
     loadLatestConversation()
     getSetting('show_latency').then((v) => setShowLatency(v === 'true'))
+    getSetting('show_context_usage').then((v) => setShowContextUsage(v === 'true'))
     getSetting('realtime_volume').then((v) => {
       const parsed = parseFloat(v ?? '')
       if (!Number.isNaN(parsed)) setBaseVolume(Math.max(0, parsed))
@@ -366,6 +374,14 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
       setIsConnecting(false)
       setIsCallActive(false)
       realtimeRef.current?.stop()
+    },
+    onUsage: (snapshot) => {
+      setUsage({
+        promptTokens: snapshot.promptTokens,
+        totalTokens: snapshot.totalTokens,
+        inputAudioTokens: snapshot.inputAudioTokens,
+        outputAudioTokens: snapshot.outputAudioTokens,
+      })
     },
   }
 
@@ -1043,6 +1059,21 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
         <div ref={messagesEndRef} />
       </div>
 
+      {/* Context usage debug strip */}
+      {showContextUsage && isCallActive && usage && (
+        <div className="px-4 py-1 text-[11px] text-muted-foreground font-mono flex items-center justify-between border-t border-border">
+          <span>
+            context: {formatTokens(usage.promptTokens)} /{' '}
+            {formatTokens(getContextWindowFor(activeRealtimeModel))}
+            {' '}
+            ({formatPercent(usage.promptTokens, getContextWindowFor(activeRealtimeModel))})
+          </span>
+          <span className="text-muted-foreground/70">
+            audio in {formatTokens(usage.inputAudioTokens)} · out {formatTokens(usage.outputAudioTokens)}
+          </span>
+        </div>
+      )}
+
       {/* Screen sharing indicator */}
       {isScreenSharing && (
         <div className="px-4 py-1.5 flex items-center gap-2 text-xs text-[var(--brand-sage)]">
@@ -1338,6 +1369,30 @@ async function defaultRelayUrl(): Promise<string> {
     // fall through
   }
   return 'ws://localhost:8080/ws'
+}
+
+// Mirrors relay-server/src/adapters/gemini.ts MODEL_CONTEXT_WINDOWS. Kept in
+// sync manually — when Google bumps a model, update both. The renderer only
+// needs entries for models the user can actually pick (set in REALTIME_MODELS).
+const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  'gemini-3.1-flash-live-preview': 131_072,
+}
+const FALLBACK_CONTEXT_WINDOW = 131_072
+
+function getContextWindowFor(model: string): number {
+  return MODEL_CONTEXT_WINDOWS[model] ?? FALLBACK_CONTEXT_WINDOW
+}
+
+function formatTokens(n: number | undefined | null): string {
+  if (n == null || !Number.isFinite(n) || n < 0) return '?'
+  if (n < 1000) return String(n)
+  if (n < 100_000) return `${(n / 1000).toFixed(1)}k`
+  return `${Math.round(n / 1000)}k`
+}
+
+function formatPercent(used: number | undefined, limit: number): string {
+  if (used == null || !Number.isFinite(used) || limit <= 0) return '?%'
+  return `${Math.round((used / limit) * 100)}%`
 }
 
 function parseWindowIdFromSourceId(sourceId: string): number | null {

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -478,11 +478,13 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
     setIsMuted(false)
     setOutputMuted(false)
     setActiveRealtimeModel('')
+    window.electronAPI?.callBar?.sendMuted?.(false)
   }, [realtime])
 
   const toggleMute = useCallback(() => {
     const next = !isMuted
     setIsMuted(next)
+    window.electronAPI?.callBar?.sendMuted?.(next)
     realtime.setMuted(next)
   }, [isMuted, realtime])
 

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -657,7 +657,13 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
       })
       setIsScreenSharing(true)
       setScreenSourceName(source.name)
-      void window.electronAPI.drawOverlay.show()
+      // For display sources the chromeMediaSourceId is "screen:<displayId>:0";
+      // pulling the displayId out and forwarding it to the overlay keeps the
+      // transparent canvas on the same monitor as the captured frame so
+      // strokes line up on multi-display setups.
+      const displayId =
+        sourceKind === 'display' ? parseDisplayIdFromSourceId(source.id) : null
+      void window.electronAPI.drawOverlay.show(displayId ?? undefined)
       if (sourceKind === 'window') {
         const windowId = parseWindowIdFromSourceId(source.id)
         if (windowId !== null) {
@@ -684,6 +690,10 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
       clearInterval(windowBoundsPollRef.current)
       windowBoundsPollRef.current = null
     }
+    // Clear before hide — the overlay window stays alive across shares,
+    // so its own strokesRef would otherwise repaint stale annotations the
+    // moment the next share starts and the user begins drawing again.
+    void window.electronAPI.drawOverlay.clear()
     void window.electronAPI.drawOverlay.hide()
   }, [])
 
@@ -1404,6 +1414,14 @@ function formatTokens(n: number | undefined | null): string {
 function formatPercent(used: number | undefined, limit: number): string {
   if (used == null || !Number.isFinite(used) || limit <= 0) return '?%'
   return `${Math.round((used / limit) * 100)}%`
+}
+
+function parseDisplayIdFromSourceId(sourceId: string): number | null {
+  // chromeMediaSourceId for screens is "screen:<electronDisplayId>:0".
+  const match = /^screen:(\d+):/.exec(sourceId)
+  if (!match) return null
+  const id = Number.parseInt(match[1], 10)
+  return Number.isFinite(id) ? id : null
 }
 
 function parseWindowIdFromSourceId(sourceId: string): number | null {

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -705,7 +705,13 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
 
   useEffect(() => {
     const off = window.electronAPI.shortcuts?.onTriggered((action) => {
-      if (action === 'mute') {
+      if (action === 'toggleCall') {
+        if (isCallActive) {
+          endCall()
+        } else if (!isConnecting) {
+          void startCall()
+        }
+      } else if (action === 'mute') {
         if (isCallActive) toggleMute()
       } else if (action === 'annotate') {
         if (isScreenSharing) toggleDrawMode()
@@ -718,7 +724,10 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
     return off
   }, [
     isCallActive,
+    isConnecting,
     isScreenSharing,
+    startCall,
+    endCall,
     toggleMute,
     toggleDrawMode,
     clearStrokes,

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -679,6 +679,27 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
     void window.electronAPI.drawOverlay.clear()
   }, [])
 
+  const toggleScreenShare = useCallback(() => {
+    if (isScreenSharing) {
+      stopScreenShare()
+    } else {
+      setShowScreenPicker(true)
+    }
+  }, [isScreenSharing, stopScreenShare])
+
+  useEffect(() => {
+    const off = window.electronAPI.shortcuts?.onTriggered((action) => {
+      if (action === 'mute') {
+        if (isCallActive) toggleMute()
+      } else if (action === 'annotate') {
+        if (isScreenSharing) toggleDrawMode()
+      } else if (action === 'screenShare') {
+        if (isCallActive) toggleScreenShare()
+      }
+    })
+    return off
+  }, [isCallActive, isScreenSharing, toggleMute, toggleDrawMode, toggleScreenShare])
+
   function startWindowBoundsPolling(windowId: number) {
     if (windowBoundsPollRef.current) {
       clearInterval(windowBoundsPollRef.current)

--- a/desktop/src/renderer/src/pages/SettingsPage.tsx
+++ b/desktop/src/renderer/src/pages/SettingsPage.tsx
@@ -85,6 +85,7 @@ export function SettingsPage() {
   // Debug
   const [debugMode, setDebugMode] = useState(false)
   const [showLatency, setShowLatency] = useState(false)
+  const [showContextUsage, setShowContextUsage] = useState(false)
   const [tracingEnabled, setTracingEnabled] = useState(false)
   const [exportingBundle, setExportingBundle] = useState(false)
   const [bundleToast, setBundleToast] = useState<{ ok: boolean; message: string } | null>(null)
@@ -159,6 +160,8 @@ export function SettingsPage() {
       if (dm === 'true') setDebugMode(true)
       const sl = await getSetting('show_latency')
       if (sl === 'true') setShowLatency(true)
+      const scu = await getSetting('show_context_usage')
+      if (scu === 'true') setShowContextUsage(true)
       const tr = await getSetting('tracing_enabled')
       if (tr === 'true') setTracingEnabled(true)
 
@@ -341,6 +344,11 @@ export function SettingsPage() {
   const toggleShowLatency = useCallback((v: boolean) => {
     setShowLatency(v)
     setSetting('show_latency', v ? 'true' : 'false')
+  }, [])
+
+  const toggleShowContextUsage = useCallback((v: boolean) => {
+    setShowContextUsage(v)
+    setSetting('show_context_usage', v ? 'true' : 'false')
   }, [])
 
   const toggleTracing = useCallback((v: boolean) => {
@@ -885,6 +893,16 @@ export function SettingsPage() {
               <p className="text-xs text-muted-foreground">Display latency badges on chat messages</p>
             </div>
             <Toggle checked={showLatency} onChange={toggleShowLatency} />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-foreground">Show Context Usage</p>
+              <p className="text-xs text-muted-foreground">
+                Live token count vs the model&apos;s context window during a call
+              </p>
+            </div>
+            <Toggle checked={showContextUsage} onChange={toggleShowContextUsage} />
           </div>
 
           <div className="flex items-center justify-between">

--- a/desktop/src/renderer/src/pages/SettingsPage.tsx
+++ b/desktop/src/renderer/src/pages/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { Card } from '../components/ui/Card'
 import { Input } from '../components/ui/Input'
 import { Select } from '../components/ui/Select'
 import { Toggle } from '../components/ui/Toggle'
+import { ShortcutsCard } from '../components/ShortcutsCard'
 import { identityApi, onboarding } from '../lib/onboarding-api'
 import { decodeVoicePreviewAudio } from '../lib/voice-preview'
 import { useTheme, type Theme } from '../lib/use-theme'
@@ -784,6 +785,8 @@ export function SettingsPage() {
             <Toggle checked={callBarEnabled} onChange={toggleCallBar} />
           </div>
         </Card>
+
+        <ShortcutsCard />
 
         {/* Updates */}
         <Card className="p-4 space-y-4">

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -89,6 +89,8 @@ export default defineConfig({
             { slug: 'desktop/time-grouping', label: 'Desktop: time grouping in chat' },
             { slug: 'desktop/typing-messages', label: 'Desktop: typing messages' },
             { slug: 'desktop/attachments', label: 'Desktop: image attachments' },
+            { slug: 'desktop/screen-annotations', label: 'Desktop: drawing on your screen' },
+            { slug: 'desktop/keyboard-shortcuts', label: 'Desktop: keyboard shortcuts' },
             { slug: 'desktop/releasing', label: 'Desktop: releasing' },
             { slug: 'mobile-app' },
             { slug: 'canvas-mode', label: 'Canvas mode (in design)', badge: { text: 'Preview', variant: 'note' } },

--- a/docs/src/content/docs/desktop/keyboard-shortcuts.mdx
+++ b/docs/src/content/docs/desktop/keyboard-shortcuts.mdx
@@ -11,6 +11,7 @@ VoiceClaw exposes a small set of global keyboard shortcuts so you can drive a ca
 
 | Action | Default | When it fires |
 |---|---|---|
+| Start or end a call | `Ctrl + J` | Any time |
 | Toggle mute | `Ctrl + M` | While a call is active |
 | Toggle annotate (drawing) | `Ctrl + A` | While screen-sharing |
 | Clear annotations | `Ctrl + Shift + A` | While screen-sharing |
@@ -31,10 +32,11 @@ Open **Settings → Keyboard Shortcuts**. Each row has:
 
 To rebind, **click the binding chip** and press the combination you want. Modifier-only presses (just `Shift`, just `Ctrl`) are ignored — you have to include a real key. `Esc` cancels the recording. If the combination is owned by the operating system or another running app, you'll see an inline error and the previous binding stays in place.
 
-A **Reset defaults** button at the top of the card restores all four shortcuts to the table above.
+A **Reset defaults** button at the top of the card restores all five shortcuts to the table above.
 
 ## What gets triggered
 
+- **Start or end a call.** If no call is active, starts a new realtime session with the current provider. If a call is in flight, ends it. The chat window comes to the front when this fires from another app so you can see the call state.
 - **Toggle mute.** Same as clicking the mic button in the call controls or the call-bar's context menu. Works mid-turn.
 - **Toggle annotate.** Enters drawing mode (cursor becomes a crosshair, the floating toolbar appears at the top of the shared display) or exits it. The annotated frames get composited into what the model sees.
 - **Clear annotations.** Erases every stroke currently on the overlay. Subsequent frames sent to the model contain no strokes.

--- a/docs/src/content/docs/desktop/keyboard-shortcuts.mdx
+++ b/docs/src/content/docs/desktop/keyboard-shortcuts.mdx
@@ -1,0 +1,52 @@
+---
+title: Keyboard shortcuts
+description: Global hotkeys for muting, annotating, screen-sharing, and clearing your strokes — they fire even when VoiceClaw isn't the focused app.
+---
+
+import { Aside } from '@astrojs/starlight/components'
+
+VoiceClaw exposes a small set of global keyboard shortcuts so you can drive a call without having to bring the app to the front. They register with the operating system at launch — you can hit them while you're focused on Chrome, your IDE, anything — and they stay out of your way otherwise.
+
+## Defaults
+
+| Action | Default | When it fires |
+|---|---|---|
+| Toggle mute | `Ctrl + M` | While a call is active |
+| Toggle annotate (drawing) | `Ctrl + A` | While screen-sharing |
+| Clear annotations | `Ctrl + Shift + A` | While screen-sharing |
+| Toggle screen share | `Ctrl + S` | While a call is active |
+
+If you're not in the right state for an action — for example, you press `Ctrl + A` outside a screen-share — the shortcut is silently ignored. The buttons in the chat strip and the in-overlay toolbar do the same things.
+
+<Aside type="caution">
+On macOS, `Ctrl + S` is **not** the standard "Save" shortcut (that's `⌘ + S`). VoiceClaw deliberately uses `Ctrl` so it doesn't collide with normal app shortcuts. If `Ctrl + S` ever steals from another app you care about, rebind it from Settings.
+</Aside>
+
+## Rebinding or unbinding
+
+Open **Settings → Keyboard Shortcuts**. Each row has:
+
+- A binding chip showing the current combination (e.g. `Ctrl M`, `⇧ ⌘ K`).
+- A **Clear** button that unbinds the action — pressing the old combo will do nothing until you set a new one.
+
+To rebind, **click the binding chip** and press the combination you want. Modifier-only presses (just `Shift`, just `Ctrl`) are ignored — you have to include a real key. `Esc` cancels the recording. If the combination is owned by the operating system or another running app, you'll see an inline error and the previous binding stays in place.
+
+A **Reset defaults** button at the top of the card restores all four shortcuts to the table above.
+
+## What gets triggered
+
+- **Toggle mute.** Same as clicking the mic button in the call controls or the call-bar's context menu. Works mid-turn.
+- **Toggle annotate.** Enters drawing mode (cursor becomes a crosshair, the floating toolbar appears at the top of the shared display) or exits it. The annotated frames get composited into what the model sees.
+- **Clear annotations.** Erases every stroke currently on the overlay. Subsequent frames sent to the model contain no strokes.
+- **Toggle screen share.** If you're not sharing, opens the source picker. If you're already sharing, stops the share immediately.
+
+## Caveats
+
+- Shortcuts are **global**. If two apps fight over the same combination, the one that registered first usually wins, but this is a best-effort behavior at the OS level.
+- The bindings live in the local desktop database and don't sync between machines yet.
+- Quitting VoiceClaw releases all of its bindings. Other apps' shortcuts are never touched.
+
+## See also
+
+- [Drawing on your screen](/desktop/screen-annotations/) — the feature most of these shortcuts drive.
+- [Floating call bar](/desktop/call-bar/) — another always-visible surface during a call.

--- a/docs/src/content/docs/desktop/screen-annotations.mdx
+++ b/docs/src/content/docs/desktop/screen-annotations.mdx
@@ -55,7 +55,7 @@ All four are configurable from [Settings → Keyboard Shortcuts](/desktop/keyboa
 
 Each captured frame goes through this path:
 
-1. The video element samples a frame at 1 Hz.
+1. The video element samples one frame a second.
 2. VoiceClaw scales it down to 1536 px on the long edge and paints any current strokes on top.
 3. The composited JPEG is sent to Gemini as the user video input.
 

--- a/docs/src/content/docs/desktop/screen-annotations.mdx
+++ b/docs/src/content/docs/desktop/screen-annotations.mdx
@@ -1,0 +1,77 @@
+---
+title: Drawing on your screen
+description: Circle, underline, or scribble on whatever you're sharing — the strokes are baked into the frames sent to Gemini, so the model sees exactly what you're pointing at.
+---
+
+import { Aside } from '@astrojs/starlight/components'
+
+When you're on a Gemini Live call and screen-sharing, VoiceClaw lets you draw on the shared region with two tools: **Draw** (freehand) and **Clear**. The strokes are composited directly into the captured JPEG frames before they're sent upstream, so the model sees them — there's no separate annotation channel for it to ignore.
+
+This is meant for pointing things out by gesture instead of by description. "Look at this" beats "the third item from the left in the second column."
+
+## Starting a session
+
+You need an active Gemini Live call (Grok Voice doesn't accept video). Start the call, click the screen-share button in the call controls, pick either a full display or a specific window. Once the share is running you'll see the share strip near the bottom of the chat with three buttons:
+
+- **Draw** — toggle annotation mode on or off.
+- **Clear** — erase every stroke on the overlay.
+- **Stop** — end the screen-share entirely.
+
+While **Draw** is on, a transparent overlay sits over the shared display. The cursor turns into a crosshair and a small floating toolbar appears at the top of the screen with **Clear** and **Done (Esc / right-click)** buttons.
+
+## Leaving draw mode
+
+Three equivalent ways:
+
+- Press **Esc**.
+- **Right-click** anywhere on the overlay.
+- Click **Done** in the floating toolbar.
+
+You can also click **Drawing** in the chat-strip toolbar to flip back. All four end up in the same idle state — the overlay becomes click-through again so you can keep using your apps.
+
+## Sharing a full display vs. a window
+
+Both work, but the experience differs slightly:
+
+- **Full display.** Strokes line up perfectly with whatever you draw on top of, because the overlay covers the same display the capture is recording.
+- **Single window.** The overlay still covers the whole display, but the captured frames are cropped to the window's bounds. VoiceClaw polls the window's screen-rect once a second so strokes track the window if you move or resize it. Strokes drawn outside the window's rect are clipped and not visible to the model.
+
+<Aside type="note">
+Window tracking uses macOS public APIs to look up the window by its `CGWindowID`. If a window is hidden, minimized, or on a different Space, bounds lookups fall back to the display rectangle — strokes will still composite, just less precisely.
+</Aside>
+
+## Keyboard shortcuts
+
+You don't have to use the chat strip. From anywhere — even another app — you can press the global shortcuts:
+
+- `Ctrl + A` — toggle annotate.
+- `Ctrl + Shift + A` — clear all strokes.
+- `Ctrl + S` — toggle screen share.
+- `Ctrl + M` — toggle mute (handy mid-drawing).
+
+All four are configurable from [Settings → Keyboard Shortcuts](/desktop/keyboard-shortcuts/).
+
+## What the model sees
+
+Each captured frame goes through this path:
+
+1. The video element samples a frame at 1 Hz.
+2. VoiceClaw scales it down to 1536 px on the long edge and paints any current strokes on top.
+3. The composited JPEG is sent to Gemini as the user video input.
+
+The strokes are part of the JPEG bytes — Gemini doesn't have a special "annotation" mode, it just sees a screenshot with extra paint. That's deliberate: any model that accepts video input will pick them up without changes on its end.
+
+## Trace artifacts
+
+If you're debugging or want to inspect what was sent, every annotated tick also writes two sibling files into the per-turn trace directory:
+
+- `NNNN.jpeg` — the composite (this is what Gemini saw).
+- `NNNN.original.jpeg` — the un-annotated capture.
+- `NNNN.strokes.png` — the strokes-only canvas with a transparent background.
+
+The directory lives alongside the relay's per-session media. See [Tracing UI](/tracing/) for how to load a session and step through frames.
+
+## See also
+
+- [Keyboard shortcuts](/desktop/keyboard-shortcuts/)
+- [Floating call bar](/desktop/call-bar/)

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -15,11 +15,11 @@ const DEFAULT_MODEL = "gemini-3.1-flash-live-preview"
 // Per-model input-token budget for the live bidi session. Override via
 // VOICECLAW_GEMINI_CONTEXT_WINDOW if Google's published numbers shift.
 const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
-  "gemini-3.1-flash-live-preview": 32_768,
+  "gemini-3.1-flash-live-preview": 131_072,
   "gemini-2.5-flash-live-preview": 32_768,
   "gemini-2.0-flash-live-preview-04-09": 32_768,
 }
-const FALLBACK_CONTEXT_WINDOW = 32_768
+const FALLBACK_CONTEXT_WINDOW = 131_072
 const WATCHDOG_TIMEOUT_MS = 20_000
 const SETUP_TIMEOUT_MS = 15_000
 const MAX_RECONNECT_ATTEMPTS = 2

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -56,6 +56,7 @@ export class GeminiAdapter implements ProviderAdapter {
   private currentUserText = ""
   private userSpeaking = false
   private hasVideoInput = false
+  private framesSent = 0
   private watchdogEnabled = false
   // Watchdog arms only after the first post-resume ASR text; any generation
   // event clears it.
@@ -208,6 +209,12 @@ export class GeminiAdapter implements ProviderAdapter {
       const onClose = (code: number, reason: Buffer) => {
         const reasonText = String(reason)
         log(`[gemini] WebSocket closed: ${code} ${reasonText}`)
+        if (this.currentUserText) {
+          log(`[gemini] user (in-flight at close): ${oneLine(this.currentUserText)}`)
+        }
+        if (this.currentAssistantText) {
+          log(`[gemini] assistant (in-flight at close): ${oneLine(this.currentAssistantText)}`)
+        }
         if (!settled) {
           finish(new Error(reasonText || "Gemini setup failed"))
           return
@@ -413,6 +420,13 @@ export class GeminiAdapter implements ProviderAdapter {
 
   sendFrame(data: string, mimeType?: string) {
     this.hasVideoInput = true
+    if (this.framesSent === 0 || this.framesSent % 30 === 0) {
+      // Cheap base64-byte estimate (length × 3/4) — actual bytes after base64
+      // decode are slightly less but this is close enough for sizing checks.
+      const approxBytes = Math.round((data.length * 3) / 4)
+      log(`[gemini] frame #${this.framesSent}: ~${(approxBytes / 1024).toFixed(0)} KB`)
+    }
+    this.framesSent++
     this.sendUpstream({
       realtimeInput: {
         video: {
@@ -671,6 +685,7 @@ export class GeminiAdapter implements ProviderAdapter {
     if (content.outputTranscription?.text) {
       if (this.currentUserText) {
         this.transcript.push({ role: "user", text: this.currentUserText })
+        log(`[gemini] user: ${oneLine(this.currentUserText)}`)
         this.sendToClient?.({
           type: "transcript.done",
           text: this.currentUserText,
@@ -734,6 +749,7 @@ export class GeminiAdapter implements ProviderAdapter {
       this.emitLatencyMetrics()
       if (this.currentUserText) {
         this.transcript.push({ role: "user", text: this.currentUserText })
+        log(`[gemini] user: ${oneLine(this.currentUserText)}`)
         this.sendToClient?.({
           type: "transcript.done",
           text: this.currentUserText,
@@ -743,6 +759,7 @@ export class GeminiAdapter implements ProviderAdapter {
       }
       if (this.currentAssistantText) {
         this.transcript.push({ role: "assistant", text: this.currentAssistantText })
+        log(`[gemini] assistant: ${oneLine(this.currentAssistantText)}`)
         this.sendToClient?.({
           type: "transcript.done",
           text: this.currentAssistantText,
@@ -764,6 +781,7 @@ export class GeminiAdapter implements ProviderAdapter {
       }
       if (this.currentUserText) {
         this.transcript.push({ role: "user", text: this.currentUserText })
+        log(`[gemini] user: ${oneLine(this.currentUserText)}`)
         this.sendToClient?.({
           type: "transcript.done",
           text: this.currentUserText,
@@ -773,6 +791,7 @@ export class GeminiAdapter implements ProviderAdapter {
       }
       if (this.currentAssistantText) {
         this.transcript.push({ role: "assistant", text: this.currentAssistantText + "..." })
+        log(`[gemini] assistant (interrupted): ${oneLine(this.currentAssistantText)}`)
         this.sendToClient?.({
           type: "transcript.done",
           text: this.currentAssistantText + "...",
@@ -1025,6 +1044,24 @@ export class GeminiAdapter implements ProviderAdapter {
     })
     this.resetLatencyMarks()
   }
+}
+
+function oneLine(s: string): string {
+  // Collapse whitespace runs into a single space so the line stays log-friendly,
+  // but escape non-printable controls (NULs, lone surrogates, etc.) so anything
+  // exotic that arrived from upstream is visible instead of swallowed by the
+  // terminal.
+  let collapsed = ""
+  for (const ch of s) {
+    const code = ch.codePointAt(0) ?? 0
+    if (code < 0x20 || code === 0x7f) {
+      collapsed += /\s/.test(ch) ? " " : `\\u${code.toString(16).padStart(4, "0")}`
+    } else {
+      collapsed += ch
+    }
+  }
+  collapsed = collapsed.replace(/\s+/g, " ").trim()
+  return collapsed.length > 1000 ? `${collapsed.slice(0, 1000)}…` : collapsed
 }
 
 function pickEarliest(a: number | null, b: number | null): number | null {

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -57,6 +57,8 @@ export class GeminiAdapter implements ProviderAdapter {
   private userSpeaking = false
   private hasVideoInput = false
   private framesSent = 0
+  private videoActive = false
+  private videoIdleTimer: ReturnType<typeof setTimeout> | null = null
   private watchdogEnabled = false
   // Watchdog arms only after the first post-resume ASR text; any generation
   // event clears it.
@@ -420,12 +422,14 @@ export class GeminiAdapter implements ProviderAdapter {
 
   sendFrame(data: string, mimeType?: string) {
     this.hasVideoInput = true
-    if (this.framesSent === 0 || this.framesSent % 30 === 0) {
-      // Cheap base64-byte estimate (length × 3/4) — actual bytes after base64
-      // decode are slightly less but this is close enough for sizing checks.
-      const approxBytes = Math.round((data.length * 3) / 4)
+    const approxBytes = Math.round((data.length * 3) / 4)
+    if (!this.videoActive) {
+      this.videoActive = true
+      log(`[gemini] screen share started (frame #${this.framesSent}: ~${(approxBytes / 1024).toFixed(0)} KB)`)
+    } else if (this.framesSent % 30 === 0) {
       log(`[gemini] frame #${this.framesSent}: ~${(approxBytes / 1024).toFixed(0)} KB`)
     }
+    this.armVideoIdleTimer()
     this.framesSent++
     this.sendUpstream({
       realtimeInput: {
@@ -438,6 +442,19 @@ export class GeminiAdapter implements ProviderAdapter {
     // Do NOT reset the watchdog here — video frames at 1 FPS should not
     // count as user activity. Only audio activity pets the watchdog so the
     // "are you still there?" prompt fires correctly during silent screen sharing.
+  }
+
+  private armVideoIdleTimer() {
+    if (this.videoIdleTimer) clearTimeout(this.videoIdleTimer)
+    // 3 s = three missed 1 FPS frames. Anything past that is almost certainly
+    // the user stopping the share, not a network blip.
+    this.videoIdleTimer = setTimeout(() => {
+      if (this.videoActive) {
+        this.videoActive = false
+        log(`[gemini] screen share stopped (after ${this.framesSent} frame${this.framesSent === 1 ? "" : "s"})`)
+      }
+      this.videoIdleTimer = null
+    }, 3000)
   }
 
   commitAudio() {
@@ -500,6 +517,10 @@ export class GeminiAdapter implements ProviderAdapter {
     this.disconnected = true
     this.clearWatchdog()
     this.clearPostResumeWatchdog()
+    if (this.videoIdleTimer) {
+      clearTimeout(this.videoIdleTimer)
+      this.videoIdleTimer = null
+    }
     if (this.upstream && this.upstream.readyState !== WebSocket.CLOSED) {
       this.upstream.close()
     }

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -657,8 +657,13 @@ export class GeminiAdapter implements ProviderAdapter {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private handleServerContent(content: any) {
-    const keys = Object.keys(content).join(", ")
-    log(`[gemini] serverContent: ${keys}`)
+    // Per-chunk modelTurn / outputTranscription deltas would log ~30 lines
+    // per assistant response — we already emit "[gemini] user: ..." and
+    // "[gemini] assistant: ..." on flush, plus distinct log lines for
+    // turn boundaries and "Response interrupted by user" further down.
+    // Surface only the meaningful state transitions here, drop the rest.
+    if (content.generationComplete) log(`[gemini] generationComplete`)
+    if (content.turnComplete) log(`[gemini] turnComplete`)
 
     // Any generation-side activity means the resumed session's turn controller
     // is healthy — cancel the post-resume watchdog.

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -614,6 +614,23 @@ export class GeminiAdapter implements ProviderAdapter {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private handleServerMessage(msg: any) {
+    // usageMetadata can ship in the same envelope as serverContent (e.g. on
+    // turnComplete). Process it before the early-returns below so we don't
+    // drop it. The dedicated usageMetadata-only branch further down covers
+    // messages where it arrives standalone.
+    if (msg.usageMetadata && (msg.serverContent || msg.toolCall)) {
+      const u = msg.usageMetadata
+      this.logUsage(u)
+      this.sendToClient?.({
+        type: "usage.metrics",
+        promptTokens: u.promptTokenCount,
+        completionTokens: u.responseTokenCount,
+        totalTokens: u.totalTokenCount,
+        inputAudioTokens: findModalityTokens(u.promptTokensDetails, "AUDIO"),
+        outputAudioTokens: findModalityTokens(u.responseTokensDetails, "AUDIO"),
+      })
+    }
+
     if (msg.serverContent) {
       this.handleServerContent(msg.serverContent)
       return
@@ -670,35 +687,36 @@ export class GeminiAdapter implements ProviderAdapter {
 
     if (msg.usageMetadata) {
       const u = msg.usageMetadata
-      const inputAudio = findModalityTokens(u.promptTokensDetails, "AUDIO")
-      const inputVideo = findModalityTokens(u.promptTokensDetails, "VIDEO")
-      const inputText = findModalityTokens(u.promptTokensDetails, "TEXT")
-      const outputAudio = findModalityTokens(u.responseTokensDetails, "AUDIO")
-      // promptTokenCount is the cumulative input tokens on the upstream side,
-      // i.e. the size of the model's running context window for this session.
-      // Show it as a fraction of the model's known limit so a climb toward
-      // the ceiling is obvious in the log.
-      const model = this.config?.model || DEFAULT_MODEL
-      const limit = contextWindowFor(model)
-      const used = u.promptTokenCount ?? 0
-      const pct = limit > 0 ? Math.round((used / limit) * 100) : 0
-      log(
-        `[gemini] context: ${formatTokens(used)} / ${formatTokens(limit)} (${pct}%) ` +
-          `audio=${formatTokens(inputAudio)}, ` +
-          `video=${formatTokens(inputVideo)}, ` +
-          `text=${formatTokens(inputText)} | ` +
-          `out ${formatTokens(u.responseTokenCount ?? 0)} (audio=${formatTokens(outputAudio)})`,
-      )
+      this.logUsage(u)
       this.sendToClient?.({
         type: "usage.metrics",
         promptTokens: u.promptTokenCount,
         completionTokens: u.responseTokenCount,
         totalTokens: u.totalTokenCount,
-        inputAudioTokens: inputAudio,
-        outputAudioTokens: outputAudio,
+        inputAudioTokens: findModalityTokens(u.promptTokensDetails, "AUDIO"),
+        outputAudioTokens: findModalityTokens(u.responseTokensDetails, "AUDIO"),
       })
       return
     }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private logUsage(u: any) {
+    const inputAudio = findModalityTokens(u.promptTokensDetails, "AUDIO")
+    const inputVideo = findModalityTokens(u.promptTokensDetails, "VIDEO")
+    const inputText = findModalityTokens(u.promptTokensDetails, "TEXT")
+    const outputAudio = findModalityTokens(u.responseTokensDetails, "AUDIO")
+    const model = this.config?.model || DEFAULT_MODEL
+    const limit = contextWindowFor(model)
+    const used = u.promptTokenCount ?? 0
+    const pct = limit > 0 ? Math.round((used / limit) * 100) : 0
+    log(
+      `[gemini] context: ${formatTokens(used)} / ${formatTokens(limit)} (${pct}%) ` +
+        `audio=${formatTokens(inputAudio)}, ` +
+        `video=${formatTokens(inputVideo)}, ` +
+        `text=${formatTokens(inputText)} | ` +
+        `out ${formatTokens(u.responseTokenCount ?? 0)} (audio=${formatTokens(outputAudio)})`,
+    )
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -662,15 +662,28 @@ export class GeminiAdapter implements ProviderAdapter {
     }
 
     if (msg.usageMetadata) {
-      log(`[gemini] Usage: ${JSON.stringify(msg.usageMetadata)}`)
       const u = msg.usageMetadata
+      const inputAudio = findModalityTokens(u.promptTokensDetails, "AUDIO")
+      const inputVideo = findModalityTokens(u.promptTokensDetails, "VIDEO")
+      const inputText = findModalityTokens(u.promptTokensDetails, "TEXT")
+      const outputAudio = findModalityTokens(u.responseTokensDetails, "AUDIO")
+      // promptTokenCount is the cumulative input tokens on the upstream side,
+      // i.e. the size of the model's running context window for this session.
+      // Print it on a single readable line so context growth before a 1007 is
+      // visible without parsing JSON.
+      log(
+        `[gemini] context: prompt=${u.promptTokenCount ?? "?"} ` +
+          `(audio=${inputAudio}, video=${inputVideo}, text=${inputText}) ` +
+          `out=${u.responseTokenCount ?? "?"} (audio=${outputAudio}) ` +
+          `total=${u.totalTokenCount ?? "?"}`,
+      )
       this.sendToClient?.({
         type: "usage.metrics",
         promptTokens: u.promptTokenCount,
         completionTokens: u.responseTokenCount,
         totalTokens: u.totalTokenCount,
-        inputAudioTokens: findModalityTokens(u.promptTokensDetails, "AUDIO"),
-        outputAudioTokens: findModalityTokens(u.responseTokensDetails, "AUDIO"),
+        inputAudioTokens: inputAudio,
+        outputAudioTokens: outputAudio,
       })
       return
     }

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -621,14 +621,19 @@ export class GeminiAdapter implements ProviderAdapter {
     if (msg.usageMetadata && (msg.serverContent || msg.toolCall)) {
       const u = msg.usageMetadata
       this.logUsage(u)
-      this.sendToClient?.({
-        type: "usage.metrics",
-        promptTokens: u.promptTokenCount,
-        completionTokens: u.responseTokenCount,
-        totalTokens: u.totalTokenCount,
-        inputAudioTokens: findModalityTokens(u.promptTokensDetails, "AUDIO"),
-        outputAudioTokens: findModalityTokens(u.responseTokensDetails, "AUDIO"),
-      })
+      // Only forward to the client when there's a meaningful prompt count.
+      // Per-chunk updates carry only an output-audio delta and would make the
+      // UI strip flicker between real values and zeros.
+      if ((u.promptTokenCount ?? 0) > 0) {
+        this.sendToClient?.({
+          type: "usage.metrics",
+          promptTokens: u.promptTokenCount,
+          completionTokens: u.responseTokenCount,
+          totalTokens: u.totalTokenCount,
+          inputAudioTokens: findModalityTokens(u.promptTokensDetails, "AUDIO"),
+          outputAudioTokens: findModalityTokens(u.responseTokensDetails, "AUDIO"),
+        })
+      }
     }
 
     if (msg.serverContent) {
@@ -688,27 +693,34 @@ export class GeminiAdapter implements ProviderAdapter {
     if (msg.usageMetadata) {
       const u = msg.usageMetadata
       this.logUsage(u)
-      this.sendToClient?.({
-        type: "usage.metrics",
-        promptTokens: u.promptTokenCount,
-        completionTokens: u.responseTokenCount,
-        totalTokens: u.totalTokenCount,
-        inputAudioTokens: findModalityTokens(u.promptTokensDetails, "AUDIO"),
-        outputAudioTokens: findModalityTokens(u.responseTokensDetails, "AUDIO"),
-      })
+      if ((u.promptTokenCount ?? 0) > 0) {
+        this.sendToClient?.({
+          type: "usage.metrics",
+          promptTokens: u.promptTokenCount,
+          completionTokens: u.responseTokenCount,
+          totalTokens: u.totalTokenCount,
+          inputAudioTokens: findModalityTokens(u.promptTokensDetails, "AUDIO"),
+          outputAudioTokens: findModalityTokens(u.responseTokensDetails, "AUDIO"),
+        })
+      }
       return
     }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private logUsage(u: any) {
+    // Gemini Live emits usageMetadata per audio chunk during a turn — most of
+    // those carry only a tiny responseTokenCount and tell us nothing about
+    // the running context window. Skip them; log only the turn-boundary
+    // updates that include the cumulative prompt count.
+    const used = u.promptTokenCount ?? 0
+    if (used <= 0) return
     const inputAudio = findModalityTokens(u.promptTokensDetails, "AUDIO")
     const inputVideo = findModalityTokens(u.promptTokensDetails, "VIDEO")
     const inputText = findModalityTokens(u.promptTokensDetails, "TEXT")
     const outputAudio = findModalityTokens(u.responseTokensDetails, "AUDIO")
     const model = this.config?.model || DEFAULT_MODEL
     const limit = contextWindowFor(model)
-    const used = u.promptTokenCount ?? 0
     const pct = limit > 0 ? Math.round((used / limit) * 100) : 0
     log(
       `[gemini] context: ${formatTokens(used)} / ${formatTokens(limit)} (${pct}%) ` +

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -716,7 +716,11 @@ export class GeminiAdapter implements ProviderAdapter {
     const used = u.promptTokenCount ?? 0
     if (used <= 0) return
     const inputAudio = findModalityTokens(u.promptTokensDetails, "AUDIO")
-    const inputVideo = findModalityTokens(u.promptTokensDetails, "VIDEO")
+    // Gemini Live counts realtimeInput.video frames under the IMAGE modality
+    // (each JPEG is tokenized as a still). Fall back to VIDEO for any model
+    // that reports it as a stream instead.
+    const inputVideo =
+      sumModalityTokens(u.promptTokensDetails, ["IMAGE", "VIDEO"])
     const inputText = findModalityTokens(u.promptTokensDetails, "TEXT")
     const outputAudio = findModalityTokens(u.responseTokensDetails, "AUDIO")
     const model = this.config?.model || DEFAULT_MODEL
@@ -1219,6 +1223,23 @@ function findModalityTokens(
   modality: string,
 ): number | undefined {
   return details?.find((d) => d.modality === modality)?.tokenCount
+}
+
+function sumModalityTokens(
+  details: { modality?: string, tokenCount?: number }[] | undefined,
+  modalities: string[],
+): number | undefined {
+  if (!details) return undefined
+  let sum = 0
+  let any = false
+  for (const m of modalities) {
+    const n = findModalityTokens(details, m)
+    if (typeof n === "number") {
+      sum += n
+      any = true
+    }
+  }
+  return any ? sum : undefined
 }
 
 function parseStatusFromErrorMessage(message: string): number | null {

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -12,6 +12,14 @@ import { mapAdapterError } from "./error-map.js"
 
 const GEMINI_WS_URL = "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
 const DEFAULT_MODEL = "gemini-3.1-flash-live-preview"
+// Per-model input-token budget for the live bidi session. Override via
+// VOICECLAW_GEMINI_CONTEXT_WINDOW if Google's published numbers shift.
+const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  "gemini-3.1-flash-live-preview": 32_768,
+  "gemini-2.5-flash-live-preview": 32_768,
+  "gemini-2.0-flash-live-preview-04-09": 32_768,
+}
+const FALLBACK_CONTEXT_WINDOW = 32_768
 const WATCHDOG_TIMEOUT_MS = 20_000
 const SETUP_TIMEOUT_MS = 15_000
 const MAX_RECONNECT_ATTEMPTS = 2
@@ -669,13 +677,18 @@ export class GeminiAdapter implements ProviderAdapter {
       const outputAudio = findModalityTokens(u.responseTokensDetails, "AUDIO")
       // promptTokenCount is the cumulative input tokens on the upstream side,
       // i.e. the size of the model's running context window for this session.
-      // Print it on a single readable line so context growth before a 1007 is
-      // visible without parsing JSON.
+      // Show it as a fraction of the model's known limit so a climb toward
+      // the ceiling is obvious in the log.
+      const model = this.config?.model || DEFAULT_MODEL
+      const limit = contextWindowFor(model)
+      const used = u.promptTokenCount ?? 0
+      const pct = limit > 0 ? Math.round((used / limit) * 100) : 0
       log(
-        `[gemini] context: prompt=${u.promptTokenCount ?? "?"} ` +
-          `(audio=${inputAudio}, video=${inputVideo}, text=${inputText}) ` +
-          `out=${u.responseTokenCount ?? "?"} (audio=${outputAudio}) ` +
-          `total=${u.totalTokenCount ?? "?"}`,
+        `[gemini] context: ${formatTokens(used)} / ${formatTokens(limit)} (${pct}%) ` +
+          `audio=${formatTokens(inputAudio)}, ` +
+          `video=${formatTokens(inputVideo)}, ` +
+          `text=${formatTokens(inputText)} | ` +
+          `out ${formatTokens(u.responseTokenCount ?? 0)} (audio=${formatTokens(outputAudio)})`,
       )
       this.sendToClient?.({
         type: "usage.metrics",
@@ -1083,6 +1096,22 @@ export class GeminiAdapter implements ProviderAdapter {
     })
     this.resetLatencyMarks()
   }
+}
+
+function contextWindowFor(model: string): number {
+  const override = process.env.VOICECLAW_GEMINI_CONTEXT_WINDOW
+  if (override) {
+    const n = Number.parseInt(override, 10)
+    if (Number.isFinite(n) && n > 0) return n
+  }
+  return MODEL_CONTEXT_WINDOWS[model] ?? FALLBACK_CONTEXT_WINDOW
+}
+
+function formatTokens(n: number | undefined | null): string {
+  if (n == null || !Number.isFinite(n) || n < 0) return "?"
+  if (n < 1000) return String(n)
+  if (n < 100_000) return `${(n / 1000).toFixed(1)}k`
+  return `${Math.round(n / 1000)}k`
 }
 
 function oneLine(s: string): string {

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -17,7 +17,6 @@ const DEFAULT_MODEL = "gemini-3.1-flash-live-preview"
 // VOICECLAW_GEMINI_CONTEXT_WINDOW if Google's published numbers shift.
 const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   "gemini-3.1-flash-live-preview": 131_072,
-  "gemini-2.5-flash-native-audio-preview-12-2025": 131_072,
 }
 const FALLBACK_CONTEXT_WINDOW = 131_072
 const WATCHDOG_TIMEOUT_MS = 20_000

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -12,12 +12,12 @@ import { mapAdapterError } from "./error-map.js"
 
 const GEMINI_WS_URL = "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
 const DEFAULT_MODEL = "gemini-3.1-flash-live-preview"
-// Per-model input-token budget for the live bidi session. Override via
+// Per-model input-token budget for the live bidi session, sourced from
+// ai.google.dev/gemini-api/docs/models. Override via
 // VOICECLAW_GEMINI_CONTEXT_WINDOW if Google's published numbers shift.
 const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   "gemini-3.1-flash-live-preview": 131_072,
-  "gemini-2.5-flash-live-preview": 32_768,
-  "gemini-2.0-flash-live-preview-04-09": 32_768,
+  "gemini-2.5-flash-native-audio-preview-12-2025": 131_072,
 }
 const FALLBACK_CONTEXT_WINDOW = 131_072
 const WATCHDOG_TIMEOUT_MS = 20_000

--- a/relay-server/src/index.ts
+++ b/relay-server/src/index.ts
@@ -35,7 +35,9 @@ app.get("/test", (req, res) => {
 
 const server = createServer(app)
 
-const wss = new WebSocketServer({ server, path: "/ws", maxPayload: 1_048_576 })
+// 4 MB headroom for screen-share frames — composite + original + strokes-png in
+// a single frame.append message can comfortably exceed the previous 1 MB cap.
+const wss = new WebSocketServer({ server, path: "/ws", maxPayload: 4 * 1_048_576 })
 
 wss.on("connection", (ws) => {
   new RelaySession(ws)

--- a/relay-server/src/instructions.ts
+++ b/relay-server/src/instructions.ts
@@ -2,6 +2,7 @@
 // Loads agent identity from brain agent workspace, adds conversation rules and context
 
 import { readFileSync, existsSync } from "node:fs"
+import { createHash } from "node:crypto"
 import { join } from "node:path"
 import { homedir } from "node:os"
 import type { SessionConfigEvent } from "./types.js"
@@ -134,7 +135,14 @@ export function buildInstructions(config: SessionConfigEvent): string {
   }
 
   const instructions = parts.join("\n\n")
-  log(`[instructions] Full prompt (${instructions.length} chars):\n---\n${instructions}\n---`)
+  // Fingerprint instead of full text: prompt drift is visible across
+  // reconnects without re-printing the whole thing every time. Set
+  // VOICECLAW_LOG_FULL_PROMPT=1 to dump the full prompt instead.
+  const sha = createHash("sha256").update(instructions).digest("hex").slice(0, 8)
+  log(`[instructions] System prompt: ${instructions.length} chars, sha=${sha}`)
+  if (process.env.VOICECLAW_LOG_FULL_PROMPT === "1") {
+    log(`[instructions] Full prompt:\n---\n${instructions}\n---`)
+  }
   return instructions
 }
 

--- a/relay-server/src/media/capture.ts
+++ b/relay-server/src/media/capture.ts
@@ -136,11 +136,13 @@ export class MediaCapture {
     t.assistantBytes += buf.byteLength
   }
 
-  onVideoFrame(base64Jpeg: string, offsetMs: number): void {
+  onVideoFrame(
+    base64Jpeg: string,
+    offsetMs: number,
+    annotation?: { original: string; strokesPng: string },
+  ): void {
     const t = this.currentTurn
     if (!t || !t.videoDir) return
-    // Lazy-create the per-turn video dir on first frame so audio-only turns
-    // don't leave empty scaffolding behind. Safe to call repeatedly.
     if (!t.videoDirReady) {
       try {
         mkdirSync(t.videoDir, { recursive: true })
@@ -150,15 +152,37 @@ export class MediaCapture {
       }
     }
     const idx = t.videoFrames.length
-    const file = `${String(idx).padStart(4, "0")}.jpeg`
+    const padded = String(idx).padStart(4, "0")
+    const file = `${padded}.jpeg`
     const abs = join(t.videoDir, file)
     try {
       const buf = Buffer.from(base64Jpeg, "base64")
-      // Track the write promise and wait for settled before finalize so
-      // timings.json can't list a frame whose JPEG hasn't landed yet.
       const p = fs.writeFile(abs, buf).catch(() => undefined)
       t.frameWrites.push(p)
-      t.videoFrames.push({ offset_ms: offsetMs, file })
+      const entry: VideoFrameEntry = { offset_ms: offsetMs, file }
+      if (annotation) {
+        const originalFile = `${padded}.original.jpeg`
+        const strokesFile = `${padded}.strokes.png`
+        try {
+          const originalBuf = Buffer.from(annotation.original, "base64")
+          t.frameWrites.push(
+            fs.writeFile(join(t.videoDir, originalFile), originalBuf).catch(() => undefined),
+          )
+          entry.original_file = originalFile
+        } catch {
+          // skip original on encode failure
+        }
+        try {
+          const strokesBuf = Buffer.from(annotation.strokesPng, "base64")
+          t.frameWrites.push(
+            fs.writeFile(join(t.videoDir, strokesFile), strokesBuf).catch(() => undefined),
+          )
+          entry.strokes_file = strokesFile
+        } catch {
+          // skip strokes on encode failure
+        }
+      }
+      t.videoFrames.push(entry)
     } catch {
       // Drop the frame on sync-encode failure — don't kill the turn.
     }
@@ -390,8 +414,15 @@ type TurnState = {
   assistantBytes: number
   videoDir: string | null
   videoDirReady: boolean
-  videoFrames: { offset_ms: number; file: string }[]
+  videoFrames: VideoFrameEntry[]
   frameWrites: Promise<void | undefined>[]
+}
+
+export type VideoFrameEntry = {
+  offset_ms: number
+  file: string
+  original_file?: string
+  strokes_file?: string
 }
 
 type CompletedTurn = {
@@ -401,7 +432,7 @@ type CompletedTurn = {
   assistantPcmPath: string | null
   assistantBytes: number
   videoDir: string | null
-  videoFrames: { offset_ms: number; file: string }[]
+  videoFrames: VideoFrameEntry[]
   turnStartRelMs: number
 }
 

--- a/relay-server/src/session.ts
+++ b/relay-server/src/session.ts
@@ -582,6 +582,7 @@ export class RelaySession {
         this.media.onVideoFrame(
           event.data,
           Math.max(0, Date.now() - this.currentTurnStartMs),
+          event.annotation,
         )
         this.adapter?.sendFrame(event.data, event.mimeType)
         break

--- a/relay-server/src/types.ts
+++ b/relay-server/src/types.ts
@@ -55,8 +55,15 @@ export interface AudioCommitEvent {
 
 export interface FrameAppendEvent {
   type: "frame.append"
-  data: string // base64 JPEG
+  data: string // base64 JPEG — composite when annotated, raw capture otherwise
   mimeType?: string // default "image/jpeg"
+  // Sibling artifacts captured alongside the composite when on-screen drawing
+  // is active. Saved into the per-turn trace as separate files; never sent
+  // upstream to the realtime model (data is what the model sees).
+  annotation?: {
+    original: string // base64 JPEG of the un-annotated capture
+    strokesPng: string // base64 PNG of strokes-only canvas, transparent background
+  }
 }
 
 export interface ResponseCreateEvent {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3299,6 +3299,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mapbox/node-pre-gyp@npm:^1.0.11":
+  version: 1.0.11
+  resolution: "@mapbox/node-pre-gyp@npm:1.0.11"
+  dependencies:
+    detect-libc: "npm:^2.0.0"
+    https-proxy-agent: "npm:^5.0.0"
+    make-dir: "npm:^3.1.0"
+    node-fetch: "npm:^2.6.7"
+    nopt: "npm:^5.0.0"
+    npmlog: "npm:^5.0.1"
+    rimraf: "npm:^3.0.2"
+    semver: "npm:^7.3.5"
+    tar: "npm:^6.1.11"
+  bin:
+    node-pre-gyp: bin/node-pre-gyp
+  checksum: 10/59529a2444e44fddb63057152452b00705aa58059079191126c79ac1388ae4565625afa84ed4dd1bf017d1111ab6e47907f7c5192e06d83c9496f2f3e708680a
+  languageName: node
+  linkType: hard
+
 "@mdx-js/mdx@npm:^3.1.1":
   version: 3.1.1
   resolution: "@mdx-js/mdx@npm:3.1.1"
@@ -3552,6 +3571,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@npmcli/agent@npm:^2.0.0":
+  version: 2.2.2
+  resolution: "@npmcli/agent@npm:2.2.2"
+  dependencies:
+    agent-base: "npm:^7.1.0"
+    http-proxy-agent: "npm:^7.0.0"
+    https-proxy-agent: "npm:^7.0.1"
+    lru-cache: "npm:^10.0.1"
+    socks-proxy-agent: "npm:^8.0.3"
+  checksum: 10/96fc0036b101bae5032dc2a4cd832efb815ce9b33f9ee2f29909ee49d96a0026b3565f73c507a69eb8603f5cb32e0ae45a70cab1e2655990a4e06ae99f7f572a
+  languageName: node
+  linkType: hard
+
 "@npmcli/agent@npm:^4.0.0":
   version: 4.0.0
   resolution: "@npmcli/agent@npm:4.0.0"
@@ -3562,6 +3594,15 @@ __metadata:
     lru-cache: "npm:^11.2.1"
     socks-proxy-agent: "npm:^8.0.3"
   checksum: 10/1a81573becc60515031accc696e6405e9b894e65c12b98ef4aeee03b5617c41948633159dbf6caf5dde5b47367eeb749bdc7b7dfb21960930a9060a935c6f636
+  languageName: node
+  linkType: hard
+
+"@npmcli/fs@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "@npmcli/fs@npm:3.1.1"
+  dependencies:
+    semver: "npm:^7.3.5"
+  checksum: 10/1e0e04087049b24b38bc0b30d87a9388ee3ca1d3fdfc347c2f77d84fcfe6a51f250bc57ba2c1f614d7e4285c6c62bf8c769bc19aa0949ea39e5b043ee023b0bd
   languageName: node
   linkType: hard
 
@@ -7492,6 +7533,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abbrev@npm:1":
+  version: 1.1.1
+  resolution: "abbrev@npm:1.1.1"
+  checksum: 10/2d882941183c66aa665118bafdab82b7a177e9add5eb2776c33e960a4f3c89cff88a1b38aba13a456de01d0dd9d66a8bea7c903268b21ea91dd1097e1e2e8243
+  languageName: node
+  linkType: hard
+
+"abbrev@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "abbrev@npm:2.0.0"
+  checksum: 10/ca0a54e35bea4ece0ecb68a47b312e1a9a6f772408d5bcb9051230aaa94b0460671c5b5c9cb3240eb5b7bc94c52476550eb221f65a0bbd0145bdc9f3113a6707
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^4.0.0":
   version: 4.0.0
   resolution: "abbrev@npm:4.0.0"
@@ -7555,10 +7610,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"agent-base@npm:6":
+  version: 6.0.2
+  resolution: "agent-base@npm:6.0.2"
+  dependencies:
+    debug: "npm:4"
+  checksum: 10/21fb903e0917e5cb16591b4d0ef6a028a54b83ac30cd1fca58dece3d4e0990512a8723f9f83130d88a41e2af8b1f7be1386fda3ea2d181bb1a62155e75e95e23
+  languageName: node
+  linkType: hard
+
 "agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
   version: 7.1.4
   resolution: "agent-base@npm:7.1.4"
   checksum: 10/79bef167247789f955aaba113bae74bf64aa1e1acca4b1d6bb444bdf91d82c3e07e9451ef6a6e2e35e8f71a6f97ce33e3d855a5328eb9fad1bc3cc4cfd031ed8
+  languageName: node
+  linkType: hard
+
+"aggregate-error@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "aggregate-error@npm:3.1.0"
+  dependencies:
+    clean-stack: "npm:^2.0.0"
+    indent-string: "npm:^4.0.0"
+  checksum: 10/1101a33f21baa27a2fa8e04b698271e64616b886795fd43c31068c07533c7b3facfcaf4e9e0cab3624bd88f729a592f1c901a1a229c9e490eafce411a8644b79
   languageName: node
   linkType: hard
 
@@ -7773,6 +7847,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aproba@npm:^1.0.3 || ^2.0.0":
+  version: 2.1.0
+  resolution: "aproba@npm:2.1.0"
+  checksum: 10/cb0e335ac398027d43bf4a139337363e161fa10a642291f7ad5068a2e24797be58270775047cba901a7c1ce945a05c7535b13f6457993517cd7dca40c9b00a00
+  languageName: node
+  linkType: hard
+
 "archiver-utils@npm:^5.0.0, archiver-utils@npm:^5.0.2":
   version: 5.0.2
   resolution: "archiver-utils@npm:5.0.2"
@@ -7811,6 +7892,16 @@ __metadata:
     "@oslojs/encoding": "npm:1.1.0"
     "@oslojs/jwt": "npm:0.2.0"
   checksum: 10/7e98cbc36bec32c2faa25f4200854361d1645ce9bb45291b2ede848cd0f01b0831f481adebd8e5a2cf4532872529394b470cad00027aadbe60f3c9a990454f6b
+  languageName: node
+  linkType: hard
+
+"are-we-there-yet@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "are-we-there-yet@npm:2.0.0"
+  dependencies:
+    delegates: "npm:^1.0.0"
+    readable-stream: "npm:^3.6.0"
+  checksum: 10/ea6f47d14fc33ae9cbea3e686eeca021d9d7b9db83a306010dd04ad5f2c8b7675291b127d3fcbfcbd8fec26e47b3324ad5b469a6cc3733a582f2fe4e12fc6756
   languageName: node
   linkType: hard
 
@@ -8891,6 +8982,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cacache@npm:^18.0.0":
+  version: 18.0.4
+  resolution: "cacache@npm:18.0.4"
+  dependencies:
+    "@npmcli/fs": "npm:^3.1.0"
+    fs-minipass: "npm:^3.0.0"
+    glob: "npm:^10.2.2"
+    lru-cache: "npm:^10.0.1"
+    minipass: "npm:^7.0.3"
+    minipass-collect: "npm:^2.0.1"
+    minipass-flush: "npm:^1.0.5"
+    minipass-pipeline: "npm:^1.2.4"
+    p-map: "npm:^4.0.0"
+    ssri: "npm:^10.0.0"
+    tar: "npm:^6.1.11"
+    unique-filename: "npm:^3.0.0"
+  checksum: 10/ca2f7b2d3003f84d362da9580b5561058ccaecd46cba661cbcff0375c90734b610520d46b472a339fd032d91597ad6ed12dde8af81571197f3c9772b5d35b104
+  languageName: node
+  linkType: hard
+
 "cacache@npm:^20.0.1":
   version: 20.0.4
   resolution: "cacache@npm:20.0.4"
@@ -9161,6 +9272,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chownr@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "chownr@npm:2.0.0"
+  checksum: 10/c57cf9dd0791e2f18a5ee9c1a299ae6e801ff58fee96dc8bfd0dcb4738a6ce58dd252a3605b1c93c6418fe4f9d5093b28ffbf4d66648cb2a9c67eaef9679be2f
+  languageName: node
+  linkType: hard
+
 "chownr@npm:^3.0.0":
   version: 3.0.0
   resolution: "chownr@npm:3.0.0"
@@ -9244,6 +9362,13 @@ __metadata:
   dependencies:
     clsx: "npm:^2.1.1"
   checksum: 10/27a1face3f5ee88caa7813743461977aef5110830dc8e8960e7c9570598b37ffb8b2760b4e5d738dc827b0eb9058ddd204e9002e9af0ef39b6851f6ea9aa82c1
+  languageName: node
+  linkType: hard
+
+"clean-stack@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "clean-stack@npm:2.2.0"
+  checksum: 10/2ac8cd2b2f5ec986a3c743935ec85b07bc174d5421a5efc8017e1f146a1cf5f781ae962618f416352103b32c9cd7e203276e8c28241bbe946160cab16149fb68
   languageName: node
   linkType: hard
 
@@ -9383,6 +9508,15 @@ __metadata:
     color-name: "npm:^1.0.0"
     simple-swizzle: "npm:^0.2.2"
   checksum: 10/72aa0b81ee71b3f4fb1ac9cd839cdbd7a011a7d318ef58e6cb13b3708dca75c7e45029697260488709f1b1c7ac4e35489a87e528156c1e365917d1c4ccb9b9cd
+  languageName: node
+  linkType: hard
+
+"color-support@npm:^1.1.2":
+  version: 1.1.3
+  resolution: "color-support@npm:1.1.3"
+  bin:
+    color-support: bin.js
+  checksum: 10/4bcfe30eea1498fe1cabc852bbda6c9770f230ea0e4faf4611c5858b1b9e4dde3730ac485e65f54ca182f4c50b626c1bea7c8441ceda47367a54a818c248aa7a
   languageName: node
   linkType: hard
 
@@ -9576,6 +9710,13 @@ __metadata:
     parseurl: "npm:~1.3.3"
     utils-merge: "npm:1.0.1"
   checksum: 10/f94818b198cc662092276ef6757dd825c59c8469c8064583525e7b81d39a3af86a01c7cb76107dfa0295dfc52b27a7ae1c40ea0e0a10189c3f8776cf08ce3a4e
+  languageName: node
+  linkType: hard
+
+"console-control-strings@npm:^1.0.0, console-control-strings@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "console-control-strings@npm:1.1.0"
+  checksum: 10/27b5fa302bc8e9ae9e98c03c66d76ca289ad0c61ce2fe20ab288d288bee875d217512d2edb2363fc83165e88f1c405180cf3f5413a46e51b4fe1a004840c6cdb
   languageName: node
   linkType: hard
 
@@ -10484,6 +10625,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"delegates@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "delegates@npm:1.0.0"
+  checksum: 10/a51744d9b53c164ba9c0492471a1a2ffa0b6727451bdc89e31627fdf4adda9d51277cfcbfb20f0a6f08ccb3c436f341df3e92631a3440226d93a8971724771fd
+  languageName: node
+  linkType: hard
+
 "denque@npm:^2.1.0":
   version: 2.1.0
   resolution: "denque@npm:2.1.0"
@@ -10947,6 +11095,15 @@ __metadata:
   version: 1.0.2
   resolution: "encodeurl@npm:1.0.2"
   checksum: 10/e50e3d508cdd9c4565ba72d2012e65038e5d71bdc9198cb125beb6237b5b1ade6c0d343998da9e170fb2eae52c1bed37d4d6d98a46ea423a0cddbed5ac3f780c
+  languageName: node
+  linkType: hard
+
+"encoding@npm:^0.1.13":
+  version: 0.1.13
+  resolution: "encoding@npm:0.1.13"
+  dependencies:
+    iconv-lite: "npm:^0.6.2"
+  checksum: 10/bb98632f8ffa823996e508ce6a58ffcf5856330fde839ae42c9e1f436cc3b5cc651d4aeae72222916545428e54fd0f6aa8862fd8d25bdbcc4589f1e3f3715e7f
   languageName: node
   linkType: hard
 
@@ -12799,6 +12956,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-minipass@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "fs-minipass@npm:2.1.0"
+  dependencies:
+    minipass: "npm:^3.0.0"
+  checksum: 10/03191781e94bc9a54bd376d3146f90fe8e082627c502185dbf7b9b3032f66b0b142c1115f3b2cc5936575fc1b44845ce903dd4c21bec2a8d69f3bd56f9cee9ec
+  languageName: node
+  linkType: hard
+
 "fs-minipass@npm:^3.0.0":
   version: 3.0.3
   resolution: "fs-minipass@npm:3.0.3"
@@ -12866,6 +13032,23 @@ __metadata:
   version: 3.1.0
   resolution: "fuzzysort@npm:3.1.0"
   checksum: 10/6220e62ff00c0855c7e8d38714ed5ba9641e14ca2e2b793229965d7b6d03a14783bf04ecc169033a4429898ccb28b3c77e45ac73abd6d4647920705832b0cb71
+  languageName: node
+  linkType: hard
+
+"gauge@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "gauge@npm:3.0.2"
+  dependencies:
+    aproba: "npm:^1.0.3 || ^2.0.0"
+    color-support: "npm:^1.1.2"
+    console-control-strings: "npm:^1.0.0"
+    has-unicode: "npm:^2.0.1"
+    object-assign: "npm:^4.1.1"
+    signal-exit: "npm:^3.0.0"
+    string-width: "npm:^4.2.3"
+    strip-ansi: "npm:^6.0.1"
+    wide-align: "npm:^1.1.2"
+  checksum: 10/46df086451672a5fecd58f7ec86da74542c795f8e00153fbef2884286ce0e86653c3eb23be2d0abb0c4a82b9b2a9dec3b09b6a1cf31c28085fa0376599a26589
   languageName: node
   linkType: hard
 
@@ -13029,6 +13212,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-windows@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "get-windows@npm:9.3.0"
+  dependencies:
+    "@mapbox/node-pre-gyp": "npm:^1.0.11"
+    node-addon-api: "npm:^8.1.0"
+    node-gyp: "npm:^10.2.0"
+  peerDependencies:
+    node-gyp: ^10.1.0
+  dependenciesMeta:
+    "@mapbox/node-pre-gyp":
+      optional: true
+    node-addon-api:
+      optional: true
+    node-gyp:
+      optional: true
+  peerDependenciesMeta:
+    node-gyp:
+      optional: true
+  checksum: 10/1935ce588dd64f419984cf30dd888241cdc2fe66c09034abe1697febbaf59140da4a54aae167eb69a3a35c81eb8d8a26e3f75d2d855752e225f7b1a8c05eb5ef
+  languageName: node
+  linkType: hard
+
 "getenv@npm:^2.0.0":
   version: 2.0.0
   resolution: "getenv@npm:2.0.0"
@@ -13077,7 +13283,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.0.0":
+"glob@npm:^10.0.0, glob@npm:^10.2.2, glob@npm:^10.3.10":
   version: 10.5.0
   resolution: "glob@npm:10.5.0"
   dependencies:
@@ -13295,6 +13501,13 @@ __metadata:
   dependencies:
     has-symbols: "npm:^1.0.3"
   checksum: 10/c74c5f5ceee3c8a5b8bc37719840dc3749f5b0306d818974141dda2471a1a2ca6c8e46b9d6ac222c5345df7a901c9b6f350b1e6d62763fec877e26609a401bfe
+  languageName: node
+  linkType: hard
+
+"has-unicode@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "has-unicode@npm:2.0.1"
+  checksum: 10/041b4293ad6bf391e21c5d85ed03f412506d6623786b801c4ab39e4e6ca54993f13201bceb544d92963f9e0024e6e7fbf0cb1d84c9d6b31cb9c79c8c990d13d8
   languageName: node
   linkType: hard
 
@@ -13763,6 +13976,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"https-proxy-agent@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "https-proxy-agent@npm:5.0.1"
+  dependencies:
+    agent-base: "npm:6"
+    debug: "npm:4"
+  checksum: 10/f0dce7bdcac5e8eaa0be3c7368bb8836ed010fb5b6349ffb412b172a203efe8f807d9a6681319105ea1b6901e1972c7b5ea899672a7b9aad58309f766dcbe0df
+  languageName: node
+  linkType: hard
+
 "https-proxy-agent@npm:^7.0.0, https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.5, https-proxy-agent@npm:^7.0.6":
   version: 7.0.6
   resolution: "https-proxy-agent@npm:7.0.6"
@@ -13896,6 +14119,13 @@ __metadata:
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
   checksum: 10/2d30b157a91fe1c1d7c6f653cbf263f039be6c5bfa959245a16d4ee191fc0f2af86c08545b6e6beeb041c56b574d2d5b9f95343d378ab49c0f37394d541e7fc8
+  languageName: node
+  linkType: hard
+
+"indent-string@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "indent-string@npm:4.0.0"
+  checksum: 10/cd3f5cbc9ca2d624c6a1f53f12e6b341659aba0e2d3254ae2b4464aaea8b4294cdb09616abbc59458f980531f2429784ed6a420d48d245bcad0811980c9efae9
   languageName: node
   linkType: hard
 
@@ -14231,6 +14461,13 @@ __metadata:
   version: 2.0.0
   resolution: "is-interactive@npm:2.0.0"
   checksum: 10/e8d52ad490bed7ae665032c7675ec07732bbfe25808b0efbc4d5a76b1a1f01c165f332775c63e25e9a03d319ebb6b24f571a9e902669fc1e40b0a60b5be6e26c
+  languageName: node
+  linkType: hard
+
+"is-lambda@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-lambda@npm:1.0.1"
+  checksum: 10/93a32f01940220532e5948538699ad610d5924ac86093fcee83022252b363eb0cc99ba53ab084a04e4fb62bf7b5731f55496257a4c38adf87af9c4d352c71c35
   languageName: node
   linkType: hard
 
@@ -15454,6 +15691,35 @@ __metadata:
     "@babel/types": "npm:^7.29.0"
     source-map-js: "npm:^1.2.1"
   checksum: 10/724d47bfa70cc5046992cf6defae51a3cb701307b35e5637faede1b109fb19ccb47d3f3886df569f5b1281deb6a1ae6993f4542e7c7c6312f70d7be0f4194833
+  languageName: node
+  linkType: hard
+
+"make-dir@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "make-dir@npm:3.1.0"
+  dependencies:
+    semver: "npm:^6.0.0"
+  checksum: 10/484200020ab5a1fdf12f393fe5f385fc8e4378824c940fba1729dcd198ae4ff24867bc7a5646331e50cead8abff5d9270c456314386e629acec6dff4b8016b78
+  languageName: node
+  linkType: hard
+
+"make-fetch-happen@npm:^13.0.0":
+  version: 13.0.1
+  resolution: "make-fetch-happen@npm:13.0.1"
+  dependencies:
+    "@npmcli/agent": "npm:^2.0.0"
+    cacache: "npm:^18.0.0"
+    http-cache-semantics: "npm:^4.1.1"
+    is-lambda: "npm:^1.0.1"
+    minipass: "npm:^7.0.2"
+    minipass-fetch: "npm:^3.0.0"
+    minipass-flush: "npm:^1.0.5"
+    minipass-pipeline: "npm:^1.2.4"
+    negotiator: "npm:^0.6.3"
+    proc-log: "npm:^4.2.0"
+    promise-retry: "npm:^2.0.1"
+    ssri: "npm:^10.0.0"
+  checksum: 10/11bae5ad6ac59b654dbd854f30782f9de052186c429dfce308eda42374528185a100ee40ac9ffdc36a2b6c821ecaba43913e4730a12f06f15e895ea9cb23fa59
   languageName: node
   linkType: hard
 
@@ -16708,6 +16974,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minipass-fetch@npm:^3.0.0":
+  version: 3.0.5
+  resolution: "minipass-fetch@npm:3.0.5"
+  dependencies:
+    encoding: "npm:^0.1.13"
+    minipass: "npm:^7.0.3"
+    minipass-sized: "npm:^1.0.3"
+    minizlib: "npm:^2.1.2"
+  dependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 10/c669948bec1373313aaa8f104b962a3ced9f45c49b26366a4b0ae27ccdfa9c5740d72c8a84d3f8623d7a61c5fc7afdfda44789008c078f61a62441142efc4a97
+  languageName: node
+  linkType: hard
+
 "minipass-fetch@npm:^5.0.0":
   version: 5.0.2
   resolution: "minipass-fetch@npm:5.0.2"
@@ -16741,6 +17022,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minipass-sized@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "minipass-sized@npm:1.0.3"
+  dependencies:
+    minipass: "npm:^3.0.0"
+  checksum: 10/40982d8d836a52b0f37049a0a7e5d0f089637298e6d9b45df9c115d4f0520682a78258905e5c8b180fb41b593b0a82cc1361d2c74b45f7ada66334f84d1ecfdd
+  languageName: node
+  linkType: hard
+
 "minipass-sized@npm:^2.0.0":
   version: 2.0.0
   resolution: "minipass-sized@npm:2.0.0"
@@ -16759,10 +17049,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minipass@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "minipass@npm:5.0.0"
+  checksum: 10/61682162d29f45d3152b78b08bab7fb32ca10899bc5991ffe98afc18c9e9543bd1e3be94f8b8373ba6262497db63607079dc242ea62e43e7b2270837b7347c93
+  languageName: node
+  linkType: hard
+
 "minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2, minipass@npm:^7.1.3":
   version: 7.1.3
   resolution: "minipass@npm:7.1.3"
   checksum: 10/175e4d5e20980c3cd316ae82d2c031c42f6c746467d8b1905b51060a0ba4461441a0c25bb67c025fd9617f9a3873e152c7b543c6b5ac83a1846be8ade80dffd6
+  languageName: node
+  linkType: hard
+
+"minizlib@npm:^2.1.1, minizlib@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "minizlib@npm:2.1.2"
+  dependencies:
+    minipass: "npm:^3.0.0"
+    yallist: "npm:^4.0.0"
+  checksum: 10/ae0f45436fb51344dcb87938446a32fbebb540d0e191d63b35e1c773d47512e17307bf54aa88326cc6d176594d00e4423563a091f7266c2f9a6872cdc1e234d1
   languageName: node
   linkType: hard
 
@@ -16782,7 +17089,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^1.0.4":
+"mkdirp@npm:^1.0.3, mkdirp@npm:^1.0.4":
   version: 1.0.4
   resolution: "mkdirp@npm:1.0.4"
   bin:
@@ -16967,17 +17274,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"negotiator@npm:^0.6.3, negotiator@npm:~0.6.4":
+  version: 0.6.4
+  resolution: "negotiator@npm:0.6.4"
+  checksum: 10/d98c04a136583afd055746168f1067d58ce4bfe6e4c73ca1d339567f81ea1f7e665b5bd1e81f4771c67b6c2ea89b21cb2adaea2b16058c7dc31317778f931dab
+  languageName: node
+  linkType: hard
+
 "negotiator@npm:^1.0.0":
   version: 1.0.0
   resolution: "negotiator@npm:1.0.0"
   checksum: 10/b5734e87295324fabf868e36fb97c84b7d7f3156ec5f4ee5bf6e488079c11054f818290fc33804cef7b1ee21f55eeb14caea83e7dafae6492a409b3e573153e5
-  languageName: node
-  linkType: hard
-
-"negotiator@npm:~0.6.4":
-  version: 0.6.4
-  resolution: "negotiator@npm:0.6.4"
-  checksum: 10/d98c04a136583afd055746168f1067d58ce4bfe6e4c73ca1d339567f81ea1f7e665b5bd1e81f4771c67b6c2ea89b21cb2adaea2b16058c7dc31317778f931dab
   languageName: node
   linkType: hard
 
@@ -17093,6 +17400,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-addon-api@npm:^8.1.0":
+  version: 8.7.0
+  resolution: "node-addon-api@npm:8.7.0"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10/a384774d04f019fc32745b9168fab8d4b91df2d7558a57c91e6d87e00acab3c9a08292c074a3c0efb5d4f4adaf1b79cb65c002a3fbcafd8d3d5b3dc91d0ac495
+  languageName: node
+  linkType: hard
+
 "node-api-version@npm:^0.2.1":
   version: 0.2.1
   resolution: "node-api-version@npm:0.2.1"
@@ -17128,7 +17444,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.7.0":
+"node-fetch@npm:^2.6.7, node-fetch@npm:^2.7.0":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -17157,6 +17473,26 @@ __metadata:
   version: 1.4.0
   resolution: "node-forge@npm:1.4.0"
   checksum: 10/d70fd769768e646eda73343d4d4105ccb6869315d975905a22117431c04ae5b6df6c488e34ed275b1a66b50195a09b84b5c8aeca3b8605c20605fcb8e9f109d9
+  languageName: node
+  linkType: hard
+
+"node-gyp@npm:^10.2.0":
+  version: 10.3.1
+  resolution: "node-gyp@npm:10.3.1"
+  dependencies:
+    env-paths: "npm:^2.2.0"
+    exponential-backoff: "npm:^3.1.1"
+    glob: "npm:^10.3.10"
+    graceful-fs: "npm:^4.2.6"
+    make-fetch-happen: "npm:^13.0.0"
+    nopt: "npm:^7.0.0"
+    proc-log: "npm:^4.1.0"
+    semver: "npm:^7.3.5"
+    tar: "npm:^6.2.1"
+    which: "npm:^4.0.0"
+  bin:
+    node-gyp: bin/node-gyp.js
+  checksum: 10/d3004f648559e42d7ec8791ea75747fe8a163a6061c202e311e5d7a5f6266baa9a5f5c6fde7be563974c88b030c5d0855fd945364f52fcd230d2a2ceee7be80d
   languageName: node
   linkType: hard
 
@@ -17228,6 +17564,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nopt@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "nopt@npm:5.0.0"
+  dependencies:
+    abbrev: "npm:1"
+  bin:
+    nopt: bin/nopt.js
+  checksum: 10/00f9bb2d16449469ba8ffcf9b8f0eae6bae285ec74b135fec533e5883563d2400c0cd70902d0a7759e47ac031ccf206ace4e86556da08ed3f1c66dda206e9ccd
+  languageName: node
+  linkType: hard
+
+"nopt@npm:^7.0.0":
+  version: 7.2.1
+  resolution: "nopt@npm:7.2.1"
+  dependencies:
+    abbrev: "npm:^2.0.0"
+  bin:
+    nopt: bin/nopt.js
+  checksum: 10/95a1f6dec8a81cd18cdc2fed93e6f0b4e02cf6bdb4501c848752c6e34f9883d9942f036a5e3b21a699047d8a448562d891e67492df68ec9c373e6198133337ae
+  languageName: node
+  linkType: hard
+
 "nopt@npm:^9.0.0":
   version: 9.0.0
   resolution: "nopt@npm:9.0.0"
@@ -17281,6 +17639,18 @@ __metadata:
     path-key: "npm:^4.0.0"
     unicorn-magic: "npm:^0.3.0"
   checksum: 10/1a1b50aba6e6af7fd34a860ba2e252e245c4a59b316571a990356417c0cdf0414cabf735f7f52d9c330899cb56f0ab804a8e21fb12a66d53d7843e39ada4a3b6
+  languageName: node
+  linkType: hard
+
+"npmlog@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "npmlog@npm:5.0.1"
+  dependencies:
+    are-we-there-yet: "npm:^2.0.0"
+    console-control-strings: "npm:^1.1.0"
+    gauge: "npm:^3.0.0"
+    set-blocking: "npm:^2.0.0"
+  checksum: 10/f42c7b9584cdd26a13c41a21930b6f5912896b6419ab15be88cc5721fc792f1c3dd30eb602b26ae08575694628ba70afdcf3675d86e4f450fc544757e52726ec
   languageName: node
   linkType: hard
 
@@ -17656,6 +18026,15 @@ __metadata:
   dependencies:
     p-limit: "npm:^3.0.2"
   checksum: 10/1623088f36cf1cbca58e9b61c4e62bf0c60a07af5ae1ca99a720837356b5b6c5ba3eb1b2127e47a06865fee59dd0453cad7cc844cda9d5a62ac1a5a51b7c86d3
+  languageName: node
+  linkType: hard
+
+"p-map@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "p-map@npm:4.0.0"
+  dependencies:
+    aggregate-error: "npm:^3.0.0"
+  checksum: 10/7ba4a2b1e24c05e1fc14bbaea0fc6d85cf005ae7e9c9425d4575550f37e2e584b1af97bcde78eacd7559208f20995988d52881334db16cf77bc1bcf68e48ed7c
   languageName: node
   linkType: hard
 
@@ -18505,7 +18884,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proc-log@npm:^4.0.0":
+"proc-log@npm:^4.0.0, proc-log@npm:^4.1.0, proc-log@npm:^4.2.0":
   version: 4.2.0
   resolution: "proc-log@npm:4.2.0"
   checksum: 10/4e1394491b717f6c1ade15c570ecd4c2b681698474d3ae2d303c1e4b6ab9455bd5a81566211e82890d5a5ae9859718cc6954d5150bb18b09b72ecb297beae90a
@@ -19136,7 +19515,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0":
+"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -20106,7 +20485,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^6.2.0, semver@npm:^6.3.0, semver@npm:^6.3.1":
+"semver@npm:^6.0.0, semver@npm:^6.2.0, semver@npm:^6.3.0, semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
   bin:
@@ -20224,6 +20603,13 @@ __metadata:
   version: 0.0.1
   resolution: "server-only@npm:0.0.1"
   checksum: 10/c432348956641ea3f460af8dc3765f3a1bdbcf7a1e0205b0756d868e6e6fe8934cdee6bff68401a1dd49ba4a831c75916517a877446d54b334f7de36fa273e53
+  languageName: node
+  linkType: hard
+
+"set-blocking@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "set-blocking@npm:2.0.0"
+  checksum: 10/8980ebf7ae9eb945bb036b6e283c547ee783a1ad557a82babf758a065e2fb6ea337fd82cac30dd565c1e606e423f30024a19fff7afbf4977d784720c4026a8ef
   languageName: node
   linkType: hard
 
@@ -20530,7 +20916,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
+"signal-exit@npm:^3.0.0, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: 10/a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
@@ -20752,6 +21138,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ssri@npm:^10.0.0":
+  version: 10.0.6
+  resolution: "ssri@npm:10.0.6"
+  dependencies:
+    minipass: "npm:^7.0.3"
+  checksum: 10/f92c1b3cc9bfd0a925417412d07d999935917bc87049f43ebec41074661d64cf720315661844106a77da9f8204b6d55ae29f9514e673083cae39464343af2a8b
+  languageName: node
+  linkType: hard
+
 "ssri@npm:^13.0.0":
   version: 13.0.1
   resolution: "ssri@npm:13.0.1"
@@ -20891,7 +21286,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -21352,6 +21747,20 @@ __metadata:
     fast-fifo: "npm:^1.2.0"
     streamx: "npm:^2.15.0"
   checksum: 10/ce57a81521de73ae7a3b7d55a08da50d6771427c249bfa89a208518e48faf5254c8fa7201a8f5419ab8bde9601a74e6dd512b31a13ec89774aec96178f99a8d3
+  languageName: node
+  linkType: hard
+
+"tar@npm:^6.1.11, tar@npm:^6.2.1":
+  version: 6.2.1
+  resolution: "tar@npm:6.2.1"
+  dependencies:
+    chownr: "npm:^2.0.0"
+    fs-minipass: "npm:^2.0.0"
+    minipass: "npm:^5.0.0"
+    minizlib: "npm:^2.1.1"
+    mkdirp: "npm:^1.0.3"
+    yallist: "npm:^4.0.0"
+  checksum: 10/bfbfbb2861888077fc1130b84029cdc2721efb93d1d1fb80f22a7ac3a98ec6f8972f29e564103bbebf5e97be67ebc356d37fa48dbc4960600a1eb7230fbd1ea0
   languageName: node
   linkType: hard
 
@@ -22054,6 +22463,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unique-filename@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "unique-filename@npm:3.0.0"
+  dependencies:
+    unique-slug: "npm:^4.0.0"
+  checksum: 10/8e2f59b356cb2e54aab14ff98a51ac6c45781d15ceaab6d4f1c2228b780193dc70fae4463ce9e1df4479cb9d3304d7c2043a3fb905bdeca71cc7e8ce27e063df
+  languageName: node
+  linkType: hard
+
+"unique-slug@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "unique-slug@npm:4.0.0"
+  dependencies:
+    imurmurhash: "npm:^0.1.4"
+  checksum: 10/40912a8963fc02fb8b600cf50197df4a275c602c60de4cac4f75879d3c48558cfac48de08a25cc10df8112161f7180b3bbb4d662aadb711568602f9eddee54f0
+  languageName: node
+  linkType: hard
+
 "unist-util-find-after@npm:^5.0.0":
   version: 5.0.0
   resolution: "unist-util-find-after@npm:5.0.0"
@@ -22734,6 +23161,7 @@ __metadata:
     electron-builder: "npm:^26.8.1"
     electron-updater: "npm:^6.6.2"
     electron-vite: "npm:^5.0.0"
+    get-windows: "npm:^9.3.0"
     lucide-react: "npm:^1.11.0"
     postcss: "npm:^8.5.3"
     posthog-js: "npm:^1.372.1"
@@ -23135,6 +23563,15 @@ __metadata:
   bin:
     why-is-node-running: cli.js
   checksum: 10/0de6e6cd8f2f94a8b5ca44e84cf1751eadcac3ebedcdc6e5fbbe6c8011904afcbc1a2777c53496ec02ced7b81f2e7eda61e76bf8262a8bc3ceaa1f6040508051
+  languageName: node
+  linkType: hard
+
+"wide-align@npm:^1.1.2":
+  version: 1.1.5
+  resolution: "wide-align@npm:1.1.5"
+  dependencies:
+    string-width: "npm:^1.0.2 || 2 || 3 || 4"
+  checksum: 10/d5f8027b9a8255a493a94e4ec1b74a27bff6679d5ffe29316a3215e4712945c84ef73ca4045c7e20ae7d0c72f5f57f296e04a4928e773d4276a2f1222e4c2e99
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

So I can circle things on my screen while talking to Gemini and have the model actually see what I'm pointing at — instead of using my voice to describe spatial layout. Two tools, deliberately small: **Draw** (freehand) and **Clear**. Works whether I'm sharing a full display or a single application window.

Strokes are composited into the captured JPEG **in the renderer** before it goes upstream, so it works for any source type. The trace keeps the un-annotated capture + a strokes-only PNG as sibling files next to the composite, so I can see both in the log.

## Screenshots

The UI is one button strip — `Draw` `Clear` `Stop` — that only renders while a Gemini call is active *and* a screen is being shared. Driving that combined runtime state from headless Playwright would require a real WSS session and a real screen capture source, so no captures attached. Will add screenshots after manual verification.

<details>
<summary>Test plan</summary>

- [ ] `yarn workspace voiceclaw-desktop dev` boots without main-process errors
- [ ] Start a Gemini call, share a full display — overlay window appears, click-through works
- [ ] Click **Draw** — cursor becomes crosshair, scribble draws an orange stroke over the screen
- [ ] Ask Gemini "what did I just draw on the screen?" — answer matches what was drawn
- [ ] Click **Clear** — strokes vanish from the overlay; next captured frame has no strokes
- [ ] Click **Stop** — overlay hides, draw mode resets
- [ ] Repeat the test sharing a **single window** (e.g., Chrome): strokes drawn over the window must land at the matching position in the captured frame, even after moving/resizing the window
- [ ] Per-turn trace dir under the relay's session media folder contains `NNNN.jpeg` (composite), `NNNN.original.jpeg`, and `NNNN.strokes.png` for ticks where strokes were present
- [ ] Verify VoiceClaw is still reachable via Cmd+Tab and the Dock during screen share (skipTransformProcessType regression check)
</details>

<details>
<summary>Implementation notes</summary>

**Architecture**
- New transparent always-on-top `BrowserWindow` (`desktop/src/main/draw-overlay.ts`) sized to the shared display. Click-through by default (`setIgnoreMouseEvents(true, { forward: true })`); switches to interactive when draw mode is on.
- Renderer route `?view=draw-overlay` mounts `DrawCanvas` which captures pointer events, stores polylines in display-CSS-coords, and ships them to main, which forwards to the chat renderer.
- `ScreenCapture` accepts an `AnnotationProvider` exposing a `SourceContext`:
  - `display` kind → composite at `scale = frame_w / display_w`
  - `window` kind with `windowBounds` → subtract origin, scale by `frame_w / window_w`, points outside the window's rect are clipped on draw
- For window sources, ChatPage polls `screen:getWindowBounds(windowId)` at 1 Hz so strokes track window moves/resizes.

**Wire protocol**
- `frame.append` (relay client→server) gains an optional `annotation: { original, strokesPng }` field. Composite is forwarded to Gemini as before; sibling artifacts are saved to the per-turn dir.
- `media.onVideoFrame` writes `NNNN.original.jpeg` + `NNNN.strokes.png` alongside the canonical `NNNN.jpeg` when annotation is present.

**Window bounds**
- macOS-only path uses [`get-windows`](https://github.com/sindresorhus/get-windows) (Sindre, MIT, prebuilt Swift binary, ~313 kB). Parses the CGWindowID out of the chromeMediaSourceId (`window:<id>:<displayId>`) and resolves live screen-rect via `openWindows()`.
- Polling interval: 1 s. Lookup failures fall back to display-scaling (best-effort) without crashing.

**Non-goals for v1**
- No color picker, no eraser, no thickness control. Two tools, single rust stroke color.
- No stroke persistence across share sessions.
- No multi-display strokes (one overlay window per share).
- Title-bar offset for window captures: assumed 0. macOS `kCGWindowBounds` includes the title bar; the captured stream may or may not. If strokes look ~24 px off vertically on window shares, that's where to look.

**Codex/Gemini review lessons reused**
The screen-frame indicator PR's review (memory #3191) flagged TS-undeclared `currentDisplayId`, missing `skipTransformProcessType: true`, and unvalidated IPC payloads. All three are addressed up-front in `draw-overlay.ts`.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)