### PR TITLE
feat(desktop): disable image attachments on Grok Voice (NAN-718)

### DIFF
--- a/desktop/src/main/ipc-handlers.ts
+++ b/desktop/src/main/ipc-handlers.ts
@@ -361,6 +361,16 @@ export function registerIpcHandlers() {
   })
 
   ipcMain.handle('attachments:pickImage', async () => {
+    // Grok Voice has no visual modality. The renderer disables the
+    // attach button on this provider, but we re-check here so a future
+    // UI bug can't silently send an image the adapter won't relay.
+    if (getActiveProvider() === 'xai') {
+      return {
+        ok: false as const,
+        error:
+          'Image attachments are only available with Gemini Live. Grok Voice does not support image input.',
+      }
+    }
     const window = getMainWindow()
     const result = window
       ? await dialog.showOpenDialog(window, {

--- a/desktop/src/renderer/src/components/ChatComposer.tsx
+++ b/desktop/src/renderer/src/components/ChatComposer.tsx
@@ -17,11 +17,21 @@ import {
 export interface ChatComposerProps {
   onSubmit: (text: string) => void
   onAttach?: () => void
+  // When set, the attach button stays visible but is disabled and the
+  // string becomes its tooltip (used to gate image attachments on
+  // models that don't accept visual input — see ChatPage).
+  attachDisabledReason?: string
   disabled?: boolean
   placeholder?: string
 }
 
-export function ChatComposer({ onSubmit, onAttach, disabled, placeholder }: ChatComposerProps) {
+export function ChatComposer({
+  onSubmit,
+  onAttach,
+  attachDisabledReason,
+  disabled,
+  placeholder,
+}: ChatComposerProps) {
   const [value, setValue] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
@@ -61,16 +71,28 @@ export function ChatComposer({ onSubmit, onAttach, disabled, placeholder }: Chat
     <div className="px-4 py-3 border-t border-border bg-background/80 backdrop-blur">
       <div className="flex items-end gap-2">
         {onAttach && (
-          <Button
-            variant="default"
-            size="icon"
-            onClick={onAttach}
-            disabled={disabled}
-            aria-label="Attach an image"
-            title="Attach an image (PNG, JPG, WEBP, ≤10MB)"
+          // Wrap in a span so the tooltip still shows when the button
+          // is disabled (most browsers suppress title on disabled
+          // controls).
+          <span
+            title={
+              attachDisabledReason
+                ? attachDisabledReason
+                : 'Attach an image (PNG, JPG, WEBP, ≤10MB)'
+            }
+            className="inline-flex"
           >
-            <Paperclip size={18} />
-          </Button>
+            <Button
+              variant="default"
+              size="icon"
+              onClick={onAttach}
+              disabled={disabled || Boolean(attachDisabledReason)}
+              aria-label="Attach an image"
+              aria-disabled={Boolean(attachDisabledReason) || undefined}
+            >
+              <Paperclip size={18} />
+            </Button>
+          </span>
         )}
         <textarea
           ref={textareaRef}

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -654,6 +654,10 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
   const ingestFiles = useCallback(async (files: File[] | FileList) => {
     const list = Array.from(files)
     if (list.length === 0) return
+    if (attachDisabledReason) {
+      setAttachmentError(attachDisabledReason)
+      return
+    }
     const accepted: PendingAttachment[] = []
     const errors: string[] = []
     for (const file of list) {
@@ -666,7 +670,7 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
       setAttachmentError(null)
     }
     if (errors.length > 0) setAttachmentError(errors.join('  '))
-  }, [])
+  }, [attachDisabledReason])
 
   const handlePickImage = useCallback(async () => {
     const result = await pickImageAttachment()
@@ -697,6 +701,14 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
 
   const handleSendAttachments = useCallback(async () => {
     if (pendingAttachments.length === 0) return
+    // Catches the case where attachments were queued (via picker, drop,
+    // or paste) and the user then switched to a model that can't accept
+    // them before clicking send.
+    if (attachDisabledReason) {
+      setAttachmentError(attachDisabledReason)
+      setPendingAttachments([])
+      return
+    }
     setSendingAttachments(true)
     try {
       const convId = await ensureConversation()
@@ -734,7 +746,7 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
     } finally {
       setSendingAttachments(false)
     }
-  }, [pendingAttachments, isCallActive, realtime])
+  }, [pendingAttachments, isCallActive, realtime, attachDisabledReason])
 
   const handleDragEnter = useCallback((e: DragEvent<HTMLDivElement>) => {
     if (!hasFilePayload(e)) return

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -639,6 +639,13 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
       ? 'Screen sharing is only available with Gemini Live. Grok Voice does not support video input.'
       : 'Share screen'
 
+  // Image attachments depend on the active model accepting visual input.
+  // Grok Voice is audio-only — surface that as a tooltip rather than
+  // letting the user attach an image the model will silently ignore.
+  const attachDisabledReason = activeRealtimeModel.startsWith('grok-voice-')
+    ? 'Image attachments are only available with Gemini Live. Grok Voice does not support image input.'
+    : undefined
+
   const timelineItems = useMemo(
     () => buildTimeline(messages, toolCalls),
     [messages, toolCalls],
@@ -958,6 +965,7 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
       <ChatComposer
         onSubmit={handleComposerSubmit}
         onAttach={handlePickImage}
+        attachDisabledReason={attachDisabledReason}
       />
 
       {/* Call controls */}


### PR DESCRIPTION
## Why

Grok Voice has no visual modality. Screen-share is already gated for that reason (`ChatPage.tsx:603-640`) — the image-attach button wasn't. A user on Grok could attach a PNG/JPEG/WEBP that the adapter would silently drop. Mirroring the existing screen-share gating closes the gap.

Closes [NAN-718](https://linear.app/nano3labs/issue/NAN-718/disable-image-attachments-when-grok-voice-is-the-active-model).

## Approach

- `ChatComposer` gets a new optional `attachDisabledReason` prop. When set, the attach button stays visible but is disabled and the string becomes its tooltip. The button is wrapped in a `<span title=…>` so the tooltip still surfaces on a disabled control (browsers suppress `title` on disabled buttons natively).
- `ChatPage` computes the reason from `activeRealtimeModel` and passes it through. Tooltip copy mirrors the existing screen-share one shape-for-shape.
- **Defense in depth**: `attachments:pickImage` IPC handler also early-returns when `getActiveProvider() === 'xai'`, so a future UI bug can't bypass the renderer-side gate.
- **Mobile**: no image-attach UI exists today (verified by grepping for `Paperclip`, `ImagePicker`, `pickImage`, etc.), so nothing to gate there.

<details><summary>Test plan</summary>

- [x] `yarn typecheck` — passes
- [x] `yarn test` — 124 tests pass, 13 files (no behavior tests added — gating is plumbing-only)
- [ ] Manual: select Grok in Settings → return to chat → attach button is greyed, tooltip reads *"Image attachments are only available with Gemini Live. Grok Voice does not support image input."*
- [ ] Manual: switch back to Gemini → button enabled, original tooltip restored
- [ ] Manual: switch to Grok mid-call → button immediately gates without restart
- [ ] Manual: trigger the IPC directly (devtools `window.electronAPI.attachments.pickImage()`) on Grok → returns `{ ok: false, error: ... }` instead of opening the dialog

</details>

<details><summary>Implementation notes</summary>

- The `attachDisabledReason` API matches the existing `screenShareTitle`/`screenShareDisabled` shape — keeps two adjacent feature-gates legible.
- Re-checking the active model in the IPC handler costs a single SQLite read (`getActiveProvider`); fine on a button-driven path.
- The renderer-side gate is the user-facing one; the IPC gate is just a safety net.

</details>