### PR TITLE
feat(desktop): cloud-mode option in onboarding wizard

### DIFF
--- a/desktop/src/main/cloud-broker.test.ts
+++ b/desktop/src/main/cloud-broker.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let storedTokenEnc: Buffer | null = null
+const fakeDb = {
+  prepare: (sql: string) => ({
+    get: () => {
+      if (!sql.includes('FROM devices')) return undefined
+      if (storedTokenEnc === null) return undefined
+      return { token_enc: storedTokenEnc }
+    },
+  }),
+}
+
+vi.mock('./db', () => ({ getDb: () => fakeDb }))
+vi.mock('./onboarding', () => ({ ensureOnboardingSchema: () => undefined }))
+
+let mockFetchResponse: {
+  ok: boolean
+  status: number
+  headers: { get: (k: string) => string | null }
+  text: () => Promise<string>
+  json: () => Promise<unknown>
+} = makeOkResponse({})
+
+const fetchCalls: Array<{ url: string; opts: unknown }> = []
+
+vi.mock('electron', () => ({
+  net: {
+    fetch: (url: string, opts: unknown) => {
+      fetchCalls.push({ url, opts })
+      return Promise.resolve(mockFetchResponse)
+    },
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    decryptString: (b: Buffer) => b.toString('utf8'),
+  },
+}))
+
+import {
+  CLOUD_BASE_URL_DEFAULT,
+  clearSessionTokenCacheForTests,
+  fetchMe,
+  fetchSessionToken,
+  getCloudBaseUrl,
+  getCurrentDeviceToken,
+  isCloudModeAvailable,
+} from './cloud-broker'
+
+function makeOkResponse(json: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    text: async () => '',
+    json: async () => json,
+  }
+}
+
+function makeErrResponse(status: number, json: unknown, retryAfter?: string) {
+  const body = JSON.stringify(json)
+  return {
+    ok: false,
+    status,
+    headers: {
+      get: (k: string) => (k.toLowerCase() === 'retry-after' ? (retryAfter ?? null) : null),
+    },
+    text: async () => body,
+    json: async () => json,
+  }
+}
+
+const DEFAULT_TOKEN_RESPONSE = {
+  token: 'ephemeral-abc',
+  model: 'gemini-live-2.5-flash-preview',
+  newSessionExpiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+  expiresAt: new Date(Date.now() + 45 * 60 * 1000).toISOString(),
+  lifetimeSeconds: 900,
+  tier: 'free',
+  quota: {
+    dailyCapSeconds: 900,
+    secondsUsedToday: 900,
+    secondsRemainingToday: 0,
+  },
+}
+
+describe('cloud-broker', () => {
+  beforeEach(() => {
+    fetchCalls.length = 0
+    storedTokenEnc = Buffer.from('device-jwt-token')
+    mockFetchResponse = makeOkResponse(DEFAULT_TOKEN_RESPONSE)
+    clearSessionTokenCacheForTests()
+    delete process.env.VOICECLAW_AUTH_BASE_URL
+  })
+
+  afterEach(() => {
+    storedTokenEnc = null
+  })
+
+  describe('config', () => {
+    it('defaults to cloud.getvoiceclaw.com', () => {
+      expect(getCloudBaseUrl()).toBe(CLOUD_BASE_URL_DEFAULT)
+      expect(CLOUD_BASE_URL_DEFAULT).toBe('https://cloud.getvoiceclaw.com')
+    })
+
+    it('respects VOICECLAW_AUTH_BASE_URL override', () => {
+      process.env.VOICECLAW_AUTH_BASE_URL = 'http://localhost:3456'
+      expect(getCloudBaseUrl()).toBe('http://localhost:3456')
+    })
+  })
+
+  describe('getCurrentDeviceToken', () => {
+    it('decrypts the stored token', () => {
+      expect(getCurrentDeviceToken()).toBe('device-jwt-token')
+    })
+
+    it('returns null when no device row exists', () => {
+      storedTokenEnc = null
+      expect(getCurrentDeviceToken()).toBeNull()
+    })
+
+    it('isCloudModeAvailable reflects whether a device token exists', () => {
+      expect(isCloudModeAvailable()).toBe(true)
+      storedTokenEnc = null
+      expect(isCloudModeAvailable()).toBe(false)
+    })
+  })
+
+  describe('fetchSessionToken', () => {
+    it('happy path: fetches token, returns parsed dates', async () => {
+      const result = await fetchSessionToken()
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.value.token).toBe('ephemeral-abc')
+      expect(result.value.model).toBe('gemini-live-2.5-flash-preview')
+      expect(result.value.tier).toBe('free')
+      expect(result.value.lifetimeSeconds).toBe(900)
+      expect(result.value.newSessionExpiresAt).toBeInstanceOf(Date)
+    })
+
+    it('sends Authorization: Bearer header with device token', async () => {
+      await fetchSessionToken()
+      expect(fetchCalls).toHaveLength(1)
+      const opts = fetchCalls[0]!.opts as { headers: Record<string, string>; method: string }
+      expect(opts.method).toBe('POST')
+      expect(opts.headers.Authorization).toBe('Bearer device-jwt-token')
+    })
+
+    it('returns not_signed_in when no device token', async () => {
+      storedTokenEnc = null
+      const result = await fetchSessionToken()
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toBe('not_signed_in')
+    })
+
+    it('caches the token and serves a second call from cache', async () => {
+      await fetchSessionToken()
+      await fetchSessionToken()
+      expect(fetchCalls).toHaveLength(1)
+    })
+
+    it('forceRefresh bypasses cache', async () => {
+      await fetchSessionToken()
+      await fetchSessionToken({ forceRefresh: true })
+      expect(fetchCalls).toHaveLength(2)
+    })
+
+    it('surfaces 429 with retry-after as a structured error', async () => {
+      mockFetchResponse = makeErrResponse(
+        429,
+        { error: 'quota_exhausted', retryAfterSeconds: 3600 },
+        '3600',
+      )
+      const result = await fetchSessionToken()
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.status).toBe(429)
+      expect(result.retryAfterSeconds).toBe(3600)
+    })
+
+    it('surfaces 401 (token expired or revoked)', async () => {
+      mockFetchResponse = makeErrResponse(401, { error: 'invalid_token' })
+      const result = await fetchSessionToken()
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.status).toBe(401)
+    })
+
+    it('coalesces concurrent calls', async () => {
+      const a = fetchSessionToken()
+      const b = fetchSessionToken()
+      await Promise.all([a, b])
+      expect(fetchCalls).toHaveLength(1)
+    })
+  })
+
+  describe('fetchMe', () => {
+    it('hits /api/auth/me with bearer', async () => {
+      mockFetchResponse = makeOkResponse({
+        user: { id: 'u1', email: 'a@b.co', name: null, tier: 'free', proUntil: null },
+        device: { id: 'd1' },
+        usage: {
+          day: '2026-05-01',
+          dailyCapSeconds: 900,
+          secondsUsedToday: 0,
+          secondsRemainingToday: 900,
+          tokensMintedToday: 0,
+          lastMintedAt: null,
+        },
+      })
+      const result = await fetchMe()
+      expect(result.ok).toBe(true)
+      if (!result.ok) return
+      expect(result.value.user.tier).toBe('free')
+      expect(fetchCalls[0]!.url).toContain('/api/auth/me')
+    })
+
+    it('returns not_signed_in without device token', async () => {
+      storedTokenEnc = null
+      const result = await fetchMe()
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error).toBe('not_signed_in')
+    })
+  })
+})

