### PR TITLE
feat(desktop,docs): point auth flow at cloud.getvoiceclaw.com

### DIFF
--- a/desktop/src/main/auth.test.ts
+++ b/desktop/src/main/auth.test.ts
@@ -99,7 +99,7 @@ describe('startSignInFlow', () => {
     const { startSignInFlow } = await import('./auth')
     startSignInFlow('google')
     expect(openExternalCalls[0]).toBe(
-      'https://getvoiceclaw.com/api/auth/google/start?target=desktop',
+      'https://cloud.getvoiceclaw.com/api/auth/google/start?target=desktop',
     )
   })
 

--- a/desktop/src/main/auth.ts
+++ b/desktop/src/main/auth.ts
@@ -6,7 +6,7 @@ import { getMainWindow } from './window-lifecycle'
 // Desktop sign-in flow:
 //
 //   1. Renderer asks main to start sign-in. We open the browser to
-//      https://getvoiceclaw.com/api/auth/google/start?target=desktop.
+//      https://cloud.getvoiceclaw.com/api/auth/google/start?target=desktop.
 //   2. Browser completes Google OAuth, the website redirects back to
 //      voiceclaw://auth/callback?ticket=…
 //   3. macOS hands the URL to this process via the open-url event. We
@@ -16,7 +16,7 @@ import { getMainWindow } from './window-lifecycle'
 //      wizard can mark the user as signed-in and advance.
 
 export const DEEP_LINK_SCHEME = 'voiceclaw'
