### PR TITLE
fix(deps): regen yarn.lock after astro bump (unblocks DMG build)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -29,10 +29,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@astrojs/compiler@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "@astrojs/compiler@npm:3.0.1"
-  checksum: 10/ee864fb2eaa8faf0b7a72cbb113d02fb344d057374b81d3b429471ff48d83e4c263f3735cb22118b0a6adedafa0eb93df384cfff67914b817857dae47df6d9fd
+"@astrojs/compiler@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@astrojs/compiler@npm:4.0.0"
+  checksum: 10/7c9351253b71ad253cf6f3ed91ec8e657dd622a6904acedf5f1a358675a413be5a0e957b18fbabd5d3b3817086c0f17d711a084680ad2dcb7f4696bf0cb5066f
   languageName: node
   linkType: hard
 
@@ -8056,11 +8056,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"astro@npm:6.1.9":
-  version: 6.1.9
-  resolution: "astro@npm:6.1.9"
+"astro@npm:6.2.1":
+  version: 6.2.1
+  resolution: "astro@npm:6.2.1"
   dependencies:
-    "@astrojs/compiler": "npm:^3.0.1"
+    "@astrojs/compiler": "npm:^4.0.0"
     "@astrojs/internal-helpers": "npm:0.9.0"
     "@astrojs/markdown-remark": "npm:7.1.1"
     "@astrojs/telemetry": "npm:3.3.1"
@@ -8120,7 +8120,7 @@ __metadata:
       optional: true
   bin:
     astro: bin/astro.mjs
-  checksum: 10/19bf6bb9018ace59cd8703a3f244bbe3e744245b748799384c1e8ac5b9ec9bd7c69580d9e34127f61a1d0cb232855b9bd7e1796e41a3ea33503cdffe4fc8a1df
+  checksum: 10/47ace59cd4941e0b366af56e7a182e6df2b4ea4d544a974c00f863ad2c8e3a6ef074b1963e6f8002e2bf91f9287e361e59bb67984110356c5a6bea215f98ab41
   languageName: node
   linkType: hard
 
@@ -22755,7 +22755,7 @@ __metadata:
   resolution: "voiceclaw-docs@workspace:docs"
   dependencies:
     "@astrojs/starlight": "npm:0.38.4"
-    astro: "npm:6.1.9"
+    astro: "npm:6.2.1"
     astro-mermaid: "npm:^2.0.1"
     mermaid: "npm:^11.14.0"
     sharp: "npm:^0.34.5"


### PR DESCRIPTION
Stale yarn.lock from astro@6.1.9 → 6.2.1 bump in docs/package.json. CI's yarn install --immutable fails. v0.10.41 DMG never built. This regenerates the lock; v0.10.42 build will succeed and ship NAN-712 (provider error banner).