### PR TITLE
fix(relay): drop OpenAI summarizer dep, route summarization through active provider

### DIFF
--- a/desktop/src/main/services/brain-doctor.ts
+++ b/desktop/src/main/services/brain-doctor.ts
@@ -501,39 +501,6 @@ async function checkXaiApiKey(acc: Acc): Promise<void> {
   }
 }
 
-async function checkOpenAiApiKey(acc: Acc): Promise<void> {
-  const apiKey = getProviderKey('openai')
-  if (!apiKey) {
-    skip(acc, 'OpenAI API key reachability', 'skipped (no OpenAI key configured)')
-    return
-  }
-  try {
-    const res = await safeFetch(
-      'https://api.openai.com/v1/models',
-      { headers: { Authorization: `Bearer ${apiKey}` } },
-      10_000,
-    )
-    const text = await res.text()
-    if (res.ok) {
-      pass(acc, 'OpenAI API key reachability', `HTTP ${res.status}`)
-    } else {
-      let hint = 'Check your OpenAI API key in VoiceClaw Settings → Provider tab'
-      if (res.status === 401) hint = 'API key invalid or revoked. Re-enter it in Settings → Provider'
-      if (res.status === 402 || (res.status === 429 && text.includes('insufficient_quota')))
-        hint = 'OpenAI quota exceeded. Top up at https://platform.openai.com/account/billing'
-      if (res.status === 429 && !text.includes('insufficient_quota'))
-        hint = 'OpenAI rate limit hit. Try again in a moment'
-      fail(acc, 'OpenAI API key reachability', `HTTP ${res.status}: ${text.substring(0, 200)}`, hint)
-    }
-  } catch (err) {
-    fail(
-      acc,
-      'OpenAI API key reachability',
-      `fetch failed: ${(err as Error).message}`,
-      'Check internet connectivity; if behind a VPN/proxy, try disabling it',
-    )
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -557,7 +524,6 @@ export async function runAllChecks(): Promise<DoctorResult> {
   await checkOpenclawCompletions(acc, openclawPort, configPath)
   await checkGeminiApiKey(acc, configPath)
   await checkXaiApiKey(acc)
-  await checkOpenAiApiKey(acc)
 
   return {
     checks: acc,

--- a/docs/src/content/docs/desktop/troubleshooting.mdx
+++ b/docs/src/content/docs/desktop/troubleshooting.mdx
@@ -33,7 +33,7 @@ If our team asks for more detail, you can export a bundle with one click:
 | Database schema | Table definitions only — no messages or history |
 | List of configured providers | Provider names only — no key values |
 | Service health snapshot | Relay and OpenClaw status at export time |
-| Brain doctor report | PASS/FAIL checklist for the 10 brain health checks |
+| Brain doctor report | PASS/FAIL checklist for the 11 brain health checks |
 
 ### What's never included
 
@@ -60,7 +60,7 @@ The gateway responded but returned no content. Expand the detail panel in the ch
 
 ### Run brain diagnostic
 
-VoiceClaw has a built-in 10-point diagnostic for brain problems. You don't need a terminal or developer tools to use it:
+VoiceClaw has a built-in 11-point diagnostic for brain problems. You don't need a terminal or developer tools to use it:
 
 1. Open **Settings → Debug**.
 2. Click **Run** next to "Run brain diagnostic".
@@ -70,7 +70,7 @@ VoiceClaw has a built-in 10-point diagnostic for brain problems. You don't need 
 
 Clicking **Run** again after fixing something re-runs all checks so you can confirm the fix worked.
 
-The 12 checks are:
+The 11 checks are:
 
 1. Bundled openclaw script exists
 2. Bundled node binary exists and is v22.12+
@@ -83,7 +83,6 @@ The 12 checks are:
 9. Direct call to openclaw's completions endpoint returns a non-empty response
 10. Gemini API key is accepted by Google's API
 11. xAI API key is reachable (skipped if no xAI key is configured)
-12. OpenAI API key is reachable (skipped if no OpenAI key is configured)
 
 The same diagnostic runs automatically as part of the diagnostic bundle (see above) and is saved as `brain-doctor.json`.
 
@@ -109,10 +108,6 @@ When the realtime voice connection fails because of an upstream provider problem
 | xAI account out of credits or hit spending limit | Account balance is $0 | Click **Open billing** → add credits at console.x.ai/team |
 | xAI rejected this request | Key lacks permission for this model | Click **Open billing** → review key permissions at console.x.ai |
 | xAI service is having issues | xAI-side outage | Click **Open billing** → check status.x.ai; try again later |
-| OpenAI API key invalid or revoked | Key was deleted or rotated | Click **Open Settings** → re-enter the key under Settings → Provider |
-| OpenAI quota exceeded | Free-tier limit reached | Click **Open billing** → add a payment method at platform.openai.com/account/billing |
-| OpenAI rate limit | Too many requests | Wait a moment and start a new call |
-| OpenAI service is having issues | OpenAI-side outage | Check status.openai.com; try again later |
 | Gemini API key invalid | Key was deleted or rotated | Click **Open Settings** → re-enter the key under Settings → Provider |
 | Gemini quota exceeded | Daily quota hit | Click **Open billing** → upgrade at aistudio.google.com/app/billing |
 | Gemini service is having issues | Google-side outage | Check status.cloud.google.com; try again later |
@@ -122,7 +117,7 @@ The banner stays visible for the rest of the session so you can confirm the fix 
 
 ### Brain diagnostic also checks provider keys
 
-The **Run brain diagnostic** tool (Settings → Debug) runs 12 checks, including reachability tests for your configured xAI and OpenAI keys (checks 11–12). If a key is invalid or your quota is exhausted, the diagnostic will flag the failing check and show the same hint as the runtime banner.
+The **Run brain diagnostic** tool (Settings → Debug) runs 11 checks, including a reachability test for your configured xAI key (check 11). If a key is invalid or your quota is exhausted, the diagnostic will flag the failing check and show the same hint as the runtime banner.
 
 ## Common problems
 

--- a/relay-server/.env.example
+++ b/relay-server/.env.example
@@ -1,10 +1,6 @@
 # ── Required ──────────────────────────────────────────────────────────────────
 
-# OpenAI API key for Realtime API access
-# Get yours at https://platform.openai.com/api-keys
-OPENAI_API_KEY=sk-...
-
-# Gemini API key for Gemini Live access
+# Gemini API key — used for both Gemini Live realtime sessions AND history summarization.
 # Get yours at https://aistudio.google.com/apikey
 GEMINI_API_KEY=
 
@@ -18,6 +14,10 @@ BRAIN_GATEWAY_AUTH_TOKEN=
 
 # ── Optional ─────────────────────────────────────────────────────────────────
 
+# xAI API key — used for both Grok Voice realtime sessions AND history summarization.
+# Get yours at https://console.x.ai
+# XAI_API_KEY=xai-...
+
 # Server port (default: 8080)
 # PORT=8080
 
@@ -27,7 +27,7 @@ BRAIN_GATEWAY_AUTH_TOKEN=
 # Brain agent workspace path (used in system instructions; formerly OPENCLAW_WORKSPACE)
 # BRAIN_WORKSPACE=
 
-# OpenAI session rotation interval in ms (default: 50 minutes)
+# Session rotation interval in ms (default: 50 minutes)
 # ROTATION_INTERVAL_MS=3000000
 
 # Langfuse tracing (optional — relay runs fine without these)

--- a/relay-server/src/history.ts
+++ b/relay-server/src/history.ts
@@ -89,8 +89,8 @@ const SUMMARY_PROMPT = [
   "- <fact or decision>",
 ].join(" ")
 
-const OPENAI_SUMMARY_MODEL = "gpt-4o-mini"
 const GEMINI_SUMMARY_MODEL = "gemini-2.5-flash"
+const XAI_SUMMARY_MODEL = "grok-3-mini"
 const SUMMARY_TIMEOUT_MS = 8_000
 
 async function summarize(
@@ -101,9 +101,9 @@ async function summarize(
     .map((m) => `${m.role === "user" ? "User" : "Assistant"}: ${m.text}`)
     .join("\n")
 
-  const order: Summarizer[] = provider === "gemini"
-    ? [summarizeWithGemini, summarizeWithOpenAI]
-    : [summarizeWithOpenAI]
+  const order: Summarizer[] = provider === "xai"
+    ? [summarizeWithXai]
+    : [summarizeWithGemini]
 
   for (const fn of order) {
     try {
@@ -149,13 +149,13 @@ async function summarizeWithGemini(transcript: string): Promise<string | null> {
   return text || null
 }
 
-async function summarizeWithOpenAI(transcript: string): Promise<string | null> {
-  const apiKey = process.env.OPENAI_API_KEY
+async function summarizeWithXai(transcript: string): Promise<string | null> {
+  const apiKey = process.env.XAI_API_KEY
   if (!apiKey) return null
 
-  const url = "https://api.openai.com/v1/chat/completions"
+  const url = "https://api.x.ai/v1/chat/completions"
   const body = {
-    model: OPENAI_SUMMARY_MODEL,
+    model: XAI_SUMMARY_MODEL,
     messages: [
       { role: "system", content: SUMMARY_PROMPT },
       { role: "user", content: transcript },
@@ -174,7 +174,7 @@ async function summarizeWithOpenAI(transcript: string): Promise<string | null> {
   })
 
   if (!res.ok) {
-    throw new Error(`OpenAI summary HTTP ${res.status}`)
+    throw new Error(`xAI summary HTTP ${res.status}`)
   }
 
   const data = await res.json() as {

--- a/relay-server/test/history.test.ts
+++ b/relay-server/test/history.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { buildHistorySplit } from "../src/history.js"
+import type { HistoryMessage } from "../src/history.js"
+
+// Enough turns to force summarization (>16 messages = >8 verbatim turns)
+function makeHistory(count: number): HistoryMessage[] {
+  return Array.from({ length: count }, (_, i) => ({
+    role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
+    text: `Turn ${i + 1}`,
+  }))
+}
+
+const RECENT_COUNT = 16 // RECENT_TURNS_VERBATIM * 2
+
+describe("buildHistorySplit — summarization routing", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.stubEnv("XAI_API_KEY", "test-xai-key")
+    vi.stubEnv("GEMINI_API_KEY", "test-gemini-key")
+    fetchSpy = vi.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it("calls xAI summarizer for xai provider", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ choices: [{ message: { content: "xAI summary" } }] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+
+    const history = makeHistory(RECENT_COUNT + 4)
+    const result = await buildHistorySplit(history, "xai")
+
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    const [url] = fetchSpy.mock.calls[0] as [string, ...unknown[]]
+    expect(url).toContain("api.x.ai")
+    expect(result.summary).toBe("xAI summary")
+    expect(result.recent).toHaveLength(RECENT_COUNT)
+  })
+
+  it("calls Gemini summarizer for gemini provider", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          candidates: [{ content: { parts: [{ text: "Gemini summary" }] } }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+
+    const history = makeHistory(RECENT_COUNT + 4)
+    const result = await buildHistorySplit(history, "gemini")
+
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    const [url] = fetchSpy.mock.calls[0] as [string, ...unknown[]]
+    expect(url).toContain("generativelanguage.googleapis.com")
+    expect(result.summary).toBe("Gemini summary")
+  })
+
+  it("falls back to truncated raw transcript when summarizer fails", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("network error"))
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+
+    const history = makeHistory(RECENT_COUNT + 4)
+    const result = await buildHistorySplit(history, "xai")
+
+    expect(result.summary).toBeTruthy()
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining("No summarizer produced output"),
+    )
+
+    logSpy.mockRestore()
+  })
+
+  it("skips summarization when history is short enough", async () => {
+    const history = makeHistory(RECENT_COUNT)
+    const result = await buildHistorySplit(history, "xai")
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(result.summary).toBeNull()
+    expect(result.recent).toHaveLength(RECENT_COUNT)
+  })
+})


### PR DESCRIPTION
## Summary

- xAI sessions now use **grok-3-mini** via `api.x.ai` for history summarization; no OpenAI call is made
- Gemini sessions stay on `gemini-2.5-flash` (unchanged)
- Both paths fall back to raw truncated transcript if their provider API fails
- `checkOpenAiApiKey` removed from `brain-doctor.ts`; doctor check count drops from 12 → 11
- `relay-server/.env.example` updated: `OPENAI_API_KEY` removed from required section; `XAI_API_KEY` added to optional with dual-use note

## Changed files

| File | Change |
|------|--------|
| `relay-server/src/history.ts` | `summarizeWithOpenAI` → `summarizeWithXai` (grok-3-mini); chain updated |
| `relay-server/test/history.test.ts` | New: xAI routing, Gemini routing, fallback truncation, short-history no-op |
| `relay-server/.env.example` | Remove `OPENAI_API_KEY` required entry; add `XAI_API_KEY` optional entry |
| `desktop/src/main/services/brain-doctor.ts` | Remove `checkOpenAiApiKey` (check #12) |
| `docs/.../troubleshooting.mdx` | Update check counts 12→11, remove OpenAI entries |

## Test plan

- [x] `yarn workspace relay-server vitest run` — 130 passed, 3 skipped (0 failed)
- [x] `yarn workspace relay-server tsc --noEmit` — clean
- [x] `yarn workspace voiceclaw-desktop tsc --noEmit` — clean
- [x] New `history.test.ts` covers: xAI route hits `api.x.ai`, Gemini route hits `generativelanguage.googleapis.com`, both-fail → truncation fallback log, short history → no fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)