### PR TITLE
fix(desktop): pre-schedule TTS chunks on audio thread to eliminate boundary clicks (NAN-706)

### DIFF
--- a/desktop/src/renderer/src/lib/audio-engine.test.ts
+++ b/desktop/src/renderer/src/lib/audio-engine.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AudioEngine, SAMPLE_RATE } from './audio-engine'
+
+type FakeSource = {
+  buffer: { duration: number } | null
+  connect: ReturnType<typeof vi.fn>
+  start: ReturnType<typeof vi.fn>
+  stop: ReturnType<typeof vi.fn>
+  onended: (() => void) | null
+}
+
+type FakeGain = { gain: { value: number }, connect: ReturnType<typeof vi.fn> }
+
+type FakeContext = {
+  currentTime: number
+  destination: object
+  createBuffer: (channels: number, length: number, rate: number) => { duration: number, copyToChannel: ReturnType<typeof vi.fn> }
+  createBufferSource: () => FakeSource
+}
+
+let ctx: FakeContext
+let gain: FakeGain
+let createdSources: FakeSource[]
+
+beforeEach(() => {
+  createdSources = []
+  ctx = makeFakeContext()
+  gain = { gain: { value: 1 }, connect: vi.fn() }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('AudioEngine.playAudio scheduling', () => {
+  it('schedules the first chunk at currentTime', () => {
+    const engine = makeEngine()
+    engine.playAudio(silentBase64Chunk(2400))
+
+    expect(createdSources).toHaveLength(1)
+    expect(createdSources[0].start).toHaveBeenCalledTimes(1)
+    expect(createdSources[0].start).toHaveBeenCalledWith(0)
+  })
+
+  it('schedules contiguous chunks at monotonically increasing start times', () => {
+    const engine = makeEngine()
+    const chunkLen = 2400
+    const chunkDuration = chunkLen / SAMPLE_RATE
+
+    engine.playAudio(silentBase64Chunk(chunkLen))
+    engine.playAudio(silentBase64Chunk(chunkLen))
+    engine.playAudio(silentBase64Chunk(chunkLen))
+
+    expect(createdSources).toHaveLength(3)
+    const startTimes = createdSources.map((s) => s.start.mock.calls[0][0] as number)
+    expect(startTimes[0]).toBe(0)
+    expect(startTimes[1]).toBeCloseTo(chunkDuration, 9)
+    expect(startTimes[2]).toBeCloseTo(2 * chunkDuration, 9)
+  })
+
+  it('clamps to currentTime when the schedule has fallen behind', () => {
+    const engine = makeEngine()
+    const chunkLen = 2400
+    engine.playAudio(silentBase64Chunk(chunkLen))
+
+    ctx.currentTime = 5
+
+    engine.playAudio(silentBase64Chunk(chunkLen))
+
+    expect(createdSources).toHaveLength(2)
+    expect(createdSources[1].start).toHaveBeenCalledWith(5)
+  })
+})
+
+describe('AudioEngine.stopPlayback', () => {
+  it('stops all live sources and resets the schedule', () => {
+    const engine = makeEngine()
+    const chunkLen = 2400
+    engine.playAudio(silentBase64Chunk(chunkLen))
+    engine.playAudio(silentBase64Chunk(chunkLen))
+
+    engine.stopPlayback()
+
+    expect(createdSources[0].stop).toHaveBeenCalledTimes(1)
+    expect(createdSources[1].stop).toHaveBeenCalledTimes(1)
+
+    ctx.currentTime = 10
+    engine.playAudio(silentBase64Chunk(chunkLen))
+    expect(createdSources[2].start).toHaveBeenCalledWith(10)
+  })
+
+  it('tolerates already-stopped sources without throwing', () => {
+    const engine = makeEngine()
+    engine.playAudio(silentBase64Chunk(2400))
+    createdSources[0].stop.mockImplementation(() => {
+      throw new Error('already stopped')
+    })
+
+    expect(() => engine.stopPlayback()).not.toThrow()
+  })
+})
+
+describe('AudioEngine source lifecycle', () => {
+  it('removes a source from the live set when it ends naturally', () => {
+    const engine = makeEngine()
+    engine.playAudio(silentBase64Chunk(2400))
+    engine.playAudio(silentBase64Chunk(2400))
+
+    createdSources[0].onended?.()
+
+    engine.stopPlayback()
+    expect(createdSources[0].stop).not.toHaveBeenCalled()
+    expect(createdSources[1].stop).toHaveBeenCalledTimes(1)
+  })
+})
+
+function makeEngine(): AudioEngine {
+  const engine = new AudioEngine()
+  // playAudio guards with `if (!this.audioCtx || !this.gainNode) return`.
+  // Inject mocks directly so we can exercise scheduling without startCapture
+  // (which depends on getUserMedia / AudioWorklet that aren't available here).
+  Object.assign(engine as unknown as Record<string, unknown>, {
+    audioCtx: ctx,
+    gainNode: gain,
+  })
+  return engine
+}
+
+function makeFakeContext(): FakeContext {
+  return {
+    currentTime: 0,
+    destination: {},
+    createBuffer: (_channels: number, length: number, rate: number) => ({
+      duration: length / rate,
+      copyToChannel: vi.fn(),
+    }),
+    createBufferSource: () => {
+      const source: FakeSource = {
+        buffer: null,
+        connect: vi.fn(),
+        start: vi.fn(),
+        stop: vi.fn(),
+        onended: null,
+      }
+      createdSources.push(source)
+      return source
+    },
+  }
+}
+
+function silentBase64Chunk(samples: number): string {
+  const bytes = new Uint8Array(samples * 2)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i])
+  return btoa(binary)
+}

