### PR TITLE
fix(relay): drop stale audio queue on Gemini 1007 close to break reconnect loop

### DIFF
--- a/.github/workflows/brain-e2e.yml
+++ b/.github/workflows/brain-e2e.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Enable corepack
+        run: corepack enable
+
       - uses: actions/setup-node@v6
         with:
           node-version: '22'

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -82,6 +82,12 @@ export class GeminiAdapter implements ProviderAdapter {
   private pendingAudio: string[] = []
   private pendingVideo: string[] = []
   private pendingControl: string[] = []
+  // Set when the previous upstream closed with 1007 (invalid argument). The
+  // queued audio captured before that close is the most likely culprit, so
+  // replaying it into the resumed session re-trips 1007 and locks us into a
+  // reconnect loop. Control messages still flush — the model needs them to
+  // stay coherent.
+  private dropPendingAudioOnFlush = false
 
   // Per-turn latency marks, emitted on turnComplete. Gemini Live has no
   // explicit "end-of-speech" event — we proxy it via the last inputTranscription
@@ -287,6 +293,8 @@ export class GeminiAdapter implements ProviderAdapter {
       })
       return
     }
+
+    if (code === 1007) this.dropPendingAudioOnFlush = true
 
     void this.reconnect(`close code ${code}`)
   }