-const DEFAULT_AUTH_BASE_URL = 'https://getvoiceclaw.com'
+const DEFAULT_AUTH_BASE_URL = 'https://cloud.getvoiceclaw.com'
 
 export function registerAuthDeepLink(): void {
   // Register the custom scheme with macOS. argv handling for non-mac

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -81,6 +81,7 @@ export default defineConfig({
           label: 'Guides',
           items: [
             { slug: 'relay-server' },
+            { slug: 'voiceclaw-cloud' },
             { slug: 'desktop-app' },
             { slug: 'desktop/onboarding', label: 'Desktop: onboarding wizard' },
             { slug: 'desktop/call-bar', label: 'Desktop: floating call bar' },

--- a/docs/src/content/docs/desktop/onboarding.mdx
+++ b/docs/src/content/docs/desktop/onboarding.mdx
@@ -13,7 +13,7 @@ The first time you open VoiceClaw on a Mac, a six-step wizard runs before the ma
 
 1. **Welcome.** A short pitch and a "let's set up" button. No data captured.
 
-2. **Sign in (optional).** Click *Continue with Google* and we open `https://getvoiceclaw.com/api/auth/google/start?target=desktop` in your browser. Complete the Google sign-in, then your browser shows a "Signed in. Returning to VoiceClaw…" page and hands control back to the desktop app via a `voiceclaw://auth/callback?ticket=…` deep link. The desktop app exchanges that ticket for a device token and stores it encrypted in its local database (see *What gets saved* below). If you close the browser before finishing, tap *Cancel* in the app and try again. Sign-in is fully optional — your API keys work with or without an account.
+2. **Sign in (optional).** Click *Continue with Google* and we open `https://cloud.getvoiceclaw.com/api/auth/google/start?target=desktop` in your browser. Complete the Google sign-in, then your browser shows a "Signed in. Returning to VoiceClaw…" page and hands control back to the desktop app via a `voiceclaw://auth/callback?ticket=…` deep link. The desktop app exchanges that ticket for a device token and stores it encrypted in its local database (see *What gets saved* below). If you close the browser before finishing, tap *Cancel* in the app and try again. Sign-in is fully optional — your API keys work with or without an account. See [VoiceClaw Cloud](/voiceclaw-cloud/) for what we store on the server side.
 
 3. **Permissions.** Two rows: microphone and screen recording. The wizard reads current state via `systemPreferences.getMediaAccessStatus()`. Microphone can be requested in-app; screen recording opens the matching pane in System Settings (`x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture`). The wizard polls every second while you're on this step, so granting a permission in System Settings flips the row to a green check without you having to click anything else. (Accessibility will be asked for separately when the AX-based screen-text-reader feature lands; today nothing in the binary consumes that grant, so the wizard doesn't ask.)
 
@@ -77,9 +77,9 @@ The desktop app registers `voiceclaw://` as a URL handler at startup via `app.se
 voiceclaw://auth/callback?ticket=<opaque>
 ```
 
-The `ticket` query parameter is exchanged for a device token at `https://getvoiceclaw.com/api/auth/ticket/redeem`. Tickets expire after 90 seconds — if your browser takes unusually long on the callback page before the deep link fires, the redeem will fail with "That sign-in link already expired. Try again." Just click *Continue with Google* again; the flow is idempotent. If the redeem fails for any other reason, the wizard surfaces the error inline on the sign-in step instead of silently advancing.
+The `ticket` query parameter is exchanged for a device token at `https://cloud.getvoiceclaw.com/api/auth/ticket/redeem`. Tickets expire after 90 seconds — if your browser takes unusually long on the callback page before the deep link fires, the redeem will fail with "That sign-in link already expired. Try again." Just click *Continue with Google* again; the flow is idempotent. If the redeem fails for any other reason, the wizard surfaces the error inline on the sign-in step instead of silently advancing.
 
-To override the auth host (useful for testing against a Vercel preview deploy), set `VOICECLAW_AUTH_BASE_URL=https://my-preview.vercel.app` before launching. The default is `https://getvoiceclaw.com`.
+To override the auth host (useful for testing against a local or staging deploy), set `VOICECLAW_AUTH_BASE_URL=https://my-staging-host` before launching. The default is `https://cloud.getvoiceclaw.com`.
 
 ## IPC surface
 

--- a/docs/src/content/docs/voiceclaw-cloud.mdx
+++ b/docs/src/content/docs/voiceclaw-cloud.mdx
@@ -1,0 +1,73 @@
+---
+title: VoiceClaw Cloud
+description: What VoiceClaw Cloud is, how cloud sign-in works, and when you need it (vs running fully self-hosted with your own API keys).
+---
+
+import { Aside } from '@astrojs/starlight/components'
+
+VoiceClaw Cloud is the optional hosted service behind sign-in for the desktop and mobile apps. It lives at `cloud.getvoiceclaw.com` and is what runs when you click *Continue with Google* (or *Continue with Apple*) in the wizard.
+
+Cloud is **opt-in**. The desktop app works fully self-hosted with your own API keys — no account, no internet trip through our servers. Sign-in only matters when you want features that need an identity, like the Pro tier or the upcoming phone↔desktop relay.
+
+## Cloud vs self-hosted
+
+|  | Self-hosted (BYO key) | VoiceClaw Cloud |
+| --- | --- | --- |
+| Account required | No | Yes (Google or Apple) |
+| Where API keys live | Your machine, encrypted with macOS Keychain | We mint short-lived broker tokens on your behalf |
+| Audio path | Your laptop ↔ Gemini/OpenAI/Grok directly | Your laptop ↔ Gemini/OpenAI/Grok directly |
+| Phone↔desktop link | Tailscale (you set it up) | Routed through us, no Tailscale needed *(coming soon)* |
+| What we store about you | Nothing | Email, OAuth provider sub, list of signed-in devices |
+| Cost | API provider's bill | Free tier or Pro subscription *(Pro coming soon)* |
+
+The audio path is identical in both modes. Sign-in does not put us between you and the AI provider for voice traffic.
+
+## Signing in
+
+In the desktop wizard, on the *Sign in* step, click **Continue with Google** or **Continue with Apple**. Your browser opens to `cloud.getvoiceclaw.com/api/auth/<provider>/start?target=desktop` and walks you through the provider's sign-in. When it's done, the browser shows a "Signed in. Returning to VoiceClaw…" page and hands back to the desktop app via a `voiceclaw://auth/callback?ticket=…` deep link.
+
+The desktop app exchanges that ticket for a long-lived **device token** — an HS256 JWT scoped to that one device, stored encrypted in macOS Keychain via Electron's `safeStorage`. We never see the plaintext token after we mint it; we keep only its SHA-256 hash to recognize the device on later requests.
+
+Tickets expire after 90 seconds, so if your browser sits on the callback page longer than that, you'll need to click *Continue with Google* again. The flow is idempotent — retrying is safe and produces a fresh ticket.
+
+## What we store
+
+| Field | Where | Why |
+| --- | --- | --- |
+| `email` | Postgres on `cloud.getvoiceclaw.com` | Identity, future billing emails |
+| `googleSub` / `appleSub` | Postgres | Stable identifier from the provider — survives email changes |
+| `name` | Postgres | Display name in the wizard |
+| `deviceId` + `tokenHash` | Postgres | Recognize your signed-in devices, support per-device revocation |
+| `lastSeenAt` per device | Postgres | Show "last used 2 hours ago" in a future settings page |
+
+We do **not** store: voice audio, transcripts, conversations, message history, screen captures, your provider keys, or anything you say to the AI. None of that ever reaches `cloud.getvoiceclaw.com`. It lives on your Mac (in `~/Library/Application Support/VoiceClaw/`) or wherever the AI provider holds it.
+
+## Apple Sign-in details
+
+Apple's flow has two quirks worth knowing:
+
+- **Hide My Email** wraps your real address in a relay like `xyz@privaterelay.appleid.com`. Mail to that address still reaches you. We store the relay address as-is — never see your real one.
+- **Names are sent only on first sign-in.** If you sign out and back in via Apple, Apple stops sending your name. We persist whatever name you provided the first time and don't clobber it on subsequent sign-ins.
+
+## Multiple devices, multiple sign-ins
+
+Each device — your Mac, your iPhone, a second Mac — gets its own device token. Signing in on one device does not sign you in on the others. They share an identity (your `User` row), not a token. Revoking one device leaves the others working.
+
+## Self-hosters
+
+If you're running VoiceClaw self-hosted with your own Gemini/OpenAI/Grok keys, you can ignore this entirely. The wizard's *Sign in* step is optional — skip it, fill in your provider key, and your app calls the AI directly. `cloud.getvoiceclaw.com` is never contacted.
+
+The phone↔desktop link works through Tailscale today; the cloud-hosted alternative (so phone works without a desktop on the same network) will require a cloud account when it ships, but BYO-key + Tailscale will keep working.
+
+<Aside type="note" title="Roadmap">
+This page describes only what ships today: cloud auth and per-device tokens. Coming next: a free trial of Gemini Live without paste-your-own-key (via short-lived broker tokens), a Pro tier with Stripe, and a Tailscale-replacement relay for phone↔desktop. Each will get its own page here when it lands.
+</Aside>
+
+## Why a separate service
+
+`getvoiceclaw.com` (the marketing site) and `cloud.getvoiceclaw.com` (the auth + broker) are deliberately separate.
+
+- The marketing site is open source, deployed on Vercel, and has no database. Anyone can read its source on GitHub and propose copy changes.
+- The cloud service is closed source and lives on our infrastructure. It holds account data and (later) handles billing, so its source isn't part of the public repo.
+
+Both are run by Nano3 Labs. If you want to run the entire stack yourself with no Nano3 Labs involvement, the self-hosted path is supported and complete — that's the dual-path commitment.


### PR DESCRIPTION
## Why

Companion to https://github.com/yagudaev/voiceclaw-cloud/pull/1 ([NAN-660](https://linear.app/nano3labs/issue/NAN-660/voiceclaw-cloud-free-pro-tier-via-ephemeral-gemini-token-broker)).

VoiceClaw Cloud now lives at `cloud.getvoiceclaw.com`. This PR moves the desktop's default OAuth base URL onto that subdomain and adds a user-facing docs page explaining what cloud-mode is, what we store, and why self-hosters can skip it entirely.

## What changes

- `desktop/src/main/auth.ts` — flip `DEFAULT_AUTH_BASE_URL` from `https://getvoiceclaw.com` to `https://cloud.getvoiceclaw.com`
- `desktop/src/main/auth.test.ts` — assertion updated to match the new default
- `docs/src/content/docs/voiceclaw-cloud.mdx` — new user-facing page on cloud sign-in, what we store, cloud vs self-hosted comparison
- `docs/src/content/docs/desktop/onboarding.mdx` — URL refs updated, link to the new page added
- `docs/astro.config.mjs` — sidebar entry under Guides

`VOICECLAW_AUTH_BASE_URL` still overrides the default for local / staging testing.

## Coordination

Land **after** voiceclaw-cloud PR #1 is deployed and verified at `cloud.getvoiceclaw.com`. Otherwise the next desktop release from main will fail OAuth.

## Out of scope (next PRs)

The website-side cleanup (deleting voiceclaw/website's `/api/auth/*` handlers and their associated lib code) lands as a follow-up after we've confirmed cloud is healthy and no stale desktop builds in the wild are still calling the old URLs.

## Test plan

- [x] `yarn vitest run src/main/auth.test.ts` — 9/9 passing
- [ ] Local desktop dev with `VOICECLAW_AUTH_BASE_URL=https://cloud.getvoiceclaw.com` (or unset, post-merge) opens the OAuth flow and completes a ticket redeem
- [ ] Docs site renders `/voiceclaw-cloud` cleanly with the sidebar entry visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)