### PR TITLE
fix: restore get-windows dep + escape MDX braces to unblock CI

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -22,6 +22,7 @@
     "archiver": "^7.0.1",
     "better-sqlite3": "^12.9.0",
     "electron-updater": "^6.6.2",
+    "get-windows": "^9.3.0",
     "posthog-js": "^1.372.1",
     "posthog-node": "^5.30.4",
     "react": "^19.1.0",

--- a/docs/src/content/docs/desktop/troubleshooting.mdx
+++ b/docs/src/content/docs/desktop/troubleshooting.mdx
@@ -111,7 +111,7 @@ When the realtime voice connection fails because of an upstream provider problem
 | Gemini API key invalid | Key was deleted or rotated | Click **Open Settings** → re-enter the key under Settings → Provider |
 | Gemini quota exceeded | Daily quota hit | Click **Open billing** → upgrade at aistudio.google.com/app/billing |
 | Gemini service is having issues | Google-side outage | Check status.cloud.google.com; try again later |
-| Connection to {provider} closed unexpectedly | Transient network drop | Start a new call |
+| Connection to \{provider\} closed unexpectedly | Transient network drop | Start a new call |
 
 The banner stays visible for the rest of the session so you can confirm the fix after returning from the billing page. Click **Dismiss** to hide it, or start a new call to reset it.
 


### PR DESCRIPTION
## Why

CI on `main` is broken. Every workflow that runs `yarn install --immutable` fails with `YN0028: The lockfile would have been modified by this install` — Desktop smoke and Deploy docs both die at the install step. The release-please bot's `0.10.47` commit (#401) stripped the `get-windows` dependency that #366 had added to `desktop/package.json`, but the regenerated `yarn.lock` still references it. CI refuses to drop the orphan entry, so install fails before any real work runs.

`screen-capture.ts` still imports `get-windows` (used to look up CGWindowID for window-source screen-share alignment), so the right fix is to put the dep back in `package.json` — not let the lockfile drop it.

Bonus: once install passes, the Deploy docs job moves on and dies on a separate pre-existing bug — `Connection to {provider} closed unexpectedly` in `troubleshooting.mdx`. MDX evaluates the `{...}` as a JS expression, throwing `provider is not defined` during prerender. Escaping the braces was a one-character change so I rolled it into the same PR rather than letting docs-deploy stay broken on main.

<details>
<summary>Test plan</summary>

- [x] `yarn install --immutable` passes locally on this branch
- [x] `cd docs && yarn build` completes (34 pages, no errors)
- [ ] CI on the PR: Desktop smoke green
- [ ] CI on the PR: Deploy docs green

</details>

<details>
<summary>Implementation notes</summary>

- I considered the alternative of regenerating `yarn.lock` to match the (mistakenly) stripped `package.json`. Rejected: `desktop/src/main/screen-capture.ts` and `desktop/src/renderer/src/pages/ChatPage.tsx` both reference `get-windows`, so dropping the dep would compile-error the desktop build. The lockfile entry was correct; the `package.json` regression is what to fix.
- The release-please diff that removed it (`cfc74f1`) is just a version bump from `0.10.46` → `0.10.47` plus the dependency line vanishing. Looks like a release-please tooling artifact rather than an intentional drop. May be worth investigating release-please config separately so this doesn't happen again on the next release.
- Docs deploy has been red since #380 (Apr 30) — the MDX `{provider}` was introduced there. Just unlucky we didn't notice until now because docs-deploy was the second-class citizen behind the more obvious lockfile failure.

</details>