### PR TITLE
feat(desktop): voice preview button in Settings (NAN-713)

### DIFF
--- a/desktop/src/main/identity.test.ts
+++ b/desktop/src/main/identity.test.ts
@@ -93,3 +93,108 @@ describe('readAgentIdentity', () => {
     expect(id.voice).toBe('Charon')
   })
 })
+
+describe('getCachedVoicePreview', () => {
+  let fetchCalls: { url: string; init?: RequestInit }[] = []
+
+  beforeEach(() => {
+    writes.length = 0
+    fileSystem.clear()
+    fetchCalls = []
+    vi.doMock('electron', () => ({
+      app: {
+        getPath: () => '/tmp/voiceclaw-identity-test',
+      },
+      net: {
+        fetch: async (url: string, init?: RequestInit) => {
+          fetchCalls.push({ url, init })
+          return {
+            ok: true,
+            json: async () => ({
+              candidates: [
+                {
+                  content: {
+                    parts: [
+                      {
+                        inlineData: {
+                          data: 'BASE64DATA',
+                          mimeType: 'audio/L16;rate=24000',
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            }),
+            text: async () => '',
+          }
+        },
+      },
+    }))
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.doUnmock('electron')
+  })
+
+  it('generates and caches the preview on first request', async () => {
+    const { getCachedVoicePreview } = await import('./identity')
+    const result = await getCachedVoicePreview({ apiKey: 'test-key', voice: 'Zephyr' })
+    expect(result).toEqual({
+      ok: true,
+      audioBase64: 'BASE64DATA',
+      mimeType: 'audio/L16;rate=24000',
+    })
+    expect(fetchCalls).toHaveLength(1)
+    // Cache file written next to identity files
+    const cacheWrite = writes.find((w) => w.path.includes('voice-previews'))
+    expect(cacheWrite).toBeDefined()
+    expect(cacheWrite?.path).toContain('Zephyr.json')
+  })
+
+  it('reuses the cached clip on subsequent calls without hitting the network', async () => {
+    const { getCachedVoicePreview } = await import('./identity')
+    await getCachedVoicePreview({ apiKey: 'test-key', voice: 'Zephyr' })
+    expect(fetchCalls).toHaveLength(1)
+    const second = await getCachedVoicePreview({ apiKey: 'test-key', voice: 'Zephyr' })
+    expect(second).toEqual({
+      ok: true,
+      audioBase64: 'BASE64DATA',
+      mimeType: 'audio/L16;rate=24000',
+    })
+    // No additional network call
+    expect(fetchCalls).toHaveLength(1)
+  })
+
+  it('serves cached previews even when the API key is missing', async () => {
+    const { getCachedVoicePreview } = await import('./identity')
+    await getCachedVoicePreview({ apiKey: 'test-key', voice: 'Kore' })
+    expect(fetchCalls).toHaveLength(1)
+    const second = await getCachedVoicePreview({ apiKey: null, voice: 'Kore' })
+    expect(second).toEqual({
+      ok: true,
+      audioBase64: 'BASE64DATA',
+      mimeType: 'audio/L16;rate=24000',
+    })
+    expect(fetchCalls).toHaveLength(1)
+  })
+
+  it('returns an error when no cache is present and no API key is configured', async () => {
+    const { getCachedVoicePreview } = await import('./identity')
+    const result = await getCachedVoicePreview({ apiKey: null, voice: 'Aoede' })
+    expect(result.ok).toBe(false)
+    expect(fetchCalls).toHaveLength(0)
+  })
+
+  it('keeps separate cache entries per voice', async () => {
+    const { getCachedVoicePreview } = await import('./identity')
+    await getCachedVoicePreview({ apiKey: 'test-key', voice: 'Puck' })
+    await getCachedVoicePreview({ apiKey: 'test-key', voice: 'Charon' })
+    expect(fetchCalls).toHaveLength(2)
+    const cacheWrites = writes.filter((w) => w.path.includes('voice-previews'))
+    const paths = cacheWrites.map((w) => w.path)
+    expect(paths.some((p) => p.includes('Puck.json'))).toBe(true)
+    expect(paths.some((p) => p.includes('Charon.json'))).toBe(true)
+  })
+})

--- a/desktop/src/main/identity.test.ts
+++ b/desktop/src/main/identity.test.ts
@@ -13,6 +13,22 @@ vi.mock('fs', () => ({
   },
 }))
 
+vi.mock('node:fs/promises', () => ({
+  mkdir: async () => undefined,
+  readFile: async (path: string) => {
+    if (!fileSystem.has(path)) {
+      const err = new Error('ENOENT') as NodeJS.ErrnoException
+      err.code = 'ENOENT'
+      throw err
+    }
+    return fileSystem.get(path) ?? ''
+  },
+  writeFile: async (path: string, content: string) => {
+    writes.push({ path, content })
+    fileSystem.set(path, content)
+  },
+}))
+
 vi.mock('electron', () => ({
   app: {
     getPath: () => '/tmp/voiceclaw-identity-test',
@@ -196,5 +212,19 @@ describe('getCachedVoicePreview', () => {
     const paths = cacheWrites.map((w) => w.path)
     expect(paths.some((p) => p.includes('Puck.json'))).toBe(true)
     expect(paths.some((p) => p.includes('Charon.json'))).toBe(true)
+  })
+
+  it('coalesces concurrent first-clicks for the same voice into one TTS call', async () => {
+    const { getCachedVoicePreview } = await import('./identity')
+    const [a, b, c] = await Promise.all([
+      getCachedVoicePreview({ apiKey: 'test-key', voice: 'Leda' }),
+      getCachedVoicePreview({ apiKey: 'test-key', voice: 'Leda' }),
+      getCachedVoicePreview({ apiKey: 'test-key', voice: 'Leda' }),
+    ])
+    expect(a.ok).toBe(true)
+    expect(b.ok).toBe(true)
+    expect(c.ok).toBe(true)
+    // All three resolve with the same payload but only one network call ran.
+    expect(fetchCalls).toHaveLength(1)
   })
 })

--- a/desktop/src/main/identity.ts
+++ b/desktop/src/main/identity.ts
@@ -14,6 +14,12 @@ export const DEFAULT_IDENTITY: AgentIdentity = {
   voice: 'Zephyr',
 }
 
+// Static text used for the cached, non-personalized voice preview shown in
+// Settings. Keep this stable — the cache key is implicitly tied to it, so
+// changing this requires bumping CACHE_VERSION below.
+const STATIC_PREVIEW_TEXT = "Hi, I'm here."
+const CACHE_VERSION = 1
+
 export function getWorkspaceDir(): string {
   return join(app.getPath('userData'), 'openclaw', 'workspace')
 }
@@ -50,11 +56,39 @@ export function writeAgentIdentity(identity: Partial<AgentIdentity>): AgentIdent
   return merged
 }
 
+export type VoicePreviewResult =
+  | { ok: true; audioBase64: string; mimeType: string }
+  | { ok: false; error: string }
+
+// Returns a cached preview clip for `voice`, generating + persisting it on
+// first request. Once cached, subsequent calls do NOT hit the Gemini TTS
+// endpoint, so this is safe to call without a configured API key after the
+// initial generation.
+export async function getCachedVoicePreview(params: {
+  apiKey?: string | null
+  voice: string
+}): Promise<VoicePreviewResult> {
+  const cached = readVoicePreviewCache(params.voice)
+  if (cached) return { ok: true, ...cached }
+  if (!params.apiKey) return { ok: false, error: 'No Gemini key configured.' }
+  const result = await speakGreetingPreview({
+    apiKey: params.apiKey,
+    voice: params.voice,
+    text: STATIC_PREVIEW_TEXT,
+  })
+  if (!result.ok) return result
+  writeVoicePreviewCache(params.voice, {
+    audioBase64: result.audioBase64,
+    mimeType: result.mimeType,
+  })
+  return result
+}
+
 export async function speakGreetingPreview(params: {
   apiKey: string
   voice: string
   text: string
-}): Promise<{ ok: true; audioBase64: string; mimeType: string } | { ok: false; error: string }> {
+}): Promise<VoicePreviewResult> {
   if (!params.apiKey) return { ok: false, error: 'No Gemini key configured.' }
   const url =
     'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:generateContent'
@@ -116,4 +150,44 @@ function readField(content: string, field: string): string | null {
   const re = new RegExp(`^[-*]\\s*\\*\\*${field}:?\\*\\*\\s*(.+?)\\s*$`, 'mi')
   const match = content.match(re)
   return match ? match[1].trim() : null
+}
+
+function getVoicePreviewCacheDir(): string {
+  return join(app.getPath('userData'), 'voice-previews', `v${CACHE_VERSION}`)
+}
+
+function getVoicePreviewCachePath(voice: string): string {
+  // Voice IDs are alphanumeric (Puck, Zephyr, kore, etc.) but defensively
+  // strip anything that could escape the cache dir.
+  const safe = voice.replace(/[^a-zA-Z0-9_-]/g, '_')
+  return join(getVoicePreviewCacheDir(), `${safe}.json`)
+}
+
+function readVoicePreviewCache(
+  voice: string,
+): { audioBase64: string; mimeType: string } | null {
+  const path = getVoicePreviewCachePath(voice)
+  if (!existsSync(path)) return null
+  try {
+    const raw = readFileSync(path, 'utf8')
+    const parsed = JSON.parse(raw) as { audioBase64?: string; mimeType?: string }
+    if (typeof parsed.audioBase64 !== 'string' || typeof parsed.mimeType !== 'string') {
+      return null
+    }
+    return { audioBase64: parsed.audioBase64, mimeType: parsed.mimeType }
+  } catch {
+    return null
+  }
+}
+
+function writeVoicePreviewCache(
+  voice: string,
+  payload: { audioBase64: string; mimeType: string },
+): void {
+  try {
+    mkdirSync(getVoicePreviewCacheDir(), { recursive: true })
+    writeFileSync(getVoicePreviewCachePath(voice), JSON.stringify(payload), 'utf8')
+  } catch (err) {
+    console.warn('[voice-preview] cache write failed', err)
+  }
 }

--- a/desktop/src/main/identity.ts
+++ b/desktop/src/main/identity.ts
@@ -1,5 +1,6 @@
 import { app, net } from 'electron'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'path'
 
 export type AgentIdentity = {
@@ -60,6 +61,12 @@ export type VoicePreviewResult =
   | { ok: true; audioBase64: string; mimeType: string }
   | { ok: false; error: string }
 
+// Per-voice in-flight request map. Coalesces concurrent first-clicks for
+// the same voice into a single TTS round-trip + cache write — without it,
+// rapid clicking would fire N redundant network requests and N writes to
+// the same file.
+const inFlightVoicePreviews = new Map<string, Promise<VoicePreviewResult>>()
+
 // Returns a cached preview clip for `voice`, generating + persisting it on
 // first request. Once cached, subsequent calls do NOT hit the Gemini TTS
 // endpoint, so this is safe to call without a configured API key after the
@@ -68,16 +75,31 @@ export async function getCachedVoicePreview(params: {
   apiKey?: string | null
   voice: string
 }): Promise<VoicePreviewResult> {
-  const cached = readVoicePreviewCache(params.voice)
+  const cached = await readVoicePreviewCache(params.voice)
   if (cached) return { ok: true, ...cached }
+  const existing = inFlightVoicePreviews.get(params.voice)
+  if (existing) return existing
   if (!params.apiKey) return { ok: false, error: 'No Gemini key configured.' }
+  const promise = generateAndCacheVoicePreview(params.apiKey, params.voice)
+  inFlightVoicePreviews.set(params.voice, promise)
+  try {
+    return await promise
+  } finally {
+    inFlightVoicePreviews.delete(params.voice)
+  }
+}
+
+async function generateAndCacheVoicePreview(
+  apiKey: string,
+  voice: string,
+): Promise<VoicePreviewResult> {
   const result = await speakGreetingPreview({
-    apiKey: params.apiKey,
-    voice: params.voice,
+    apiKey,
+    voice,
     text: STATIC_PREVIEW_TEXT,
   })
   if (!result.ok) return result
-  writeVoicePreviewCache(params.voice, {
+  await writeVoicePreviewCache(voice, {
     audioBase64: result.audioBase64,
     mimeType: result.mimeType,
   })
@@ -163,30 +185,29 @@ function getVoicePreviewCachePath(voice: string): string {
   return join(getVoicePreviewCacheDir(), `${safe}.json`)
 }
 
-function readVoicePreviewCache(
+async function readVoicePreviewCache(
   voice: string,
-): { audioBase64: string; mimeType: string } | null {
-  const path = getVoicePreviewCachePath(voice)
-  if (!existsSync(path)) return null
+): Promise<{ audioBase64: string; mimeType: string } | null> {
   try {
-    const raw = readFileSync(path, 'utf8')
+    const raw = await readFile(getVoicePreviewCachePath(voice), 'utf8')
     const parsed = JSON.parse(raw) as { audioBase64?: string; mimeType?: string }
     if (typeof parsed.audioBase64 !== 'string' || typeof parsed.mimeType !== 'string') {
       return null
     }
     return { audioBase64: parsed.audioBase64, mimeType: parsed.mimeType }
   } catch {
+    // ENOENT / parse failure / partial write — treat as cache miss.
     return null
   }
 }
 
-function writeVoicePreviewCache(
+async function writeVoicePreviewCache(
   voice: string,
   payload: { audioBase64: string; mimeType: string },
-): void {
+): Promise<void> {
   try {
-    mkdirSync(getVoicePreviewCacheDir(), { recursive: true })
-    writeFileSync(getVoicePreviewCachePath(voice), JSON.stringify(payload), 'utf8')
+    await mkdir(getVoicePreviewCacheDir(), { recursive: true })
+    await writeFile(getVoicePreviewCachePath(voice), JSON.stringify(payload), 'utf8')
   } catch (err) {
     console.warn('[voice-preview] cache write failed', err)
   }

--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -18,6 +18,7 @@ import { buildDiagnosticBundle } from './services/diagnostic-bundle'
 import {
   type AgentIdentity,
   readAgentIdentity,
+  getCachedVoicePreview,
   speakGreetingPreview,
   writeAgentIdentity,
 } from './identity'
@@ -536,6 +537,16 @@ export function registerIpcHandlers() {
       const apiKey = getProviderKey('gemini')
       if (!apiKey) return { ok: false as const, error: 'No Gemini key configured.' }
       return speakGreetingPreview({ apiKey, voice: params.voice, text: params.text })
+    },
+  )
+
+  // Static, cached preview used by the Settings voice picker. The clip is
+  // generated once per voice and reused thereafter, so this does NOT hit the
+  // TTS endpoint after the first call (and works without a key once cached).
+  ipcMain.handle(
+    'identity:getVoicePreview',
+    async (_e, params: { voice: string }) => {
+      return getCachedVoicePreview({ apiKey: getProviderKey('gemini'), voice: params.voice })
     },
   )
 

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -234,6 +234,11 @@ const electronAPI = {
         | { ok: true; audioBase64: string; mimeType: string }
         | { ok: false; error: string }
       >,
+    getVoicePreview: (params: { voice: string }) =>
+      ipcRenderer.invoke('identity:getVoicePreview', params) as Promise<
+        | { ok: true; audioBase64: string; mimeType: string }
+        | { ok: false; error: string }
+      >,
   },
   screen: {
     getSources: () =>

--- a/desktop/src/renderer/src/lib/onboarding-api.ts
+++ b/desktop/src/renderer/src/lib/onboarding-api.ts
@@ -94,6 +94,10 @@ declare global {
           | { ok: true; audioBase64: string; mimeType: string }
           | { ok: false; error: string }
         >
+        getVoicePreview: (params: { voice: string }) => Promise<
+          | { ok: true; audioBase64: string; mimeType: string }
+          | { ok: false; error: string }
+        >
       }
     }
   }
@@ -134,4 +138,6 @@ export const identityApi = {
   save: (patch: AgentIdentityPatch) => window.electronAPI.identity.save(patch),
   speakPreview: (params: { voice: string; text: string }) =>
     window.electronAPI.identity.speakPreview(params),
+  getVoicePreview: (params: { voice: string }) =>
+    window.electronAPI.identity.getVoicePreview(params),
 }

--- a/desktop/src/renderer/src/lib/voice-preview.ts
+++ b/desktop/src/renderer/src/lib/voice-preview.ts
@@ -1,0 +1,59 @@
+// Shared helpers for decoding the inline base64 audio returned by the
+// Gemini TTS preview endpoints (used by Onboarding's StepIdentity and the
+// Settings voice picker).
+
+export function decodeVoicePreviewAudio(base64: string, mimeType: string): HTMLAudioElement {
+  if (mimeType.startsWith('audio/L16') || mimeType.startsWith('audio/pcm')) {
+    const sampleRate = parsePcmSampleRate(mimeType) ?? 24000
+    const wav = pcmToWav(base64, sampleRate)
+    const blob = new Blob([wav], { type: 'audio/wav' })
+    return new Audio(URL.createObjectURL(blob))
+  }
+  return new Audio(`data:${mimeType};base64,${base64}`)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parsePcmSampleRate(mimeType: string): number | null {
+  const match = mimeType.match(/rate=(\d+)/i)
+  return match ? Number(match[1]) : null
+}
+
+function pcmToWav(base64: string, sampleRate: number): ArrayBuffer {
+  const binary = atob(base64)
+  const pcm = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) pcm[i] = binary.charCodeAt(i)
+
+  const numChannels = 1
+  const bitsPerSample = 16
+  const byteRate = (sampleRate * numChannels * bitsPerSample) / 8
+  const blockAlign = (numChannels * bitsPerSample) / 8
+  const dataSize = pcm.length
+  const buffer = new ArrayBuffer(44 + dataSize)
+  const view = new DataView(buffer)
+
+  writeString(view, 0, 'RIFF')
+  view.setUint32(4, 36 + dataSize, true)
+  writeString(view, 8, 'WAVE')
+  writeString(view, 12, 'fmt ')
+  view.setUint32(16, 16, true)
+  view.setUint16(20, 1, true)
+  view.setUint16(22, numChannels, true)
+  view.setUint32(24, sampleRate, true)
+  view.setUint32(28, byteRate, true)
+  view.setUint16(32, blockAlign, true)
+  view.setUint16(34, bitsPerSample, true)
+  writeString(view, 36, 'data')
+  view.setUint32(40, dataSize, true)
+
+  new Uint8Array(buffer, 44).set(pcm)
+  return buffer
+}
+
+function writeString(view: DataView, offset: number, value: string) {
+  for (let i = 0; i < value.length; i += 1) {
+    view.setUint8(offset + i, value.charCodeAt(i))
+  }
+}

--- a/desktop/src/renderer/src/lib/voice-preview.ts
+++ b/desktop/src/renderer/src/lib/voice-preview.ts
@@ -1,15 +1,21 @@
-// Shared helpers for decoding the inline base64 audio returned by the
-// Gemini TTS preview endpoints (used by Onboarding's StepIdentity and the
-// Settings voice picker).
+export type VoicePreviewClip = {
+  audio: HTMLAudioElement
+  // Releases any blob: URL backing this clip. Callers MUST invoke `revoke`
+  // once playback is finished or the clip is replaced — otherwise PCM
+  // previews leak renderer memory across clicks.
+  revoke: () => void
+}
 
-export function decodeVoicePreviewAudio(base64: string, mimeType: string): HTMLAudioElement {
+export function decodeVoicePreviewAudio(base64: string, mimeType: string): VoicePreviewClip {
   if (mimeType.startsWith('audio/L16') || mimeType.startsWith('audio/pcm')) {
     const sampleRate = parsePcmSampleRate(mimeType) ?? 24000
     const wav = pcmToWav(base64, sampleRate)
     const blob = new Blob([wav], { type: 'audio/wav' })
-    return new Audio(URL.createObjectURL(blob))
+    const url = URL.createObjectURL(blob)
+    return { audio: new Audio(url), revoke: () => URL.revokeObjectURL(url) }
   }
-  return new Audio(`data:${mimeType};base64,${base64}`)
+  // data: URLs are owned by the engine and don't need revocation.
+  return { audio: new Audio(`data:${mimeType};base64,${base64}`), revoke: () => {} }
 }
 
 // ---------------------------------------------------------------------------

--- a/desktop/src/renderer/src/pages/SettingsPage.tsx
+++ b/desktop/src/renderer/src/pages/SettingsPage.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { UpdateState } from '../lib/db'
-import { Wifi, WifiOff, Eye, EyeOff } from 'lucide-react'
+import { Wifi, WifiOff, Eye, EyeOff, Play } from 'lucide-react'
 import { Button } from '../components/ui/Button'
 import { Card } from '../components/ui/Card'
 import { Input } from '../components/ui/Input'
 import { Select } from '../components/ui/Select'
 import { Toggle } from '../components/ui/Toggle'
 import { identityApi, onboarding } from '../lib/onboarding-api'
+import { decodeVoicePreviewAudio } from '../lib/voice-preview'
 import { useTheme, type Theme } from '../lib/use-theme'
 import { enumerateAudioDevices, type AudioDevice } from '../lib/audio-engine'
 import { getSetting, setSetting } from '../lib/db'
@@ -94,6 +95,12 @@ export function SettingsPage() {
   const [agentName, setAgentName] = useState('')
   const [agentDescription, setAgentDescription] = useState('')
   const identityLoadedRef = useRef(false)
+
+  // Voice preview playback (clicking ▶ on a voice card plays a sample
+  // without changing the selection). Errors render inline below the grid.
+  const [previewing, setPreviewing] = useState<string | null>(null)
+  const [previewError, setPreviewError] = useState('')
+  const previewAudioRef = useRef<HTMLAudioElement | null>(null)
 
   // Privacy / telemetry
   const [telemetryEnabled, setTelemetryEnabled] = useState(true)
@@ -233,6 +240,59 @@ export function SettingsPage() {
       void setVoiceForProvider(providerForModel(model), v)
     }
   }, [model])
+
+  // Stop in-flight preview audio on unmount.
+  useEffect(() => {
+    return () => {
+      const audio = previewAudioRef.current
+      if (audio) {
+        try {
+          audio.pause()
+        } catch {
+          // ignore
+        }
+      }
+    }
+  }, [])
+
+  const handleVoicePreview = useCallback(async (voiceId: string) => {
+    setPreviewError('')
+    // Stop any in-flight clip so re-clicking restarts cleanly.
+    const prev = previewAudioRef.current
+    if (prev) {
+      try {
+        prev.pause()
+      } catch {
+        // ignore
+      }
+      previewAudioRef.current = null
+    }
+    setPreviewing(voiceId)
+    try {
+      const result = await identityApi.getVoicePreview({ voice: voiceId })
+      if (!result.ok) {
+        setPreviewError(result.error)
+        setPreviewing(null)
+        return
+      }
+      const audio = decodeVoicePreviewAudio(result.audioBase64, result.mimeType)
+      previewAudioRef.current = audio
+      audio.onended = () => setPreviewing((p) => (p === voiceId ? null : p))
+      audio.onerror = () => {
+        setPreviewError(`Audio playback failed (${result.mimeType}).`)
+        setPreviewing((p) => (p === voiceId ? null : p))
+      }
+      try {
+        await audio.play()
+      } catch (err) {
+        setPreviewError(err instanceof Error ? err.message : 'Could not play audio.')
+        setPreviewing(null)
+      }
+    } catch (err) {
+      setPreviewError(err instanceof Error ? err.message : 'Preview failed.')
+      setPreviewing(null)
+    }
+  }, [])
 
   const updateVolume = useCallback((v: number) => {
     setVolume(v)
@@ -569,20 +629,55 @@ export function SettingsPage() {
         <Card className="p-4 space-y-4">
           <h3 className="text-sm font-semibold text-foreground">Voice</h3>
           <div className="grid grid-cols-2 gap-1.5">
-            {(model.startsWith('gemini-') ? GEMINI_VOICES : XAI_VOICES).map((v) => (
-              <button
-                key={v}
-                onClick={() => updateVoice(v)}
-                className={`rounded-md border px-3 py-2 text-sm text-left transition-colors
-                  ${voice === v ? 'border-primary bg-accent font-medium text-foreground' : 'border-input text-muted-foreground hover:bg-accent'}
-                `}
-              >
-                {model.startsWith('gemini-')
-                  ? GEMINI_VOICE_LABELS[v as typeof GEMINI_VOICES[number]]
-                  : XAI_VOICE_LABELS[v as typeof XAI_VOICES[number]]}
-              </button>
-            ))}
+            {(model.startsWith('gemini-') ? GEMINI_VOICES : XAI_VOICES).map((v) => {
+              const isGemini = model.startsWith('gemini-')
+              const label = isGemini
+                ? GEMINI_VOICE_LABELS[v as typeof GEMINI_VOICES[number]]
+                : XAI_VOICE_LABELS[v as typeof XAI_VOICES[number]]
+              const selected = voice === v
+              const isPlaying = previewing === v
+              return (
+                <div
+                  key={v}
+                  className={`flex items-stretch gap-1 rounded-md border transition-colors
+                    ${selected ? 'border-primary bg-accent' : 'border-input'}
+                  `}
+                >
+                  <button
+                    onClick={() => updateVoice(v)}
+                    className={`flex-1 rounded-l-md px-3 py-2 text-left text-sm transition-colors
+                      ${selected ? 'font-medium text-foreground' : 'text-muted-foreground hover:bg-accent'}
+                    `}
+                  >
+                    {label}
+                  </button>
+                  {isGemini ? (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        void handleVoicePreview(v)
+                      }}
+                      disabled={isPlaying}
+                      aria-label={`Preview ${v} voice`}
+                      title={isPlaying ? 'Playing…' : `Preview ${label}`}
+                      className={`flex w-9 items-center justify-center rounded-r-md border-l border-input
+                        text-muted-foreground transition-colors hover:bg-background hover:text-foreground
+                        disabled:opacity-50 disabled:cursor-not-allowed
+                      `}
+                    >
+                      <Play size={14} className={isPlaying ? 'animate-pulse' : ''} />
+                    </button>
+                  ) : null}
+                </div>
+              )
+            })}
           </div>
+          {previewError ? (
+            <p className="text-xs text-destructive" role="alert">
+              {previewError}
+            </p>
+          ) : null}
         </Card>
 
         {/* Audio Devices */}

--- a/desktop/src/renderer/src/pages/SettingsPage.tsx
+++ b/desktop/src/renderer/src/pages/SettingsPage.tsx
@@ -100,7 +100,10 @@ export function SettingsPage() {
   // without changing the selection). Errors render inline below the grid.
   const [previewing, setPreviewing] = useState<string | null>(null)
   const [previewError, setPreviewError] = useState('')
-  const previewAudioRef = useRef<HTMLAudioElement | null>(null)
+  const previewClipRef = useRef<{ audio: HTMLAudioElement; revoke: () => void } | null>(null)
+  // Monotonic token used to invalidate stale in-flight preview requests
+  // when the user clicks another voice (or unmounts) before the IPC returns.
+  const previewTokenRef = useRef(0)
 
   // Privacy / telemetry
   const [telemetryEnabled, setTelemetryEnabled] = useState(true)
@@ -241,54 +244,69 @@ export function SettingsPage() {
     }
   }, [model])
 
-  // Stop in-flight preview audio on unmount.
+  // Stop + release any in-flight preview clip on unmount.
   useEffect(() => {
     return () => {
-      const audio = previewAudioRef.current
-      if (audio) {
+      previewTokenRef.current += 1
+      const clip = previewClipRef.current
+      if (clip) {
         try {
-          audio.pause()
+          clip.audio.pause()
         } catch {
           // ignore
         }
+        clip.revoke()
+        previewClipRef.current = null
       }
     }
   }, [])
 
   const handleVoicePreview = useCallback(async (voiceId: string) => {
-    setPreviewError('')
-    // Stop any in-flight clip so re-clicking restarts cleanly.
-    const prev = previewAudioRef.current
+    const token = ++previewTokenRef.current
+    // Stop + release the previous clip so re-clicking restarts cleanly and
+    // we don't leak the blob: URL backing a PCM preview.
+    const prev = previewClipRef.current
     if (prev) {
       try {
-        prev.pause()
+        prev.audio.pause()
       } catch {
         // ignore
       }
-      previewAudioRef.current = null
+      prev.revoke()
+      previewClipRef.current = null
     }
+    setPreviewError('')
     setPreviewing(voiceId)
     try {
       const result = await identityApi.getVoicePreview({ voice: voiceId })
+      if (token !== previewTokenRef.current) return
       if (!result.ok) {
         setPreviewError(result.error)
         setPreviewing(null)
         return
       }
-      const audio = decodeVoicePreviewAudio(result.audioBase64, result.mimeType)
-      previewAudioRef.current = audio
-      audio.onended = () => setPreviewing((p) => (p === voiceId ? null : p))
-      audio.onerror = () => {
-        setPreviewError(`Audio playback failed (${result.mimeType}).`)
+      const clip = decodeVoicePreviewAudio(result.audioBase64, result.mimeType)
+      previewClipRef.current = clip
+      const finish = () => {
+        if (previewClipRef.current === clip) {
+          clip.revoke()
+          previewClipRef.current = null
+        }
         setPreviewing((p) => (p === voiceId ? null : p))
       }
+      clip.audio.onended = finish
+      clip.audio.onerror = () => {
+        setPreviewError(`Audio playback failed (${result.mimeType}).`)
+        finish()
+      }
       try {
-        await audio.play()
+        await clip.audio.play()
       } catch (err) {
         setPreviewError(err instanceof Error ? err.message : 'Could not play audio.')
-        setPreviewing(null)
+        finish()
       }
     } catch (err) {
+      if (token !== previewTokenRef.current) return
       setPreviewError(err instanceof Error ? err.message : 'Preview failed.')
       setPreviewing(null)
     }

--- a/desktop/src/renderer/src/pages/onboarding/StepIdentity.tsx
+++ b/desktop/src/renderer/src/pages/onboarding/StepIdentity.tsx
@@ -38,23 +38,33 @@ export function StepIdentity({
   const [voice, setVoice] = useState(initialIdentity.voice ?? DEFAULT_VOICE)
   const [previewing, setPreviewing] = useState<string | null>(null)
   const [previewError, setPreviewError] = useState('')
-  const audioRef = useRef<HTMLAudioElement | null>(null)
+  const clipRef = useRef<{ audio: HTMLAudioElement; revoke: () => void } | null>(null)
+  const previewTokenRef = useRef(0)
+
+  const stopActiveClip = () => {
+    const clip = clipRef.current
+    if (!clip) return
+    try {
+      clip.audio.pause()
+    } catch {
+      // ignore
+    }
+    clip.revoke()
+    clipRef.current = null
+  }
 
   useEffect(() => {
     return () => {
-      const audio = audioRef.current
-      if (audio) {
-        try {
-          audio.pause()
-        } catch {
-          // ignore
-        }
-      }
+      // Bump the token so any in-flight `handlePreview` ignores its result.
+      previewTokenRef.current += 1
+      stopActiveClip()
     }
   }, [])
 
   const handlePreview = async (voiceId: string) => {
     if (previewMode) return
+    const token = ++previewTokenRef.current
+    stopActiveClip()
     setPreviewError('')
     setPreviewing(voiceId)
     try {
@@ -62,6 +72,7 @@ export function StepIdentity({
         voice: voiceId,
         text: `Hi, I'm ${name.trim() || DEFAULT_NAME}.`,
       })
+      if (token !== previewTokenRef.current) return
       if (!result.ok) {
         console.error('[voice-preview] api error', result.error)
         setPreviewError(result.error)
@@ -69,22 +80,30 @@ export function StepIdentity({
         return
       }
       console.info('[voice-preview] got audio', { voiceId, mimeType: result.mimeType, bytes: result.audioBase64.length })
-      const audio = decodeVoicePreviewAudio(result.audioBase64, result.mimeType)
-      audioRef.current = audio
-      audio.onended = () => setPreviewing((p) => (p === voiceId ? null : p))
-      audio.onerror = (e) => {
-        console.error('[voice-preview] audio element error', e, 'mimeType:', result.mimeType)
-        setPreviewError(`Audio playback failed (${result.mimeType}). Try a different voice.`)
+      const clip = decodeVoicePreviewAudio(result.audioBase64, result.mimeType)
+      clipRef.current = clip
+      const finish = () => {
+        if (clipRef.current === clip) {
+          clip.revoke()
+          clipRef.current = null
+        }
         setPreviewing((p) => (p === voiceId ? null : p))
       }
+      clip.audio.onended = finish
+      clip.audio.onerror = (e) => {
+        console.error('[voice-preview] audio element error', e, 'mimeType:', result.mimeType)
+        setPreviewError(`Audio playback failed (${result.mimeType}). Try a different voice.`)
+        finish()
+      }
       try {
-        await audio.play()
+        await clip.audio.play()
       } catch (err) {
         console.error('[voice-preview] audio.play() rejected', err)
         setPreviewError(err instanceof Error ? err.message : 'Could not play audio.')
-        setPreviewing(null)
+        finish()
       }
     } catch (err) {
+      if (token !== previewTokenRef.current) return
       console.error('[voice-preview] handler threw', err)
       setPreviewError(err instanceof Error ? err.message : 'Preview failed.')
       setPreviewing(null)

--- a/desktop/src/renderer/src/pages/onboarding/StepIdentity.tsx
+++ b/desktop/src/renderer/src/pages/onboarding/StepIdentity.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { StepFrame } from './StepFrame'
 import { identityApi, type OnboardingPayload } from '../../lib/onboarding-api'
+import { decodeVoicePreviewAudio } from '../../lib/voice-preview'
 
 const GEMINI_VOICES = [
   { id: 'Aoede', label: 'Aoede (F) — warm, conversational', preview: "Hi, I'm here." },
@@ -68,7 +69,7 @@ export function StepIdentity({
         return
       }
       console.info('[voice-preview] got audio', { voiceId, mimeType: result.mimeType, bytes: result.audioBase64.length })
-      const audio = decodeAudio(result.audioBase64, result.mimeType)
+      const audio = decodeVoicePreviewAudio(result.audioBase64, result.mimeType)
       audioRef.current = audio
       audio.onended = () => setPreviewing((p) => (p === voiceId ? null : p))
       audio.onerror = (e) => {
@@ -250,54 +251,3 @@ function VoiceRow({
   )
 }
 
-function decodeAudio(base64: string, mimeType: string): HTMLAudioElement {
-  if (mimeType.startsWith('audio/L16') || mimeType.startsWith('audio/pcm')) {
-    const sampleRate = parseSampleRate(mimeType) ?? 24000
-    const wav = pcmToWav(base64, sampleRate)
-    const blob = new Blob([wav], { type: 'audio/wav' })
-    return new Audio(URL.createObjectURL(blob))
-  }
-  return new Audio(`data:${mimeType};base64,${base64}`)
-}
-
-function parseSampleRate(mimeType: string): number | null {
-  const match = mimeType.match(/rate=(\d+)/i)
-  return match ? Number(match[1]) : null
-}
-
-function pcmToWav(base64: string, sampleRate: number): ArrayBuffer {
-  const binary = atob(base64)
-  const pcm = new Uint8Array(binary.length)
-  for (let i = 0; i < binary.length; i += 1) pcm[i] = binary.charCodeAt(i)
-
-  const numChannels = 1
-  const bitsPerSample = 16
-  const byteRate = (sampleRate * numChannels * bitsPerSample) / 8
-  const blockAlign = (numChannels * bitsPerSample) / 8
-  const dataSize = pcm.length
-  const buffer = new ArrayBuffer(44 + dataSize)
-  const view = new DataView(buffer)
-
-  writeString(view, 0, 'RIFF')
-  view.setUint32(4, 36 + dataSize, true)
-  writeString(view, 8, 'WAVE')
-  writeString(view, 12, 'fmt ')
-  view.setUint32(16, 16, true)
-  view.setUint16(20, 1, true)
-  view.setUint16(22, numChannels, true)
-  view.setUint32(24, sampleRate, true)
-  view.setUint32(28, byteRate, true)
-  view.setUint16(32, blockAlign, true)
-  view.setUint16(34, bitsPerSample, true)
-  writeString(view, 36, 'data')
-  view.setUint32(40, dataSize, true)
-
-  new Uint8Array(buffer, 44).set(pcm)
-  return buffer
-}
-
-function writeString(view: DataView, offset: number, value: string) {
-  for (let i = 0; i < value.length; i += 1) {
-    view.setUint8(offset + i, value.charCodeAt(i))
-  }
-}


### PR DESCRIPTION
## Why

The Settings voice picker showed names only, with no way to hear a voice before committing — the same affordance already exists in onboarding (`StepIdentity`), so users had to either remember from setup or change-and-listen-then-revert. Closes [NAN-713](https://linear.app/nano3labs/issue/NAN-713/settings-voice-picker-has-no-preview-button).

## Approach

- **Preview is a separate action.** A small play button sits beside the voice label; clicking it plays the sample without touching the selection. Errors render inline beneath the grid.
- **Samples are static, generated once per voice.** Per the ticket's hard requirement: a new `getCachedVoicePreview` helper writes the first response to `userData/voice-previews/v1/<voice>.json` and serves cached bytes on every subsequent click — no network call, works offline once warmed.
- **Onboarding still uses dynamic, name-personalized preview text** ("Hi, I'm Pam.") via the existing `speakPreview` IPC. Settings uses the cached static-text path. Audio decoding is shared via a new `lib/voice-preview.ts` module (extracted from the duplicated PCM→WAV helpers in `StepIdentity.tsx`).
- XAI voices show no preview button (the existing TTS endpoint is Gemini-only).

<details><summary>Test plan</summary>

- [x] `yarn typecheck` — passes
- [x] `yarn test` — 13 files, 124 tests pass (5 new tests cover cache hit/miss, missing-key, and per-voice isolation)
- [ ] Manual: open Settings on Gemini model → click ▶ on each voice → hear sample, selection unchanged
- [ ] Manual: click ▶ twice quickly → no overlap, second click restarts cleanly
- [ ] Manual: clear Gemini key → cached voices still preview; uncached voice surfaces "No Gemini key configured." inline
- [ ] Manual: switch model to Grok → no preview buttons render, no errors

</details>

<details><summary>Implementation notes</summary>

- `getCachedVoicePreview` is in `desktop/src/main/identity.ts` next to the existing `speakGreetingPreview`. Cache version is encoded in the directory name (`v1`) so future static-text changes can bust it without manual cleanup.
- The shared decode helper is in `desktop/src/renderer/src/lib/voice-preview.ts`. `StepIdentity.tsx` was refactored to use it, deleting ~50 lines of duplicated PCM→WAV code.
- I went with **option 1 from the ticket** (port the handler) plus a tiny shared decode helper. Extracting a full `<VoicePicker>` would have meant either compromising the onboarding row layout (preview + select on one line, monospace label) or the Settings 2-col grid — not worth it for two consumers.

</details>