--- a/desktop/src/renderer/src/lib/audio-engine.ts
+++ b/desktop/src/renderer/src/lib/audio-engine.ts
@@ -1,9 +1,5 @@
-// Web Audio API engine for microphone capture and audio playback.
-// Uses AudioWorklet for mic capture (runs on a separate audio thread),
-// with a ScriptProcessorNode fallback for environments that lack support.
-
 export const SAMPLE_RATE = 24000
-const FRAME_SIZE = 2400 // 100ms at 24kHz
+const FRAME_SIZE = 2400
 
 export type AudioDevice = {
   deviceId: string
@@ -16,24 +12,18 @@ export class AudioEngine {
   private micStream: MediaStream | null = null
   private source: MediaStreamAudioSourceNode | null = null
   private gainNode: GainNode | null = null
-  private playbackQueue: Float32Array[] = []
-  private activeSource: AudioBufferSourceNode | null = null
-  private isPlaying = false
+  private liveSources: Set<AudioBufferSourceNode> = new Set()
+  private nextStartTime = 0
   private muted = false
   private currentRms = 0
   private outputVolume = 1
   private outputMuted = false
 
-  // Output (AI voice) level meter — an AnalyserNode tapped off the
-  // playback gain. Cheap enough to keep always-on so the call bar can
-  // light up when the assistant is talking.
   private outputAnalyser: AnalyserNode | null = null
   private outputAnalyserBuf: Float32Array | null = null
 
-  // AudioWorklet path
   private workletNode: AudioWorkletNode | null = null
 
-  // ScriptProcessorNode fallback path
   private processor: ScriptProcessorNode | null = null
   private captureBuffer = new Float32Array(0)
 
@@ -43,15 +33,11 @@ export class AudioEngine {
   ) {
     this.audioCtx = new AudioContext({ sampleRate: SAMPLE_RATE })
 
-    // Gain node for playback volume
     this.gainNode = this.audioCtx.createGain()
     this.gainNode.connect(this.audioCtx.destination)
     this.applyOutputGain()
 
-    // Tap the gain for an output level meter. The analyser lives on the
-    // gain's post-volume signal so the reading reflects what the user
-    // is actually hearing (useful for visualization; the call bar bars
-    // match perceived loudness this way).
+    // Tap the gain post-volume so the level meter reflects what the user hears.
     this.outputAnalyser = this.audioCtx.createAnalyser()
     this.outputAnalyser.fftSize = 512
     this.outputAnalyserBuf = new Float32Array(this.outputAnalyser.fftSize)
@@ -100,18 +86,34 @@ export class AudioEngine {
   playAudio(base64: string) {
     if (!this.audioCtx || !this.gainNode) return
 
-    const float32 = pcm16Base64ToFloat32(base64)
-    this.playbackQueue.push(float32)
-    if (!this.isPlaying) this.drainPlaybackQueue()
+    const samples = pcm16Base64ToFloat32(base64)
+    if (samples.length === 0) return
+
+    const buffer = this.audioCtx.createBuffer(1, samples.length, SAMPLE_RATE)
+    buffer.copyToChannel(samples, 0)
+
+    const source = this.audioCtx.createBufferSource()
+    source.buffer = buffer
+    source.connect(this.gainNode)
+
+    // Pre-schedule on the audio thread so contiguous chunks stitch sample-accurately.
+    // Driving .start() from main-thread onended leaves an audible silence gap.
+    const startAt = Math.max(this.audioCtx.currentTime, this.nextStartTime)
+    source.start(startAt)
+    this.nextStartTime = startAt + buffer.duration
+
+    this.liveSources.add(source)
+    source.onended = () => {
+      this.liveSources.delete(source)
+    }
   }
 
   stopPlayback() {
-    this.playbackQueue = []
-    this.isPlaying = false
-    if (this.activeSource) {
-      try { this.activeSource.stop() } catch { /* already stopped */ }
-      this.activeSource = null
+    this.nextStartTime = 0
+    for (const source of this.liveSources) {
+      try { source.stop() } catch { /* already stopped */ }
     }
+    this.liveSources.clear()
   }
 
   setVolume(volume: number) {
@@ -142,7 +144,6 @@ export class AudioEngine {
 
   setMuted(muted: boolean) {
     this.muted = muted
-    // Forward mute state to the worklet thread
     this.workletNode?.port.postMessage({ type: 'mute', value: muted })
   }
 
@@ -172,8 +173,6 @@ export class AudioEngine {
     this.gainNode = null
   }
 
-  // --- Private: capture strategies ---
-
   private startWorkletCapture(onAudioData: (base64: string) => void) {
     if (!this.audioCtx || !this.source) return
 
@@ -189,12 +188,10 @@ export class AudioEngine {
       }
     }
 
-    // Forward initial mute state
     this.workletNode.port.postMessage({ type: 'mute', value: this.muted })
 
     this.source.connect(this.workletNode)
-    // AudioWorkletNode must be connected to destination (even silently)
-    // so the audio graph keeps processing.
+    // Worklet must be connected to destination (even silently) so the graph keeps pulling.
     this.workletNode.connect(this.audioCtx.destination)
   }
 
@@ -207,14 +204,12 @@ export class AudioEngine {
     this.processor.onaudioprocess = (e) => {
       const input = e.inputBuffer.getChannelData(0)
 
-      // Compute RMS for level meter
       let sum = 0
       for (let i = 0; i < input.length; i++) sum += input[i] * input[i]
       this.currentRms = Math.sqrt(sum / input.length)
 
       if (this.muted) return
 
-      // Accumulate and emit FRAME_SIZE chunks
       const merged = new Float32Array(this.captureBuffer.length + input.length)
       merged.set(this.captureBuffer)
       merged.set(input, this.captureBuffer.length)
@@ -235,26 +230,6 @@ export class AudioEngine {
     if (!this.gainNode) return
     this.gainNode.gain.value = this.outputMuted ? 0 : this.outputVolume
   }
-
-  private drainPlaybackQueue() {
-    if (!this.audioCtx || !this.gainNode || this.playbackQueue.length === 0) {
-      this.isPlaying = false
-      return
-    }
-    this.isPlaying = true
-    const samples = this.playbackQueue.shift()!
-    const buffer = this.audioCtx.createBuffer(1, samples.length, SAMPLE_RATE)
-    buffer.copyToChannel(samples, 0)
-    const source = this.audioCtx.createBufferSource()
-    source.buffer = buffer
-    source.connect(this.gainNode)
-    source.onended = () => {
-      if (this.activeSource === source) this.activeSource = null
-      this.drainPlaybackQueue()
-    }
-    this.activeSource = source
-    source.start()
-  }
 }
 
 export async function enumerateAudioDevices(): Promise<AudioDevice[]> {
@@ -267,8 +242,6 @@ export async function enumerateAudioDevices(): Promise<AudioDevice[]> {
       kind: d.kind as 'audioinput' | 'audiooutput',
     }))
 }
-
-// --- Helpers ---
 
 async function tryRegisterWorklet(ctx: AudioContext): Promise<boolean> {
   try {

--- a/desktop/src/renderer/src/lib/audio-engine.ts
+++ b/desktop/src/renderer/src/lib/audio-engine.ts
@@ -96,8 +96,6 @@ export class AudioEngine {
     source.buffer = buffer
     source.connect(this.gainNode)
 
-    // Pre-schedule on the audio thread so contiguous chunks stitch sample-accurately.
-    // Driving .start() from main-thread onended leaves an audible silence gap.
     const startAt = Math.max(this.audioCtx.currentTime, this.nextStartTime)
     source.start(startAt)
     this.nextStartTime = startAt + buffer.duration


### PR DESCRIPTION
## Why

Gemini TTS playback was choppy with audible crackle / static at chunk boundaries. Grok was clean. Spike in #346 pinned this to a renderer underrun: each delta was wrapped in its own AudioBufferSourceNode and chained via onended -> drainPlaybackQueue. onended fires on the main thread, so the next buffer can only .start() after a thread hop, and the gap fills with silence at 24 kHz -> a click on every chunk boundary. Gemini emits ~20-50 chunks/s vs Grok's larger chunks, hence Gemini-only.

## What

`desktop/src/renderer/src/lib/audio-engine.ts`
- Track `nextStartTime` on the engine. Each `playAudio` call schedules `source.start(Math.max(currentTime, nextStartTime))` and advances `nextStartTime += buffer.duration`. The audio thread now stitches contiguous buffers sample-accurately — no more main-thread hop between chunks.
- Live sources tracked in `Set<AudioBufferSourceNode>`. `source.onended` only removes from the set; it does not drive the next start.
- `stopPlayback` resets `nextStartTime = 0` and stops every live source, so barge-in cuts immediately and the next turn starts at `currentTime` instead of a stale schedule.
- Edge case: if the queue drains and a new chunk arrives later, `nextStartTime` is in the past, and `Math.max` clamps to `currentTime`. Covered by test.
- Removed the file-top descriptive comment (per CLAUDE.md).

`desktop/src/renderer/src/lib/audio-engine.test.ts` (new, 6 tests)
- First chunk schedules at `currentTime`.
- Three contiguous chunks schedule at monotonically increasing start times matching cumulative duration.
- After a gap, the next chunk clamps to `currentTime` rather than a stale `nextStartTime`.
- `stopPlayback` stops all live sources and resets the schedule.
- `stopPlayback` tolerates already-stopped sources without throwing.
- Natural `onended` removes a source from the live set so `stopPlayback` only stops still-playing sources.

## Test plan

- [x] `yarn workspace voiceclaw-desktop typecheck` — green
- [x] `yarn workspace voiceclaw-desktop test` — 125 passed (was 119, 6 new in audio-engine.test.ts)
- [x] `yarn workspace voiceclaw-desktop build` — green
- [ ] Manual: start a Gemini call, listen for crackle/static at chunk boundaries — should be gone
- [ ] Manual: switch to Grok, no regression
- [ ] Manual: barge-in mid-reply, start a new turn — should not have a stale audio gap

## Reference

Spike findings: #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)