--- a/desktop/src/main/cloud-broker.ts
+++ b/desktop/src/main/cloud-broker.ts
@@ -1,0 +1,186 @@
+import { net, safeStorage } from 'electron'
+import { getDb } from './db'
+import { ensureOnboardingSchema } from './onboarding'
+
+// Cloud-mode broker client.
+//
+// When the user opts into VoiceClaw Cloud, voiceclaw-cloud mints a
+// short-lived Gemini Live ephemeral token on demand. This module
+// fetches and caches it, refreshing before TTL expiry so a session
+// never sees an expired token mid-call.
+//
+// The device_token issued at OAuth ticket-redeem (stored encrypted in
+// SQLite via safeStorage) is the bearer credential.
+
+export const CLOUD_BASE_URL_DEFAULT = 'https://cloud.getvoiceclaw.com'
+
+const REFRESH_AT_FRACTION = 0.8
+
+export type SessionToken = {
+  token: string
+  model: string
+  newSessionExpiresAt: Date
+  expiresAt: Date
+  lifetimeSeconds: number
+  tier: 'free' | 'pro'
+  quota: {
+    dailyCapSeconds: number
+    secondsUsedToday: number
+    secondsRemainingToday: number
+  }
+}
+
+export type CloudMeResponse = {
+  user: {
+    id: string
+    email: string
+    name: string | null
+    tier: 'free' | 'pro'
+    proUntil: string | null
+  }
+  device: { id: string }
+  usage: {
+    day: string
+    dailyCapSeconds: number
+    secondsUsedToday: number
+    secondsRemainingToday: number
+    tokensMintedToday: number
+    lastMintedAt: string | null
+  }
+}
+
+export type FetchResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; status: number; error: string; retryAfterSeconds?: number }
+
+type CachedToken = {
+  token: SessionToken
+  refreshAt: number
+}
+
+let cached: CachedToken | null = null
+let inflight: Promise<FetchResult<SessionToken>> | null = null
+
+export function getCloudBaseUrl(): string {
+  return process.env.VOICECLAW_AUTH_BASE_URL ?? CLOUD_BASE_URL_DEFAULT
+}
+
+export function isCloudModeAvailable(): boolean {
+  return getCurrentDeviceToken() !== null
+}
+
+export function getCurrentDeviceToken(): string | null {
+  ensureOnboardingSchema()
+  const db = getDb()
+  const row = db
+    .prepare(
+      'SELECT token_enc FROM devices ORDER BY created_at DESC LIMIT 1',
+    )
+    .get() as { token_enc: Buffer } | undefined
+  if (!row) return null
+  if (!safeStorage.isEncryptionAvailable()) return null
+  try {
+    return safeStorage.decryptString(row.token_enc)
+  } catch {
+    return null
+  }
+}
+
+export async function fetchSessionToken(options: {
+  forceRefresh?: boolean
+} = {}): Promise<FetchResult<SessionToken>> {
+  if (!options.forceRefresh && cached && Date.now() < cached.refreshAt) {
+    return { ok: true, value: cached.token }
+  }
+  if (inflight) return inflight
+
+  inflight = doFetch().finally(() => {
+    inflight = null
+  })
+  return inflight
+}
+
+export async function fetchMe(): Promise<FetchResult<CloudMeResponse>> {
+  const deviceToken = getCurrentDeviceToken()
+  if (!deviceToken) {
+    return { ok: false, status: 0, error: 'not_signed_in' }
+  }
+  const url = `${getCloudBaseUrl()}/api/auth/me`
+  const response = await net.fetch(url, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${deviceToken}` },
+  })
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    return { ok: false, status: response.status, error: text.slice(0, 200) }
+  }
+  const body = (await response.json()) as CloudMeResponse
+  return { ok: true, value: body }
+}
+
+export function clearSessionTokenCacheForTests(): void {
+  cached = null
+  inflight = null
+}
+
+async function doFetch(): Promise<FetchResult<SessionToken>> {
+  const deviceToken = getCurrentDeviceToken()
+  if (!deviceToken) {
+    return { ok: false, status: 0, error: 'not_signed_in' }
+  }
+  const url = `${getCloudBaseUrl()}/api/gemini/session-token`
+  const response = await net.fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${deviceToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: '{}',
+  })
+  if (!response.ok) {
+    const retryAfter = response.headers.get('retry-after')
+    const retryAfterSeconds = retryAfter ? parseInt(retryAfter, 10) : undefined
+    let errorBody = ''
+    try {
+      errorBody = await response.text()
+    } catch {
+      errorBody = ''
+    }
+    return {
+      ok: false,
+      status: response.status,
+      error: errorBody.slice(0, 200),
+      retryAfterSeconds,
+    }
+  }
+  const raw = (await response.json()) as {
+    token: string
+    model: string
+    newSessionExpiresAt: string
+    expiresAt: string
+    lifetimeSeconds: number
+    tier: 'free' | 'pro'
+    quota: {
+      dailyCapSeconds: number
+      secondsUsedToday: number
+      secondsRemainingToday: number
+    }
+  }
+  const token: SessionToken = {
+    token: raw.token,
+    model: raw.model,
+    newSessionExpiresAt: new Date(raw.newSessionExpiresAt),
+    expiresAt: new Date(raw.expiresAt),
+    lifetimeSeconds: raw.lifetimeSeconds,
+    tier: raw.tier,
+    quota: raw.quota,
+  }
+
+  const now = Date.now()
+  const window = token.newSessionExpiresAt.getTime() - now
+  cached = {
+    token,
+    refreshAt: now + Math.max(5_000, Math.floor(window * REFRESH_AT_FRACTION)),
+  }
+  return { ok: true, value: token }
+}

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -46,6 +46,12 @@ import {
   installNow,
 } from './services/auto-updater'
 import { startSignInFlow } from './auth'
+import {
+  fetchMe as cloudFetchMe,
+  fetchSessionToken as cloudFetchSessionToken,
+  getCloudBaseUrl,
+  isCloudModeAvailable,
+} from './cloud-broker'
 import { getMainWindow } from './window-lifecycle'
 import {
   getActiveProvider,
@@ -561,6 +567,29 @@ export function registerIpcHandlers() {
   ipcMain.handle('updates:checkNow', () => checkForUpdatesNow())
   ipcMain.handle('updates:installNow', (_e, source: 'banner' | 'settings' | 'tray' = 'settings') => {
     installNow(source)
+  })
+
+  // Cloud-mode broker (cloud.getvoiceclaw.com)
+  ipcMain.handle('cloud:getStatus', () => ({
+    signedIn: isCloudModeAvailable(),
+    baseUrl: getCloudBaseUrl(),
+  }))
+  ipcMain.handle('cloud:fetchMe', async () => cloudFetchMe())
+  ipcMain.handle('cloud:fetchSessionToken', async (_e, opts?: { forceRefresh?: boolean }) => {
+    const result = await cloudFetchSessionToken(opts ?? {})
+    if (result.ok) {
+      return {
+        ok: true as const,
+        token: result.value.token,
+        model: result.value.model,
+        newSessionExpiresAt: result.value.newSessionExpiresAt.toISOString(),
+        expiresAt: result.value.expiresAt.toISOString(),
+        lifetimeSeconds: result.value.lifetimeSeconds,
+        tier: result.value.tier,
+        quota: result.value.quota,
+      }
+    }
+    return result
   })
 
   // Network: test relay server connection from main process (avoids CORS)

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -11,12 +11,16 @@ type WizardStepId =
   | 'identity'
   | 'testcall'
 
+type AccessMode = 'cloud' | 'byo-key'
+
 type OnboardingPayload = {
   signedIn?: boolean
   permissions?: {
     mic?: 'granted' | 'denied' | 'not-determined' | 'restricted' | 'unknown'
     screen?: 'granted' | 'denied' | 'not-determined' | 'restricted' | 'unknown'
   }
+  accessMode?: AccessMode
+  cloudVerified?: boolean
   provider?: 'gemini' | 'openai' | 'xai'
   providerKeyValidated?: boolean
   brain?: 'openclaw' | 'claude' | 'codex' | { url: string }
@@ -299,6 +303,56 @@ const electronAPI = {
   },
   attachments: {
     pickImage: () => ipcRenderer.invoke('attachments:pickImage') as Promise<PickImageResult>,
+  },
+  cloud: {
+    getStatus: () =>
+      ipcRenderer.invoke('cloud:getStatus') as Promise<{
+        signedIn: boolean
+        baseUrl: string
+      }>,
+    fetchMe: () =>
+      ipcRenderer.invoke('cloud:fetchMe') as Promise<
+        | {
+            ok: true
+            value: {
+              user: {
+                id: string
+                email: string
+                name: string | null
+                tier: 'free' | 'pro'
+                proUntil: string | null
+              }
+              device: { id: string }
+              usage: {
+                day: string
+                dailyCapSeconds: number
+                secondsUsedToday: number
+                secondsRemainingToday: number
+                tokensMintedToday: number
+                lastMintedAt: string | null
+              }
+            }
+          }
+        | { ok: false; status: number; error: string; retryAfterSeconds?: number }
+      >,
+    fetchSessionToken: (opts?: { forceRefresh?: boolean }) =>
+      ipcRenderer.invoke('cloud:fetchSessionToken', opts) as Promise<
+        | {
+            ok: true
+            token: string
+            model: string
+            newSessionExpiresAt: string
+            expiresAt: string
+            lifetimeSeconds: number
+            tier: 'free' | 'pro'
+            quota: {
+              dailyCapSeconds: number
+              secondsUsedToday: number
+              secondsRemainingToday: number
+            }
+          }
+        | { ok: false; status: number; error: string; retryAfterSeconds?: number }
+      >,
   },
 }
 

--- a/desktop/src/renderer/src/lib/onboarding-api.ts
+++ b/desktop/src/renderer/src/lib/onboarding-api.ts
@@ -11,6 +11,7 @@ export type WizardStepId =
   | 'testcall'
 
 export type ProviderId = 'gemini' | 'openai' | 'xai'
+export type AccessMode = 'cloud' | 'byo-key'
 
 export type PermissionStatus =
   | 'granted'
@@ -31,12 +32,42 @@ export type OnboardingPayload = {
     mic?: PermissionStatus
     screen?: PermissionStatus
   }
+  accessMode?: AccessMode
+  cloudVerified?: boolean
   provider?: ProviderId
   providerKeyValidated?: boolean
   brain?: 'openclaw' | 'claude' | 'codex' | { url: string }
   identity?: AgentIdentityPatch
   user?: { id?: string; email?: string | null; name?: string | null }
 }
+
+export type CloudStatus = {
+  signedIn: boolean
+  baseUrl: string
+}
+
+export type CloudUserInfo = {
+  user: {
+    id: string
+    email: string
+    name: string | null
+    tier: 'free' | 'pro'
+    proUntil: string | null
+  }
+  device: { id: string }
+  usage: {
+    day: string
+    dailyCapSeconds: number
+    secondsUsedToday: number
+    secondsRemainingToday: number
+    tokensMintedToday: number
+    lastMintedAt: string | null
+  }
+}
+
+export type CloudMeResult =
+  | { ok: true; value: CloudUserInfo }
+  | { ok: false; status: number; error: string; retryAfterSeconds?: number }
 
 export type OnboardingState = {
   currentStep: WizardStepId
@@ -83,6 +114,27 @@ declare global {
       brain: {
         detect: () => Promise<BrainDetection>
       }
+      cloud: {
+        getStatus: () => Promise<CloudStatus>
+        fetchMe: () => Promise<CloudMeResult>
+        fetchSessionToken: (opts?: { forceRefresh?: boolean }) => Promise<
+          | {
+              ok: true
+              token: string
+              model: string
+              newSessionExpiresAt: string
+              expiresAt: string
+              lifetimeSeconds: number
+              tier: 'free' | 'pro'
+              quota: {
+                dailyCapSeconds: number
+                secondsUsedToday: number
+                secondsRemainingToday: number
+              }
+            }
+          | { ok: false; status: number; error: string; retryAfterSeconds?: number }
+        >
+      }
       identity: {
         get: () => Promise<{ name: string; description: string; voice: string }>
         save: (patch: AgentIdentityPatch) => Promise<{
@@ -127,6 +179,13 @@ export const providerApi = {
 
 export const brainApi = {
   detect: () => window.electronAPI.brain.detect(),
+}
+
+export const cloudApi = {
+  getStatus: () => window.electronAPI.cloud.getStatus(),
+  fetchMe: () => window.electronAPI.cloud.fetchMe(),
+  fetchSessionToken: (opts?: { forceRefresh?: boolean }) =>
+    window.electronAPI.cloud.fetchSessionToken(opts),
 }
 
 export const identityApi = {

--- a/desktop/src/renderer/src/pages/onboarding/StepProvider.tsx
+++ b/desktop/src/renderer/src/pages/onboarding/StepProvider.tsx
@@ -1,8 +1,11 @@
-import { useState } from 'react'
-import { Eye, EyeOff } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Cloud, Eye, EyeOff, Key } from 'lucide-react'
 import { StepFrame } from './StepFrame'
 import {
+  cloudApi,
   providerApi,
+  type AccessMode,
+  type CloudUserInfo,
   type OnboardingPayload,
   type ProviderId,
 } from '../../lib/onboarding-api'
@@ -51,11 +54,19 @@ type ValidationState =
   | { kind: 'valid' }
   | { kind: 'invalid'; error: string }
 
+type CloudState =
+  | { kind: 'unknown' }
+  | { kind: 'not-signed-in' }
+  | { kind: 'verifying' }
+  | { kind: 'verified'; me: CloudUserInfo }
+  | { kind: 'error'; error: string }
+
 type Props = {
   onContinue?: (patch: OnboardingPayload) => void
   onBack?: () => void
   onStartOver?: () => void
   initialProvider?: ProviderId
+  initialAccessMode?: AccessMode
   previewMode?: boolean
 }
 
@@ -64,15 +75,54 @@ export function StepProvider({
   onBack,
   onStartOver,
   initialProvider = 'gemini',
+  initialAccessMode = 'byo-key',
   previewMode = false,
 }: Props) {
+  const [accessMode, setAccessMode] = useState<AccessMode>(initialAccessMode)
   const [selected, setSelected] = useState<ProviderId>(
     PROVIDERS.some((p) => p.id === initialProvider) ? initialProvider : 'gemini',
   )
   const [apiKey, setApiKey] = useState('')
   const [showKey, setShowKey] = useState(false)
   const [validation, setValidation] = useState<ValidationState>({ kind: 'empty' })
+  const [cloudState, setCloudState] = useState<CloudState>({ kind: 'unknown' })
   const active = PROVIDERS.find((p) => p.id === selected) ?? PROVIDERS[0]
+
+  useEffect(() => {
+    if (previewMode) return
+    if (accessMode !== 'cloud') return
+    if (cloudState.kind !== 'unknown') return
+    void verifyCloud()
+  }, [accessMode, cloudState.kind, previewMode])
+
+  const verifyCloud = async () => {
+    setCloudState({ kind: 'verifying' })
+    try {
+      const status = await cloudApi.getStatus()
+      if (!status.signedIn) {
+        setCloudState({ kind: 'not-signed-in' })
+        return
+      }
+      const result = await cloudApi.fetchMe()
+      if (!result.ok) {
+        if (result.status === 401) {
+          setCloudState({ kind: 'not-signed-in' })
+          return
+        }
+        setCloudState({
+          kind: 'error',
+          error: result.error || `Server returned ${result.status}`,
+        })
+        return
+      }
+      setCloudState({ kind: 'verified', me: result.value })
+    } catch (err) {
+      setCloudState({
+        kind: 'error',
+        error: err instanceof Error ? err.message : 'Could not reach VoiceClaw Cloud.',
+      })
+    }
+  }
 
   const handleKeyChange = (key: string) => {
     setApiKey(key)
@@ -109,21 +159,42 @@ export function StepProvider({
   }
 
   const handleContinue = async () => {
-    if (validation.kind !== 'valid') {
-      await handleValidate()
-      // re-read state inside handleValidate; handleContinue stops here
-      // and the user clicks Continue again once they see the green check.
+    if (accessMode === 'cloud') {
+      if (cloudState.kind === 'verified') {
+        onContinue?.({ accessMode: 'cloud', cloudVerified: true, provider: 'gemini' })
+      } else {
+        await verifyCloud()
+      }
       return
     }
-    onContinue?.({ provider: selected, providerKeyValidated: true })
+    if (validation.kind !== 'valid') {
+      await handleValidate()
+      return
+    }
+    onContinue?.({ accessMode: 'byo-key', provider: selected, providerKeyValidated: true })
   }
 
-  const continueLabel =
-    validation.kind === 'valid'
-      ? 'Continue'
-      : validation.kind === 'validating'
-        ? 'Checking…'
-        : 'Validate + continue'
+  const cloudReady = cloudState.kind === 'verified'
+  const cloudBusy = cloudState.kind === 'verifying'
+
+  const continueLabel = (() => {
+    if (accessMode === 'cloud') {
+      if (cloudReady) return 'Continue'
+      if (cloudBusy) return 'Checking…'
+      if (cloudState.kind === 'not-signed-in') return 'Sign in first'
+      return 'Verify + continue'
+    }
+    if (validation.kind === 'valid') return 'Continue'
+    if (validation.kind === 'validating') return 'Checking…'
+    return 'Validate + continue'
+  })()
+
+  const continueDisabled = (() => {
+    if (accessMode === 'cloud') {
+      return cloudBusy || cloudState.kind === 'not-signed-in'
+    }
+    return validation.kind === 'validating' || apiKey.length === 0
+  })()
 
   return (
     <StepFrame
@@ -131,15 +202,32 @@ export function StepProvider({
       totalSteps={6}
       eyebrow="04 / Voice provider"
       title="Pick a voice. Paste a key."
-      description="VoiceClaw doesn't keep your key. It goes straight into macOS Keychain on this machine, encrypted the way the OS encrypts your Wi-Fi passwords."
+      description="Run on VoiceClaw Cloud (free trial, no key needed) or bring your own provider key. Keys go straight into macOS Keychain — VoiceClaw never sees them."
       primaryAction={{
         label: continueLabel,
         onClick: () => void handleContinue(),
-        disabled: validation.kind === 'validating' || apiKey.length === 0,
+        disabled: continueDisabled,
       }}
       secondaryAction={{ label: 'Back', onClick: onBack }}
       onStartOver={onStartOver}
     >
+      <div className="mb-5 grid gap-3 md:grid-cols-2">
+        <AccessModeCard
+          mode="cloud"
+          selected={accessMode === 'cloud'}
+          onSelect={() => setAccessMode('cloud')}
+        />
+        <AccessModeCard
+          mode="byo-key"
+          selected={accessMode === 'byo-key'}
+          onSelect={() => setAccessMode('byo-key')}
+        />
+      </div>
+
+      {accessMode === 'cloud' ? (
+        <CloudPanel state={cloudState} onRetry={() => void verifyCloud()} />
+      ) : (
+        <>
       <div className="grid gap-3 md:grid-cols-2">
         {PROVIDERS.map((provider) => (
           <ProviderCard
@@ -253,6 +341,8 @@ export function StepProvider({
           , no audio yet.
         </p>
       </div>
+        </>
+      )}
     </StepFrame>
   )
 }
@@ -407,4 +497,172 @@ function mapVisual(state: ValidationState): {
     dot: 'var(--muted)',
     label: 'Press tab to check',
   }
+}
+
+function AccessModeCard({
+  mode,
+  selected,
+  onSelect,
+}: {
+  mode: AccessMode
+  selected: boolean
+  onSelect: () => void
+}) {
+  const isCloud = mode === 'cloud'
+  const Icon = isCloud ? Cloud : Key
+  const tagline = isCloud ? 'Free trial · Recommended' : 'Bring your own key'
+  const title = isCloud ? 'VoiceClaw Cloud' : 'Use your own provider'
+  const detail = isCloud
+    ? '15 minutes a day on Gemini Live, on us. Sign in once. No key paste, no setup.'
+    : 'Paste a Gemini, OpenAI, or Grok key. The key stays on this Mac, in macOS Keychain.'
+  return (
+    <button
+      onClick={onSelect}
+      className="flex flex-col items-start gap-3 rounded-[20px] border p-5 text-left transition-all"
+      style={{
+        borderColor: selected ? 'var(--accent)' : 'var(--line-strong)',
+        backgroundColor: selected ? 'var(--accent-soft)' : 'var(--panel)',
+        boxShadow: selected ? 'none' : 'var(--shadow)',
+      }}
+    >
+      <div className="flex w-full items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <Icon className="h-5 w-5" style={{ color: selected ? 'var(--accent)' : 'var(--muted)' }} />
+          <div>
+            <p
+              className="text-[10px] uppercase"
+              style={{
+                fontFamily: 'var(--font-mono)',
+                letterSpacing: '0.24em',
+                color: selected ? 'var(--accent)' : 'var(--muted)',
+              }}
+            >
+              {tagline}
+            </p>
+            <p
+              className="mt-1 text-[16px] font-medium tracking-[-0.01em]"
+              style={{ color: 'var(--ink)' }}
+            >
+              {title}
+            </p>
+          </div>
+        </div>
+        <RadioDot selected={selected} />
+      </div>
+      <p className="text-[13px] leading-[1.55]" style={{ color: 'var(--muted)' }}>
+        {detail}
+      </p>
+    </button>
+  )
+}
+
+function CloudPanel({
+  state,
+  onRetry,
+}: {
+  state: CloudState
+  onRetry: () => void
+}) {
+  return (
+    <div
+      className="rounded-[22px] border p-6"
+      style={{
+        borderColor: 'var(--line-strong)',
+        backgroundColor: 'var(--panel)',
+        boxShadow: 'var(--shadow)',
+      }}
+    >
+      {state.kind === 'verified' ? (
+        <CloudVerifiedDetails me={state.me} />
+      ) : state.kind === 'verifying' || state.kind === 'unknown' ? (
+        <p className="text-[14px]" style={{ color: 'var(--muted)' }}>
+          Checking your VoiceClaw Cloud account…
+        </p>
+      ) : state.kind === 'not-signed-in' ? (
+        <CloudNotSignedIn />
+      ) : (
+        <CloudErrorPanel error={state.error} onRetry={onRetry} />
+      )}
+    </div>
+  )
+}
+
+function CloudVerifiedDetails({ me }: { me: CloudUserInfo }) {
+  const remainingMin = Math.floor(me.usage.secondsRemainingToday / 60)
+  const capMin = Math.floor(me.usage.dailyCapSeconds / 60)
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <span
+          className="h-2 w-2 rounded-full"
+          style={{ backgroundColor: 'var(--accent)' }}
+        />
+        <p
+          className="text-[12px] uppercase"
+          style={{
+            fontFamily: 'var(--font-mono)',
+            letterSpacing: '0.22em',
+            color: 'var(--accent)',
+          }}
+        >
+          {me.user.tier === 'pro' ? 'Pro tier' : 'Free tier · Verified'}
+        </p>
+      </div>
+      <div>
+        <p className="text-[14px]" style={{ color: 'var(--ink)' }}>
+          Signed in as <strong>{me.user.email}</strong>.
+        </p>
+        <p className="mt-2 text-[13px]" style={{ color: 'var(--muted)' }}>
+          {remainingMin} of {capMin} minutes available today. Daily quota resets
+          at 00:00 UTC.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function CloudNotSignedIn() {
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-[14px]" style={{ color: 'var(--ink)' }}>
+        Sign in to use VoiceClaw Cloud.
+      </p>
+      <p className="text-[13px]" style={{ color: 'var(--muted)' }}>
+        Go back to the sign-in step and choose Google or Apple. We need a
+        device token before the cloud broker will mint Gemini sessions on
+        your behalf.
+      </p>
+    </div>
+  )
+}
+
+function CloudErrorPanel({
+  error,
+  onRetry,
+}: {
+  error: string
+  onRetry: () => void
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-[14px]" style={{ color: 'var(--accent)' }}>
+        Could not verify VoiceClaw Cloud.
+      </p>
+      <p className="text-[12px]" style={{ color: 'var(--muted)' }}>
+        {error}
+      </p>
+      <button
+        onClick={onRetry}
+        className="self-start rounded-[12px] border px-4 py-2 text-[12px] uppercase"
+        style={{
+          fontFamily: 'var(--font-mono)',
+          letterSpacing: '0.22em',
+          borderColor: 'var(--line-strong)',
+          color: 'var(--ink)',
+        }}
+      >
+        Retry
+      </button>
+    </div>
+  )
 }


### PR DESCRIPTION
## Why

[NAN-660](https://linear.app/nano3labs/issue/NAN-660/voiceclaw-cloud-free-pro-tier-via-ephemeral-gemini-token-broker) PR #3 of 4. Adds the user-facing path to the broker: the wizard now offers VoiceClaw Cloud as a first-class option above BYO-key.

## What's in this PR

**`cloud-broker` module** — `desktop/src/main/cloud-broker.ts`
- Thin client over `/api/auth/me` and `/api/gemini/session-token`
- Reads device token from encrypted SQLite `devices` row (set in PR #1's auth flow)
- Caches the broker-issued ephemeral token in memory; refreshes at 80% of `newSessionExpireTime`
- Coalesces concurrent fetches (one cache miss → one upstream call)
- 15 vitest cases: happy / not-signed-in / 401 / 429 with `Retry-After` / cache reuse / `forceRefresh` / call coalescing / `fetchMe`

**IPC + preload**
- New handlers: `cloud:getStatus`, `cloud:fetchMe`, `cloud:fetchSessionToken`
- Renderer-side `cloudApi` wrapper in `onboarding-api.ts`

**Wizard StepProvider**
- New access-mode picker at the top of step 4: VoiceClaw Cloud vs Bring-Your-Own
- Cloud branch auto-verifies on select: hits `/api/auth/me`, surfaces tier + minutes-remaining-today
- Three failure shapes covered: not signed in (sends user back to step 2), broker error (with retry), or 401 (treated as not signed in)
- BYO branch unchanged from main
- Onboarding payload records `accessMode` + `cloudVerified` for downstream steps

## Out of scope

- **Relay-server consumption of ephemeral tokens (PR #3.5).** The token is fetched and cached, but the relay-server still uses `GEMINI_API_KEY` from env. Wiring relay to ask cloud-broker for a fresh token at session start is its own diff — it touches relay's lifecycle and queue management.
- **Dashboard \"minutes remaining\" widget.** Will land alongside PR #3.5 when there's a real session-time-used signal.
- **Settings page to switch modes post-wizard.** Today, switching modes requires re-running the wizard. Settings UI is a follow-up.

## Coordination

Depends on:
- **PR #1** (voiceclaw-cloud auth) — deployed at `cloud.getvoiceclaw.com`
- **PR #1.5** (this repo, URL flip + docs) — must merge first; otherwise `cloud:getStatus` and `cloud:fetchMe` reach the old host
- **PR #2** (voiceclaw-cloud broker) — deployed at `cloud.getvoiceclaw.com`

## Test plan

- [x] 15 new cloud-broker vitest cases passing
- [x] Existing 119 desktop tests still passing (134 total)
- [x] Typecheck clean
- [ ] Local dev with `VOICECLAW_AUTH_BASE_URL=http://localhost:3000` against a running voiceclaw-cloud — pick cloud mode, see the verified panel
- [ ] Live dev against `cloud.getvoiceclaw.com` after deploys land
- [ ] Sign out → re-enter wizard → cloud panel renders \"sign in first\" branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)