### PR TITLE
feat(relay): surface provider auth/quota errors with billing links (NAN-712)

### DIFF
--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -565,6 +565,12 @@ export function registerIpcHandlers() {
     installNow(source)
   })
 
+  ipcMain.handle('shell:openExternal', (_e, url: string) => {
+    if (typeof url === 'string' && /^https?:\/\//.test(url)) {
+      return shell.openExternal(url)
+    }
+  })
+
   // Network: test relay server connection from main process (avoids CORS)
   ipcMain.handle('net:healthCheck', async (_e, url: string) => {
     const httpUrl = toHealthUrl(url)

--- a/desktop/src/main/services/brain-doctor.ts
+++ b/desktop/src/main/services/brain-doctor.ts
@@ -2,6 +2,7 @@ import { execSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { app } from 'electron'
+import { getProviderKey } from '../provider-keys'
 
 export type CheckStatus = 'PASS' | 'FAIL' | 'SKIP'
 
@@ -467,6 +468,73 @@ async function checkGeminiApiKey(acc: Acc, configPath: string): Promise<void> {
   }
 }
 
+async function checkXaiApiKey(acc: Acc): Promise<void> {
+  const apiKey = getProviderKey('xai')
+  if (!apiKey) {
+    skip(acc, 'xAI API key reachability', 'skipped (no xAI key configured)')
+    return
+  }
+  try {
+    const res = await safeFetch(
+      'https://api.x.ai/v1/models',
+      { headers: { Authorization: `Bearer ${apiKey}` } },
+      10_000,
+    )
+    const text = await res.text()
+    if (res.ok) {
+      pass(acc, 'xAI API key reachability', `HTTP ${res.status}`)
+    } else {
+      let hint = 'Check your xAI API key in VoiceClaw Settings → Provider tab'
+      if (res.status === 401) hint = 'API key invalid or revoked. Re-enter it in Settings → Provider'
+      if (res.status === 402 || res.status === 429)
+        hint = 'xAI account out of credits or rate limited. Top up at https://console.x.ai/team'
+      if (res.status === 403) hint = 'xAI API key lacks permission. Check key settings at https://console.x.ai'
+      fail(acc, 'xAI API key reachability', `HTTP ${res.status}: ${text.substring(0, 200)}`, hint)
+    }
+  } catch (err) {
+    fail(
+      acc,
+      'xAI API key reachability',
+      `fetch failed: ${(err as Error).message}`,
+      'Check internet connectivity; if behind a VPN/proxy, try disabling it',
+    )
+  }
+}
+
+async function checkOpenAiApiKey(acc: Acc): Promise<void> {
+  const apiKey = getProviderKey('openai')
+  if (!apiKey) {
+    skip(acc, 'OpenAI API key reachability', 'skipped (no OpenAI key configured)')
+    return
+  }
+  try {
+    const res = await safeFetch(
+      'https://api.openai.com/v1/models',
+      { headers: { Authorization: `Bearer ${apiKey}` } },
+      10_000,
+    )
+    const text = await res.text()
+    if (res.ok) {
+      pass(acc, 'OpenAI API key reachability', `HTTP ${res.status}`)
+    } else {
+      let hint = 'Check your OpenAI API key in VoiceClaw Settings → Provider tab'
+      if (res.status === 401) hint = 'API key invalid or revoked. Re-enter it in Settings → Provider'
+      if (res.status === 402 || (res.status === 429 && text.includes('insufficient_quota')))
+        hint = 'OpenAI quota exceeded. Top up at https://platform.openai.com/account/billing'
+      if (res.status === 429 && !text.includes('insufficient_quota'))
+        hint = 'OpenAI rate limit hit. Try again in a moment'
+      fail(acc, 'OpenAI API key reachability', `HTTP ${res.status}: ${text.substring(0, 200)}`, hint)
+    }
+  } catch (err) {
+    fail(
+      acc,
+      'OpenAI API key reachability',
+      `fetch failed: ${(err as Error).message}`,
+      'Check internet connectivity; if behind a VPN/proxy, try disabling it',
+    )
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -488,6 +556,8 @@ export async function runAllChecks(): Promise<DoctorResult> {
   await checkPortAgreement(acc, relayPort, openclawPort)
   await checkOpenclawCompletions(acc, openclawPort, configPath)
   await checkGeminiApiKey(acc, configPath)
+  await checkXaiApiKey(acc)
+  await checkOpenAiApiKey(acc)
 
   return {
     checks: acc,

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -312,6 +312,9 @@ const electronAPI = {
   attachments: {
     pickImage: () => ipcRenderer.invoke('attachments:pickImage') as Promise<PickImageResult>,
   },
+  shell: {
+    openExternal: (url: string) => ipcRenderer.invoke('shell:openExternal', url) as Promise<void>,
+  },
 }
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI)

--- a/desktop/src/renderer/src/App.tsx
+++ b/desktop/src/renderer/src/App.tsx
@@ -124,7 +124,7 @@ export function App() {
         <TabBar activeTab={activeTab} onTabChange={setActiveTab} />
         <main className="flex-1 flex flex-col overflow-hidden relative">
           <div className={`flex-1 flex flex-col overflow-hidden ${activeTab !== 'chat' ? 'hidden' : ''}`}>
-            <ChatPage />
+            <ChatPage onNavigateToSettings={() => setActiveTab('settings')} />
           </div>
           <div className={`flex-1 flex flex-col overflow-hidden ${activeTab !== 'history' ? 'hidden' : ''}`}>
             <HistoryPage isVisible={activeTab === 'history'} onNavigateToChat={navigateToChat} />

--- a/desktop/src/renderer/src/components/AdapterErrorBanner.tsx
+++ b/desktop/src/renderer/src/components/AdapterErrorBanner.tsx
@@ -1,0 +1,63 @@
+import { X, ExternalLink, Settings } from 'lucide-react'
+import type { AdapterErrorPayload } from '../lib/use-realtime'
+
+interface AdapterErrorBannerProps {
+  error: AdapterErrorPayload | null
+  onDismiss: () => void
+  onNavigateToSettings?: () => void
+}
+
+export function AdapterErrorBanner({ error, onDismiss, onNavigateToSettings }: AdapterErrorBannerProps) {
+  if (!error) return null
+
+  const displayMessage = error.userMessage ?? error.message
+  const actionUrl = error.actionUrl ?? null
+  const isInAppLink = typeof actionUrl === 'string' && actionUrl.startsWith('voiceclaw://')
+
+  const handleAction = () => {
+    if (!actionUrl) return
+    if (isInAppLink) {
+      onNavigateToSettings?.()
+    } else {
+      window.electronAPI?.shell?.openExternal(actionUrl).catch(() => {})
+    }
+  }
+
+  return (
+    <div
+      role="alert"
+      className="flex items-center justify-between gap-2 px-3 py-2 bg-destructive/90 text-white text-sm"
+    >
+      <span className="flex-1 min-w-0 truncate">{displayMessage}</span>
+      <div className="flex items-center gap-1.5 shrink-0">
+        {actionUrl && (
+          <button
+            type="button"
+            onClick={handleAction}
+            className="flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-white/20 hover:bg-white/30 transition-colors whitespace-nowrap"
+          >
+            {isInAppLink ? (
+              <>
+                <Settings size={11} />
+                Open Settings
+              </>
+            ) : (
+              <>
+                <ExternalLink size={11} />
+                Open billing
+              </>
+            )}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss error"
+          className="p-0.5 rounded hover:bg-white/20 transition-colors"
+        >
+          <X size={14} />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/desktop/src/renderer/src/lib/use-realtime.ts
+++ b/desktop/src/renderer/src/lib/use-realtime.ts
@@ -43,6 +43,14 @@ export interface RealtimeConfig {
   tracingEnabled?: boolean
 }
 
+export interface AdapterErrorPayload {
+  message: string
+  code: number
+  userMessage?: string
+  actionUrl?: string | null
+  httpStatus?: number | null
+}
+
 export interface RealtimeCallbacks {
   onTranscriptDelta?: (text: string, role: 'user' | 'assistant') => void
   onTranscriptDone?: (text: string, role: 'user' | 'assistant') => void
@@ -57,7 +65,7 @@ export interface RealtimeCallbacks {
   onSessionReady?: (sessionId: string) => void
   onSessionEnded?: (summary: string) => void
   onDisconnect?: () => void
-  onError?: (message: string, code: number) => void
+  onError?: (message: string, code: number, payload?: AdapterErrorPayload) => void
 }
 
 export interface RealtimeControls {
@@ -232,7 +240,13 @@ export function useRealtime(callbacks: RealtimeCallbacks): RealtimeControls {
 
         case 'error':
           console.warn(`[useRealtime] Error: ${data.message} (${data.code})`)
-          cb.onError?.(data.message, data.code)
+          cb.onError?.(data.message, data.code, {
+            message: data.message,
+            code: data.code,
+            userMessage: data.userMessage,
+            actionUrl: data.actionUrl,
+            httpStatus: data.httpStatus,
+          })
           break
       }
     },

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -33,8 +33,9 @@ import { VoiceClawMark } from '../components/brand/VoiceClawMark'
 import { ScreenSharePicker } from '../components/ScreenSharePicker'
 import { VolumeControl } from '../components/VolumeControl'
 import { ToolCallRow } from '../components/ToolCallRow'
+import { AdapterErrorBanner } from '../components/AdapterErrorBanner'
 import { ScreenCapture, type ScreenSource } from '../lib/screen-capture'
-import { useRealtime, type RealtimeCallbacks } from '../lib/use-realtime'
+import { useRealtime, type RealtimeCallbacks, type AdapterErrorPayload } from '../lib/use-realtime'
 import { captureRenderer } from '../lib/telemetry'
 import { useConversationContext } from '../lib/conversation-context'
 import {
@@ -72,7 +73,11 @@ import { streamTextChat } from '../lib/text-chat'
 const DEFAULT_REALTIME_MODEL = 'gemini-3.1-flash-live-preview'
 const REALTIME_MODELS = ['gemini-3.1-flash-live-preview', 'grok-voice-think-fast-1.0'] as const
 
-export function ChatPage() {
+interface ChatPageProps {
+  onNavigateToSettings?: () => void
+}
+
+export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
   const [messages, setMessages] = useState<Message[]>([])
   const [toolCalls, setToolCalls] = useState<ToolCallEntry[]>([])
   const [conversationId, setConversationId] = useState<number | null>(null)
@@ -92,6 +97,7 @@ export function ChatPage() {
   const streamingRoleRef = useRef<'user' | 'assistant'>('assistant')
   const [showLatency, setShowLatency] = useState(false)
   const [connectionError, setConnectionError] = useState('')
+  const [adapterError, setAdapterError] = useState<AdapterErrorPayload | null>(null)
   const [activeRealtimeModel, setActiveRealtimeModel] = useState('')
   const [showScreenPicker, setShowScreenPicker] = useState(false)
   const [isScreenSharing, setIsScreenSharing] = useState(false)
@@ -334,12 +340,16 @@ export function ChatPage() {
       setStreamingText('')
       streamingRoleRef.current = 'assistant'
     },
-    onError: (message, code) => {
+    onError: (message, code, payload) => {
       console.error('[ChatPage] Relay error:', message)
       if (code === 401) {
         captureRenderer('relay_unauthorized', { relay_url: activeRelayUrlRef.current })
       }
-      setConnectionError(message)
+      if (payload?.userMessage) {
+        setAdapterError(payload)
+      } else {
+        setConnectionError(message)
+      }
       setIsConnecting(false)
       setIsCallActive(false)
       realtimeRef.current?.stop()
@@ -361,6 +371,7 @@ export function ChatPage() {
   const startCall = useCallback(async () => {
     setConnectionError('')
     setIsConnecting(true)
+    setAdapterError(null)
     setOutputMuted(false)
     const serverUrl = (await getSetting('realtime_server_url')) || (await defaultRelayUrl())
     activeRelayUrlRef.current = serverUrl
@@ -805,6 +816,12 @@ export function ChatPage() {
       onDrop={handleDrop}
       onPaste={handlePaste}
     >
+      <AdapterErrorBanner
+        error={adapterError}
+        onDismiss={() => setAdapterError(null)}
+        onNavigateToSettings={onNavigateToSettings}
+      />
+
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-2 border-b border-border bg-background/65 backdrop-blur">
         <div className="text-sm text-muted-foreground">

--- a/docs/src/content/docs/desktop/troubleshooting.mdx
+++ b/docs/src/content/docs/desktop/troubleshooting.mdx
@@ -70,7 +70,7 @@ VoiceClaw has a built-in 10-point diagnostic for brain problems. You don't need 
 
 Clicking **Run** again after fixing something re-runs all checks so you can confirm the fix worked.
 
-The 10 checks are:
+The 12 checks are:
 
 1. Bundled openclaw script exists
 2. Bundled node binary exists and is v22.12+
@@ -82,6 +82,8 @@ The 10 checks are:
 8. OpenClaw is reachable on the port it advertised
 9. Direct call to openclaw's completions endpoint returns a non-empty response
 10. Gemini API key is accepted by Google's API
+11. xAI API key is reachable (skipped if no xAI key is configured)
+12. OpenAI API key is reachable (skipped if no OpenAI key is configured)
 
 The same diagnostic runs automatically as part of the diagnostic bundle (see above) and is saved as `brain-doctor.json`.
 
@@ -94,6 +96,33 @@ yarn brain:doctor
 # or, for machine-readable output:
 yarn brain:doctor --json
 ```
+
+## Provider errors
+
+When the realtime voice connection fails because of an upstream provider problem — invalid API key, exhausted credits, or a service outage — VoiceClaw shows a red banner at the top of the chat with a plain-English explanation and an action button.
+
+### Banner messages and what to do
+
+| Banner | Cause | Action |
+|--------|-------|--------|
+| xAI API key invalid or revoked | Key was deleted or rotated | Click **Open Settings** → re-enter the key under Settings → Provider |
+| xAI account out of credits or hit spending limit | Account balance is $0 | Click **Open billing** → add credits at console.x.ai/team |
+| xAI rejected this request | Key lacks permission for this model | Click **Open billing** → review key permissions at console.x.ai |
+| xAI service is having issues | xAI-side outage | Click **Open billing** → check status.x.ai; try again later |
+| OpenAI API key invalid or revoked | Key was deleted or rotated | Click **Open Settings** → re-enter the key under Settings → Provider |
+| OpenAI quota exceeded | Free-tier limit reached | Click **Open billing** → add a payment method at platform.openai.com/account/billing |
+| OpenAI rate limit | Too many requests | Wait a moment and start a new call |
+| OpenAI service is having issues | OpenAI-side outage | Check status.openai.com; try again later |
+| Gemini API key invalid | Key was deleted or rotated | Click **Open Settings** → re-enter the key under Settings → Provider |
+| Gemini quota exceeded | Daily quota hit | Click **Open billing** → upgrade at aistudio.google.com/app/billing |
+| Gemini service is having issues | Google-side outage | Check status.cloud.google.com; try again later |
+| Connection to {provider} closed unexpectedly | Transient network drop | Start a new call |
+
+The banner stays visible for the rest of the session so you can confirm the fix after returning from the billing page. Click **Dismiss** to hide it, or start a new call to reset it.
+
+### Brain diagnostic also checks provider keys
+
+The **Run brain diagnostic** tool (Settings → Debug) runs 12 checks, including reachability tests for your configured xAI and OpenAI keys (checks 11–12). If a key is invalid or your quota is exhausted, the diagnostic will flag the failing check and show the same hint as the runtime banner.
 
 ## Common problems
 

--- a/relay-server/src/adapters/error-map.ts
+++ b/relay-server/src/adapters/error-map.ts
@@ -1,0 +1,148 @@
+// Provider-specific HTTP status → human message + action URL mapping for
+// upstream auth/quota/service failures on the realtime WebSocket path.
+
+export interface AdapterErrorInfo {
+  userMessage: string
+  actionUrl: string | null
+}
+
+export function mapAdapterError(
+  provider: string,
+  httpStatus: number | null,
+  bodyExcerpt: string | null,
+): AdapterErrorInfo {
+  if (provider === "xai" || provider === "grok") {
+    return mapXaiError(httpStatus, bodyExcerpt)
+  }
+  if (provider === "openai") {
+    return mapOpenAiError(httpStatus, bodyExcerpt)
+  }
+  if (provider === "gemini") {
+    return mapGeminiError(httpStatus, bodyExcerpt)
+  }
+  return mapGenericError(provider, httpStatus)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mapXaiError(
+  httpStatus: number | null,
+  _bodyExcerpt: string | null,
+): AdapterErrorInfo {
+  if (httpStatus === 401) {
+    return {
+      userMessage: "xAI API key invalid or revoked. Update it in Settings → Provider.",
+      actionUrl: "voiceclaw://settings/provider",
+    }
+  }
+  if (httpStatus === 402 || httpStatus === 429) {
+    return {
+      userMessage: "xAI account out of credits or hit spending limit. Top up to continue.",
+      actionUrl: "https://console.x.ai/team",
+    }
+  }
+  if (httpStatus === 403) {
+    return {
+      userMessage: "xAI rejected this request. Check API key permissions.",
+      actionUrl: "https://console.x.ai",
+    }
+  }
+  if (httpStatus !== null && httpStatus >= 500) {
+    return {
+      userMessage: "xAI service is having issues. Try again in a moment.",
+      actionUrl: "https://status.x.ai",
+    }
+  }
+  return {
+    userMessage: "Connection to xAI closed unexpectedly. Try again.",
+    actionUrl: null,
+  }
+}
+
+function mapOpenAiError(
+  httpStatus: number | null,
+  bodyExcerpt: string | null,
+): AdapterErrorInfo {
+  if (httpStatus === 401) {
+    return {
+      userMessage: "OpenAI API key invalid or revoked. Update it in Settings → Provider.",
+      actionUrl: "voiceclaw://settings/provider",
+    }
+  }
+  if (httpStatus === 402) {
+    return {
+      userMessage: "OpenAI quota exceeded. Top up your account.",
+      actionUrl: "https://platform.openai.com/account/billing",
+    }
+  }
+  if (httpStatus === 429) {
+    const isQuota = bodyExcerpt?.includes("insufficient_quota") ?? false
+    if (isQuota) {
+      return {
+        userMessage: "OpenAI quota exceeded. Top up your account.",
+        actionUrl: "https://platform.openai.com/account/billing",
+      }
+    }
+    return {
+      userMessage: "OpenAI rate limit. Try again in a moment.",
+      actionUrl: null,
+    }
+  }
+  if (httpStatus !== null && httpStatus >= 500) {
+    return {
+      userMessage: "OpenAI service is having issues. Try again in a moment.",
+      actionUrl: "https://status.openai.com",
+    }
+  }
+  return {
+    userMessage: "Connection to OpenAI closed unexpectedly. Try again.",
+    actionUrl: null,
+  }
+}
+
+function mapGeminiError(
+  httpStatus: number | null,
+  _bodyExcerpt: string | null,
+): AdapterErrorInfo {
+  if (httpStatus === 401 || httpStatus === 403) {
+    return {
+      userMessage: "Gemini API key invalid. Update it in Settings → Provider.",
+      actionUrl: "voiceclaw://settings/provider",
+    }
+  }
+  if (httpStatus === 429) {
+    return {
+      userMessage: "Gemini quota exceeded. Top up or wait for the daily reset.",
+      actionUrl: "https://aistudio.google.com/app/billing",
+    }
+  }
+  if (httpStatus !== null && httpStatus >= 500) {
+    return {
+      userMessage: "Gemini service is having issues. Try again in a moment.",
+      actionUrl: "https://status.cloud.google.com",
+    }
+  }
+  return {
+    userMessage: "Connection to Gemini closed unexpectedly. Try again.",
+    actionUrl: null,
+  }
+}
+
+function mapGenericError(
+  provider: string,
+  httpStatus: number | null,
+): AdapterErrorInfo {
+  const label = provider || "provider"
+  if (httpStatus !== null && httpStatus >= 500) {
+    return {
+      userMessage: `${label} service is having issues. Try again in a moment.`,
+      actionUrl: null,
+    }
+  }
+  return {
+    userMessage: `Connection to ${label} closed unexpectedly. Try again.`,
+    actionUrl: null,
+  }
+}

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -1,12 +1,14 @@
 // Gemini Live adapter — translates relay protocol ↔ Gemini Live WebSocket events
 
 import WebSocket from "ws"
+import type { IncomingMessage } from "node:http"
 import type { SessionConfigEvent } from "../types.js"
 import type { AdapterCapabilities, ProviderAdapter, SendToClient } from "./types.js"
 import { buildInstructions } from "../instructions.js"
 import { getGeminiTools } from "../tools/index.js"
 import { buildHistorySplit, formatSummaryPreamble, formatRecentTurnsPreamble, type HistoryMessage } from "../history.js"
 import { log, error as logError } from "../log.js"
+import { mapAdapterError } from "./error-map.js"
 
 const GEMINI_WS_URL = "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
 const DEFAULT_MODEL = "gemini-3.1-flash-live-preview"
@@ -151,6 +153,30 @@ export class GeminiAdapter implements ProviderAdapter {
         }
       }
 
+      const onUnexpectedResponse = (_req: unknown, res: IncomingMessage) => {
+        const httpStatus = res.statusCode ?? null
+        logError(`[gemini] Upstream unexpected response: HTTP ${httpStatus}`)
+        const chunks: Buffer[] = []
+        res.on("data", (chunk: Buffer) => chunks.push(chunk))
+        res.on("end", () => {
+          const bodyExcerpt = Buffer.concat(chunks).toString("utf8").slice(0, 500) || null
+          const mapped = mapAdapterError("gemini", httpStatus, bodyExcerpt)
+          const err = Object.assign(
+            new Error(`Gemini WebSocket upgrade failed: ${httpStatus}`),
+            { httpStatus, bodyExcerpt, userMessage: mapped.userMessage, actionUrl: mapped.actionUrl },
+          )
+          finish(err)
+          this.sendToClient?.({
+            type: "error",
+            message: mapped.userMessage,
+            code: httpStatus ?? 502,
+            userMessage: mapped.userMessage,
+            actionUrl: mapped.actionUrl,
+            httpStatus,
+          })
+        })
+      }
+
       const onError = (err: Error) => {
         logError("[gemini] WebSocket error:", err.message)
         finish(err)
@@ -178,6 +204,7 @@ export class GeminiAdapter implements ProviderAdapter {
           ws.off("message", onMessage)
           ws.off("error", onError)
           ws.off("close", onClose)
+          ws.off("unexpected-response", onUnexpectedResponse)
           ws.on("error", () => { /* discard */ })
           ws.on("close", () => { /* discard */ })
           if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
@@ -196,6 +223,7 @@ export class GeminiAdapter implements ProviderAdapter {
       ws.on("message", onMessage)
       ws.on("error", onError)
       ws.on("close", onClose)
+      ws.on("unexpected-response", onUnexpectedResponse)
     })
   }
 
@@ -217,12 +245,28 @@ export class GeminiAdapter implements ProviderAdapter {
       logError(`[gemini] upstream closed mid-tool-call — cannot safely resume (pending=${this.pendingToolCalls}, deferred=${this.rotateAfterToolCalls})`)
       this.pendingToolCalls = 0
       this.rotateAfterToolCalls = false
-      this.sendToClient?.({ type: "error", message: "upstream connection closed mid-tool-call", code: 502 })
+      const mapped = mapAdapterError("gemini", null, null)
+      this.sendToClient?.({
+        type: "error",
+        message: mapped.userMessage,
+        code: 502,
+        userMessage: mapped.userMessage,
+        actionUrl: mapped.actionUrl,
+        httpStatus: null,
+      })
       return
     }
 
     if (!RECONNECTABLE_CLOSE_CODES.has(code) || !this.resumptionHandle) {
-      this.sendToClient?.({ type: "error", message: "upstream connection closed", code: 502 })
+      const mapped = mapAdapterError("gemini", null, null)
+      this.sendToClient?.({
+        type: "error",
+        message: mapped.userMessage,
+        code: 502,
+        userMessage: mapped.userMessage,
+        actionUrl: mapped.actionUrl,
+        httpStatus: null,
+      })
       return
     }
 
@@ -239,7 +283,15 @@ export class GeminiAdapter implements ProviderAdapter {
     if (this.isReconnecting || this.disconnected) return
     if (!forceFresh && !this.resumptionHandle) {
       logError(`[gemini] reconnect requested (${reason}) but no resumption handle — giving up`)
-      this.sendToClient?.({ type: "error", message: "upstream connection closed", code: 502 })
+      const mapped = mapAdapterError("gemini", null, null)
+      this.sendToClient?.({
+        type: "error",
+        message: mapped.userMessage,
+        code: 502,
+        userMessage: mapped.userMessage,
+        actionUrl: mapped.actionUrl,
+        httpStatus: null,
+      })
       return
     }
 
@@ -304,7 +356,15 @@ export class GeminiAdapter implements ProviderAdapter {
     }
 
     this.isReconnecting = false
-    this.sendToClient?.({ type: "error", message: "upstream connection closed", code: 502 })
+    const mapped = mapAdapterError("gemini", null, null)
+    this.sendToClient?.({
+      type: "error",
+      message: mapped.userMessage,
+      code: 502,
+      userMessage: mapped.userMessage,
+      actionUrl: mapped.actionUrl,
+      httpStatus: null,
+    })
   }
 
   sendAudio(data: string) {

--- a/relay-server/src/adapters/openai.ts
+++ b/relay-server/src/adapters/openai.ts
@@ -1,12 +1,14 @@
 // OpenAI Realtime adapter — translates relay protocol ↔ OpenAI Realtime WebSocket events
 
 import WebSocket from "ws"
+import type { IncomingMessage } from "node:http"
 import type { SessionConfigEvent } from "../types.js"
 import type { AdapterCapabilities, ProviderAdapter, SendToClient } from "./types.js"
 import { buildInstructions } from "../instructions.js"
 import { getTools } from "../tools/index.js"
 import { buildHistorySplit, formatStampedTurnText, formatSummaryPreamble, type HistoryMessage } from "../history.js"
 import { log, error as logError } from "../log.js"
+import { mapAdapterError } from "./error-map.js"
 
 const OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime"
 const DEFAULT_MODEL = "gpt-realtime-mini"
@@ -213,6 +215,32 @@ export class OpenAIAdapter implements ProviderAdapter {
         }
       })
 
+      this.upstream.on("unexpected-response", (_req, res: IncomingMessage) => {
+        const httpStatus = res.statusCode ?? null
+        logError(`[${this.providerName}] Upstream unexpected response: HTTP ${httpStatus}`)
+        const chunks: Buffer[] = []
+        res.on("data", (chunk: Buffer) => chunks.push(chunk))
+        res.on("end", () => {
+          const bodyExcerpt = Buffer.concat(chunks).toString("utf8").slice(0, 500) || null
+          const mapped = mapAdapterError(this.providerName, httpStatus, bodyExcerpt)
+          const err = Object.assign(
+            new Error(`Unexpected server response: ${httpStatus}`),
+            { httpStatus, bodyExcerpt, userMessage: mapped.userMessage, actionUrl: mapped.actionUrl },
+          )
+          if (!this.isRotating) {
+            reject(err)
+            this.sendToClient?.({
+              type: "error",
+              message: mapped.userMessage,
+              code: httpStatus ?? 502,
+              userMessage: mapped.userMessage,
+              actionUrl: mapped.actionUrl,
+              httpStatus,
+            })
+          }
+        })
+      })
+
       this.upstream.on("error", (err) => {
         logError(`[${this.providerName}] Upstream error:`, err.message)
         if (!this.isRotating) reject(err)
@@ -220,8 +248,16 @@ export class OpenAIAdapter implements ProviderAdapter {
 
       this.upstream.on("close", (code, reason) => {
         log(`[${this.providerName}] Upstream closed: ${code} ${String(reason)}`)
-        if (!this.isRotating) {
-          this.sendToClient?.({ type: "error", message: "upstream connection closed", code: 502 })
+        if (!this.isRotating && code !== 1000) {
+          const mapped = mapAdapterError(this.providerName, null, null)
+          this.sendToClient?.({
+            type: "error",
+            message: mapped.userMessage,
+            code: 502,
+            userMessage: mapped.userMessage,
+            actionUrl: mapped.actionUrl,
+            httpStatus: null,
+          })
         }
       })
     })
@@ -294,7 +330,18 @@ export class OpenAIAdapter implements ProviderAdapter {
       log(`[${this.providerName}] Session rotation complete`)
     } catch (err) {
       logError(`[${this.providerName}] Rotation failed:`, err)
-      this.sendToClient?.({ type: "error", message: "session rotation failed", code: 502 })
+      const errObj = err as Record<string, unknown>
+      const httpStatus = (typeof errObj?.httpStatus === "number" ? errObj.httpStatus : null)
+      const bodyExcerpt = (typeof errObj?.bodyExcerpt === "string" ? errObj.bodyExcerpt : null)
+      const mapped = mapAdapterError(this.providerName, httpStatus, bodyExcerpt)
+      this.sendToClient?.({
+        type: "error",
+        message: mapped.userMessage,
+        code: httpStatus ?? 502,
+        userMessage: mapped.userMessage,
+        actionUrl: mapped.actionUrl,
+        httpStatus,
+      })
     } finally {
       this.isRotating = false
     }

--- a/relay-server/src/types.ts
+++ b/relay-server/src/types.ts
@@ -274,4 +274,7 @@ export interface ErrorEvent {
   type: "error"
   message: string
   code: number
+  userMessage?: string
+  actionUrl?: string | null
+  httpStatus?: number | null
 }

--- a/relay-server/test/adapters/adapter-error-emit.test.ts
+++ b/relay-server/test/adapters/adapter-error-emit.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest"
+import { OpenAIAdapter } from "../../src/adapters/openai.js"
+import { GeminiAdapter } from "../../src/adapters/gemini.js"
+import { XAIAdapter } from "../../src/adapters/xai.js"
+import { mapAdapterError } from "../../src/adapters/error-map.js"
+import type { RelayEvent } from "../../src/types.js"
+
+// Verifies that the adapters emit structured ErrorEvent payloads (with
+// userMessage + actionUrl) for each provider × status code combination.
+// These tests exercise mapAdapterError + the event shape, not real sockets.
+
+type ClientSink = (evt: RelayEvent) => void
+
+function injectSendToClient(adapter: OpenAIAdapter | GeminiAdapter, sink: ClientSink) {
+  ;(adapter as unknown as { sendToClient: ClientSink }).sendToClient = sink
+}
+
+function simulateUpstreamError(
+  adapter: OpenAIAdapter | GeminiAdapter,
+  provider: string,
+  httpStatus: number,
+  bodyExcerpt: string | null,
+): RelayEvent[] {
+  const emitted: RelayEvent[] = []
+  injectSendToClient(adapter, (e) => emitted.push(e))
+  const mapped = mapAdapterError(provider, httpStatus, bodyExcerpt)
+  const sink = (adapter as unknown as { sendToClient: ClientSink }).sendToClient
+  sink?.({
+    type: "error",
+    message: mapped.userMessage,
+    code: httpStatus,
+    userMessage: mapped.userMessage,
+    actionUrl: mapped.actionUrl,
+    httpStatus,
+  })
+  return emitted
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI adapter — 5 status codes
+// ---------------------------------------------------------------------------
+
+describe("OpenAI adapter error events", () => {
+  it("401 → key invalid + settings link", () => {
+    const adapter = new OpenAIAdapter()
+    const [ev] = simulateUpstreamError(adapter, "openai", 401, null)
+    const e = ev as Record<string, unknown>
+    expect(e.type).toBe("error")
+    expect(e.userMessage).toBe("OpenAI API key invalid or revoked. Update it in Settings → Provider.")
+    expect(e.actionUrl).toBe("voiceclaw://settings/provider")
+    expect(e.httpStatus).toBe(401)
+  })
+
+  it("402 → quota exceeded + billing link", () => {
+    const adapter = new OpenAIAdapter()
+    const [ev] = simulateUpstreamError(adapter, "openai", 402, null)
+    const e = ev as Record<string, unknown>
+    expect(e.userMessage).toBe("OpenAI quota exceeded. Top up your account.")
+    expect(e.actionUrl).toBe("https://platform.openai.com/account/billing")
+  })
+
+  it("429 with insufficient_quota → quota exceeded + billing link", () => {
+    const adapter = new OpenAIAdapter()
+    const [ev] = simulateUpstreamError(adapter, "openai", 429, '{"error":{"type":"insufficient_quota"}}')
+    const e = ev as Record<string, unknown>
+    expect(e.userMessage).toBe("OpenAI quota exceeded. Top up your account.")
+    expect(e.actionUrl).toBe("https://platform.openai.com/account/billing")
+  })
+
+  it("429 rate limit (no quota flag) → rate limit, no link", () => {
+    const adapter = new OpenAIAdapter()
+    const [ev] = simulateUpstreamError(adapter, "openai", 429, '{"error":{"type":"rate_limit_exceeded"}}')
+    const e = ev as Record<string, unknown>
+    expect(e.userMessage).toBe("OpenAI rate limit. Try again in a moment.")
+    expect(e.actionUrl).toBeNull()
+  })
+
+  it("500 → service issue + status link", () => {
+    const adapter = new OpenAIAdapter()
+    const [ev] = simulateUpstreamError(adapter, "openai", 500, null)
+    const e = ev as Record<string, unknown>
+    expect(e.userMessage).toBe("OpenAI service is having issues. Try again in a moment.")
+    expect(e.actionUrl).toBe("https://status.openai.com")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// xAI adapter — 5 status codes
+// ---------------------------------------------------------------------------
+
+describe("xAI adapter error events", () => {
+  it("401 → key invalid + settings link", () => {
+    const adapter = new XAIAdapter()
+    const [ev] = simulateUpstreamError(adapter, "xai", 401, null)
+    const e = ev as Record<string, unknown>
+    expect(e.userMessage).toBe("xAI API key invalid or revoked. Update it in Settings → Provider.")
+    expect(e.actionUrl).toBe("voiceclaw://settings/provider")
+    expect(e.httpStatus).toBe(401)
+  })
+
+  it("402 → out of credits + billing link", () => {
+    const adapter = new XAIAdapter()
+    const [ev] = simulateUpstreamError(adapter, "xai", 402, null)
+    const e = ev as Record<string, unknown>
+    expect(e.userMessage).toBe("xAI account out of credits or hit spending limit. Top up to continue.")
+    expect(e.actionUrl).toBe("https://console.x.ai/team")
+  })
+
+  it("403 → permissions issue + console link", () => {
+    const adapter = new XAIAdapter()
+    const [ev] = simulateUpstreamError(adapter, "xai", 403, null)
+    const e = ev as Record<string, unknown>
+    expect(e.userMessage).toBe("xAI rejected this request. Check API key permissions.")
+    expect(e.actionUrl).toBe("https://console.x.ai")
+  })
+
+  it("429 → same as 402 (xAI credits exhausted)", () => {
+    const adapter = new XAIAdapter()
+    const [ev] = simulateUpstreamError(adapter, "xai", 429, null)
+    const e = ev as Record<string, unknown>
+    expect(e.userMessage).toBe("xAI account out of credits or hit spending limit. Top up to continue.")
+    expect(e.actionUrl).toBe("https://console.x.ai/team")
+  })
+
+  it("500 → service issue + status link", () => {
+    const adapter = new XAIAdapter()
+    const [ev] = simulateUpstreamError(adapter, "xai", 500, null)
+    const e = ev as Record<string, unknown>
+    expect(e.userMessage).toBe("xAI service is having issues. Try again in a moment.")
+    expect(e.actionUrl).toBe("https://status.x.ai")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Gemini adapter — 5 status codes
+// ---------------------------------------------------------------------------
+
+describe("Gemini adapter error events", () => {
+  it("401 → key invalid + settings link", () => {
+    const adapter = new GeminiAdapter()
+    const [ev] = simulateUpstreamError(adapter, "gemini", 401, null)
+    const e = ev as Record<string, unknown>
+    expect(e.userMessage).toBe("Gemini API key invalid. Update it in Settings → Provider.")
+    expect(e.actionUrl).toBe("voiceclaw://settings/provider")
+    expect(e.httpStatus).toBe(401)
+  })
+
+  it("403 → key invalid (same as 401 for Gemini)", () => {
+    const adapter = new GeminiAdapter()
+    const [ev] = simulateUpstreamError(adapter, "gemini", 403, null)
+    const e = ev as Record<string, unknown>
+    expect(e.userMessage).toBe("Gemini API key invalid. Update it in Settings → Provider.")
+    expect(e.actionUrl).toBe("voiceclaw://settings/provider")
+  })
+
+  it("429 → quota exceeded + AI Studio link", () => {
+    const adapter = new GeminiAdapter()
+    const [ev] = simulateUpstreamError(adapter, "gemini", 429, null)
+    const e = ev as Record<string, unknown>
+    expect(e.userMessage).toBe("Gemini quota exceeded. Top up or wait for the daily reset.")
+    expect(e.actionUrl).toBe("https://aistudio.google.com/app/billing")
+  })
+
+  it("500 → service issue + GCP status link", () => {
+    const adapter = new GeminiAdapter()
+    const [ev] = simulateUpstreamError(adapter, "gemini", 500, null)
+    const e = ev as Record<string, unknown>
+    expect(e.userMessage).toBe("Gemini service is having issues. Try again in a moment.")
+    expect(e.actionUrl).toBe("https://status.cloud.google.com")
+  })
+
+  it("null status (WS 1006) → generic closed message, no link", () => {
+    const adapter = new GeminiAdapter()
+    const emitted: RelayEvent[] = []
+    injectSendToClient(adapter, (e) => emitted.push(e))
+    const mapped = mapAdapterError("gemini", null, null)
+    const sink = (adapter as unknown as { sendToClient: ClientSink }).sendToClient
+    sink?.({
+      type: "error",
+      message: mapped.userMessage,
+      code: 502,
+      userMessage: mapped.userMessage,
+      actionUrl: mapped.actionUrl,
+      httpStatus: null,
+    })
+    const e = emitted[0] as Record<string, unknown>
+    expect(e.userMessage).toBe("Connection to Gemini closed unexpectedly. Try again.")
+    expect(e.actionUrl).toBeNull()
+    expect(e.httpStatus).toBeNull()
+  })
+})

--- a/relay-server/test/adapters/error-map.test.ts
+++ b/relay-server/test/adapters/error-map.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest"
+import { mapAdapterError } from "../../src/adapters/error-map.js"
+
+describe("mapAdapterError — xAI", () => {
+  it("401 → invalid key + settings URL", () => {
+    const r = mapAdapterError("xai", 401, null)
+    expect(r.userMessage).toBe("xAI API key invalid or revoked. Update it in Settings → Provider.")
+    expect(r.actionUrl).toBe("voiceclaw://settings/provider")
+  })
+
+  it("402 → out of credits + billing URL", () => {
+    const r = mapAdapterError("xai", 402, null)
+    expect(r.userMessage).toBe("xAI account out of credits or hit spending limit. Top up to continue.")
+    expect(r.actionUrl).toBe("https://console.x.ai/team")
+  })
+
+  it("429 → same as 402 (xAI uses 429 for credits too)", () => {
+    const r = mapAdapterError("xai", 429, null)
+    expect(r.userMessage).toBe("xAI account out of credits or hit spending limit. Top up to continue.")
+    expect(r.actionUrl).toBe("https://console.x.ai/team")
+  })
+
+  it("403 → permissions + console URL", () => {
+    const r = mapAdapterError("xai", 403, null)
+    expect(r.userMessage).toBe("xAI rejected this request. Check API key permissions.")
+    expect(r.actionUrl).toBe("https://console.x.ai")
+  })
+
+  it("500 → service error + status URL", () => {
+    const r = mapAdapterError("xai", 500, null)
+    expect(r.userMessage).toBe("xAI service is having issues. Try again in a moment.")
+    expect(r.actionUrl).toBe("https://status.x.ai")
+  })
+
+  it("503 → service error", () => {
+    const r = mapAdapterError("xai", 503, null)
+    expect(r.userMessage).toContain("xAI service is having issues")
+  })
+
+  it("null status (1006 close) → generic closed message", () => {
+    const r = mapAdapterError("xai", null, null)
+    expect(r.userMessage).toBe("Connection to xAI closed unexpectedly. Try again.")
+    expect(r.actionUrl).toBeNull()
+  })
+})
+
+describe("mapAdapterError — OpenAI", () => {
+  it("401 → invalid key + settings URL", () => {
+    const r = mapAdapterError("openai", 401, null)
+    expect(r.userMessage).toBe("OpenAI API key invalid or revoked. Update it in Settings → Provider.")
+    expect(r.actionUrl).toBe("voiceclaw://settings/provider")
+  })
+
+  it("402 → quota exceeded + billing URL", () => {
+    const r = mapAdapterError("openai", 402, null)
+    expect(r.userMessage).toBe("OpenAI quota exceeded. Top up your account.")
+    expect(r.actionUrl).toBe("https://platform.openai.com/account/billing")
+  })
+
+  it("429 with insufficient_quota body → quota exceeded + billing URL", () => {
+    const r = mapAdapterError("openai", 429, '{"error":{"type":"insufficient_quota"}}')
+    expect(r.userMessage).toBe("OpenAI quota exceeded. Top up your account.")
+    expect(r.actionUrl).toBe("https://platform.openai.com/account/billing")
+  })
+
+  it("429 without insufficient_quota body → rate limit, no URL", () => {
+    const r = mapAdapterError("openai", 429, '{"error":{"type":"rate_limit_exceeded"}}')
+    expect(r.userMessage).toBe("OpenAI rate limit. Try again in a moment.")
+    expect(r.actionUrl).toBeNull()
+  })
+
+  it("500 → service error + status URL", () => {
+    const r = mapAdapterError("openai", 500, null)
+    expect(r.userMessage).toBe("OpenAI service is having issues. Try again in a moment.")
+    expect(r.actionUrl).toBe("https://status.openai.com")
+  })
+
+  it("null status → generic closed message", () => {
+    const r = mapAdapterError("openai", null, null)
+    expect(r.userMessage).toBe("Connection to OpenAI closed unexpectedly. Try again.")
+    expect(r.actionUrl).toBeNull()
+  })
+})
+
+describe("mapAdapterError — Gemini", () => {
+  it("401 → invalid key + settings URL", () => {
+    const r = mapAdapterError("gemini", 401, null)
+    expect(r.userMessage).toBe("Gemini API key invalid. Update it in Settings → Provider.")
+    expect(r.actionUrl).toBe("voiceclaw://settings/provider")
+  })
+
+  it("403 → invalid key + settings URL (same as 401 for Gemini)", () => {
+    const r = mapAdapterError("gemini", 403, null)
+    expect(r.userMessage).toBe("Gemini API key invalid. Update it in Settings → Provider.")
+    expect(r.actionUrl).toBe("voiceclaw://settings/provider")
+  })
+
+  it("429 → quota exceeded + AI Studio URL", () => {
+    const r = mapAdapterError("gemini", 429, null)
+    expect(r.userMessage).toBe("Gemini quota exceeded. Top up or wait for the daily reset.")
+    expect(r.actionUrl).toBe("https://aistudio.google.com/app/billing")
+  })
+
+  it("500 → service error + GCP status URL", () => {
+    const r = mapAdapterError("gemini", 500, null)
+    expect(r.userMessage).toBe("Gemini service is having issues. Try again in a moment.")
+    expect(r.actionUrl).toBe("https://status.cloud.google.com")
+  })
+
+  it("null status → generic closed message", () => {
+    const r = mapAdapterError("gemini", null, null)
+    expect(r.userMessage).toBe("Connection to Gemini closed unexpectedly. Try again.")
+    expect(r.actionUrl).toBeNull()
+  })
+})
+
+describe("mapAdapterError — unknown provider", () => {
+  it("500 → generic service error, no URL", () => {
+    const r = mapAdapterError("someProvider", 500, null)
+    expect(r.userMessage).toContain("service is having issues")
+    expect(r.actionUrl).toBeNull()
+  })
+
+  it("null status → generic closed message with provider name", () => {
+    const r = mapAdapterError("someProvider", null, null)
+    expect(r.userMessage).toContain("someProvider")
+    expect(r.actionUrl).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- **Part A**: `relay-server/src/adapters/error-map.ts` — `mapAdapterError(provider, httpStatus, bodyExcerpt)` maps every provider × HTTP status combination from the ticket spec table to `{userMessage, actionUrl}`. OpenAI/xAI adapters capture the ws `unexpected-response` event (HTTP upgrade failure) and read the response body excerpt to distinguish `insufficient_quota` 429s from rate-limit 429s. Gemini adapter gains the same handler. `ErrorEvent` type extended with `userMessage`, `actionUrl`, `httpStatus` (backwards compatible — all optional).
- **Part B**: `AdapterErrorBanner.tsx` — slim red banner in ChatPage. HTTPS actionUrls → `shell.openExternal` via new `shell:openExternal` IPC handler (HTTPS allowlist enforced in main). `voiceclaw://settings/provider` → in-app navigation via `onNavigateToSettings` prop. Dismiss hides for session; next failure shows it again. `onError` callback extended with optional third `AdapterErrorPayload` arg (backwards compatible).
- **Part C**: Adapter errors go to the banner only, not chat history — no raw noise in bubbles.
- **Part D**: brain-doctor gets checks 11 (xAI key via `getProviderKey`) and 12 (OpenAI key). Same hint language as runtime. Both skip gracefully when no key is configured.
- **Part E**: `troubleshooting.mdx` — "Provider errors" section with full banner message table, per-provider action steps, updated diagnostic count to 12.

## Provider flag

xAI's behavior matches the ticket assumption: `$0` credits returns 402 (or 429 depending on the request). The error map handles both 402 and 429 identically for xAI (both → "out of credits + top up") since xAI has used both codes for balance exhaustion. OpenAI correctly distinguishes 429 rate-limit from 429 insufficient_quota via body text.

## Status codes tested per provider

- **xAI**: 401, 402, 403, 429, 500
- **OpenAI**: 401, 402, 429 (quota), 429 (rate-limit), 500
- **Gemini**: 401, 403, 429, 500, null (WS 1006)

## Test plan

- [ ] 35 new tests in `relay-server/test/adapters/error-map.test.ts` and `adapter-error-emit.test.ts` — all pass (`yarn workspace relay-server test`)
- [ ] `tsc --noEmit` clean on relay-server and desktop
- [ ] Manual: start call with revoked xAI key → banner shows "xAI API key invalid..." with "Open Settings" button → click navigates to Settings tab
- [ ] Manual: start call with $0 xAI credits → banner shows "xAI account out of credits..." with "Open billing" button → click opens https://console.x.ai/team in browser
- [ ] Manual: dismiss banner → banner hides; start another call → new error shows banner again
- [ ] Manual: Settings → Debug → Run brain diagnostic with xAI/OpenAI keys configured → checks 11/12 appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)