@@ -831,20 +839,26 @@ export class GeminiAdapter implements ProviderAdapter {
     const control = this.pendingControl
     const audio = this.pendingAudio
     const video = this.pendingVideo
+    const dropAudio = this.dropPendingAudioOnFlush
     this.pendingControl = []
     this.pendingAudio = []
     // Drop video frames — they are stale by the time we reconnect and sending
     // them can trigger a 1007 (invalid argument) from Gemini. The client
     // refreshes screen-share frames within ~1 s anyway.
     this.pendingVideo = []
-    if (control.length > 0 || audio.length > 0) {
-      log(`[gemini] Flushing reconnect queue (${control.length} control, ${audio.length} audio)`)
+    this.dropPendingAudioOnFlush = false
+    const audioToSend = dropAudio ? [] : audio
+    if (control.length > 0 || audioToSend.length > 0) {
+      log(`[gemini] Flushing reconnect queue (${control.length} control, ${audioToSend.length} audio)`)
+    }
+    if (dropAudio && audio.length > 0) {
+      log(`[gemini] Dropping ${audio.length} stale audio chunk(s) from reconnect queue (prior close was 1007)`)
     }
     if (video.length > 0) {
       log(`[gemini] Dropping ${video.length} stale video frame(s) from reconnect queue`)
     }
     for (const p of control) this.upstream.send(p)
-    for (const p of audio) this.upstream.send(p)
+    for (const p of audioToSend) this.upstream.send(p)
   }
 
   private armPostResumeListener() {

--- a/relay-server/src/adapters/gemini.ts
+++ b/relay-server/src/adapters/gemini.ts
@@ -82,9 +82,10 @@ export class GeminiAdapter implements ProviderAdapter {
   private pendingAudio: string[] = []
   private pendingVideo: string[] = []
   private pendingControl: string[] = []
-  // Set when the previous upstream closed with 1007 (invalid argument). The
-  // queued audio captured before that close is the most likely culprit, so
-  // replaying it into the resumed session re-trips 1007 and locks us into a
+  // Set when the previous upstream closed with 1007 (invalid argument). Audio
+  // is only queued while isReconnecting is true, so the chunks captured during
+  // that reconnect window are continuous with whatever payload tripped 1007 —
+  // replaying them into the resumed session re-trips 1007 and locks us into a
   // reconnect loop. Control messages still flush — the model needs them to
   // stay coherent.
   private dropPendingAudioOnFlush = false

--- a/relay-server/test/adapters/gemini-reconnect.test.ts
+++ b/relay-server/test/adapters/gemini-reconnect.test.ts
@@ -327,6 +327,51 @@ describe("GeminiAdapter reconnect", () => {
       expect(eventsOfType(mock.events, "error")).toHaveLength(0)
     })
 
+    it("drops the audio queue when the prior close was 1007, but still flushes control", async () => {
+      mock = await mountMockGemini([
+        { steps: [
+          { at: 20, msg: { sessionResumptionUpdate: { newHandle: "h1", resumable: true } } },
+          { at: 60, close: 1007, reason: "Request contains an invalid argument." },
+        ] },
+        { ackSetup: 150, steps: [] },
+      ])
+
+      await waitMs(80)
+      for (let i = 0; i < 8; i++) mock.adapter.sendAudio(pcm16Chunk(960, i))
+      mock.adapter.sendToolResult("call-after-1007", JSON.stringify({ ok: true }))
+
+      await waitMs(1500)
+
+      const onSocket2 = mock.messagesPerSocket[1] ?? []
+      const audio = onSocket2.filter((m) => "realtimeInput" in m)
+      const tools = onSocket2.filter((m) => "toolResponse" in m)
+      expect(audio).toHaveLength(0)
+      expect(tools).toHaveLength(1)
+      expect(eventsOfType(mock.events, "session.rotated")).toHaveLength(1)
+      expect(eventsOfType(mock.events, "error")).toHaveLength(0)
+    })
+
+    it("still flushes the audio queue when the prior close was 1011 (transient server error)", async () => {
+      mock = await mountMockGemini([
+        { steps: [
+          { at: 20, msg: { sessionResumptionUpdate: { newHandle: "h1", resumable: true } } },
+          { at: 60, close: 1011, reason: "internal error" },
+        ] },
+        { ackSetup: 150, steps: [] },
+      ])
+
+      await waitMs(80)
+      for (let i = 0; i < 8; i++) mock.adapter.sendAudio(pcm16Chunk(960, i))
+
+      await waitMs(1500)
+
+      const onSocket2 = mock.messagesPerSocket[1] ?? []
+      const audio = onSocket2.filter((m) => "realtimeInput" in m)
+      expect(audio).toHaveLength(8)
+      expect(eventsOfType(mock.events, "session.rotated")).toHaveLength(1)
+      expect(eventsOfType(mock.events, "error")).toHaveLength(0)
+    })
+
     it("drops newest control messages once the queue is full, preserving originals", async () => {
       mock = await mountMockGemini([
         { steps: [


### PR DESCRIPTION
## Why

Gemini Live occasionally closes the WS with `1007 Request contains an invalid argument` at user-input boundaries. The relay reconnects with the resumption handle and replays its pending audio queue — but those chunks are exactly what tripped 1007. Replaying them re-trips 1007, putting the call into a tight reconnect loop (real-world repro: close 1007 → reconnect → flush 4 audio → close 1007 → ...).

This change gates the audio drop to **close code 1007 only**. For 1006 / 1011 / 1012 / 1013 the queued audio is harmless and dropping it would lose user words, so the existing replay behavior is preserved. Control messages (`toolResponse`, `clientContent`) still flush on 1007 so the model state stays coherent.

## Test plan

- [x] `yarn workspace relay-server test test/adapters/` — all 88 tests pass (86 baseline + 2 new)
- [x] `yarn workspace relay-server test` — full suite green (126 pass, 3 skipped, no new skips)
- [x] `yarn workspace relay-server build` — `tsc` clean
- [ ] Manual: trigger a 1007 in a real call (or have it happen organically) and confirm the resumed session does not immediately close again with 1007

## Implementation notes

<details>

- New private field `dropPendingAudioOnFlush: boolean` on `GeminiAdapter`. One-shot flag, set in `handleUpstreamClose(code)` when `code === 1007`, consumed and cleared in `flushPending`.
- Set point is **after** the existing early-return guards (`!RECONNECTABLE_CLOSE_CODES.has(code) || !this.resumptionHandle`), so the flag is only set when we actually decide to reconnect.
- Consume point is `flushPending` — runs after `setupComplete` on the resumed socket. Control queue still flushes; audio queue is logged-and-dropped.
- Did not touch:
  - Video drop path (already drops every reconnect for the same 1007 reason).
  - The `goAway` → close path (`isReconnecting === true` makes `handleUpstreamClose` return early before our check, which is correct — goAway-driven rotations are graceful and the queued audio is safe).
  - The post-resume "poisoned handle" watchdog (`armPostResumeWatchdog`) — that's a different recovery path (force-fresh on no-generation), still useful as a fallback when the 1007 turns out not to be audio-shaped.
  - `openai.ts` — Gemini-specific.
- Two new tests in `gemini-reconnect.test.ts` under `send queue during rotation`:
  - 1007 close → audio queue drops to 0 on flush, control still flushes, no client-facing error.
  - 1011 close → audio queue still flushes (regression guard for the gating).

### Things noticed in passing

- `RECONNECTABLE_CLOSE_CODES` already includes `1007` with a comment hypothesizing stale **video** frames as the cause. The bug log here suggests stale **audio** can also do it (matches the `reference_tracer_locations.md` note). Worth tightening the comment in a follow-up.
- `flushPending` flushes **all** queued audio after setup. With `MAX_PENDING_AUDIO = 50` (~1s at 50Hz), that's potentially a 1s burst into a freshly resumed session. Not part of this fix, but if 1007s persist after this change, the next thing to look at is whether the burst itself is the trigger (rate, or boundary alignment with the resumption checkpoint).

</details>