### PR TITLE
fix(desktop): clip phantom scrollbars from messages container

### DIFF
--- a/desktop/src/renderer/src/components/MessageBubble.tsx
+++ b/desktop/src/renderer/src/components/MessageBubble.tsx
@@ -52,7 +52,7 @@ export function MessageBubble({
         onContextMenu={handleContextMenu}
         title={exactTime}
         className={`
-          max-w-[80%] rounded-md px-4 py-2.5 text-sm leading-relaxed
+          max-w-[80%] min-w-0 rounded-md px-4 py-2.5 text-sm leading-relaxed break-words
           ${isUser
             ? 'bg-primary text-primary-foreground'
             : 'bg-card text-foreground border border-border'

--- a/desktop/src/renderer/src/pages/ChatPage.tsx
+++ b/desktop/src/renderer/src/pages/ChatPage.tsx
@@ -1034,7 +1034,7 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
       </div>
 
       {/* Messages */}
-      <div className="flex-1 overflow-y-auto px-4 py-4">
+      <div className="flex-1 overflow-y-auto overflow-x-hidden px-4 py-4">
         {messages.length === 0 && !isCallActive && (
           <div className="flex h-full flex-col items-center justify-center text-center text-muted-foreground">
             <div className="mb-5 flex size-16 items-center justify-center rounded-md border border-border bg-card text-foreground vc-panel-shadow">
@@ -1076,7 +1076,7 @@ export function ChatPage({ onNavigateToSettings }: ChatPageProps = {}) {
           <div className={`flex ${streamingRole === 'user' ? 'justify-end' : 'justify-start'} mb-3`}>
             <div
               className={`
-                max-w-[80%] rounded-md px-4 py-2.5 text-sm leading-relaxed
+                max-w-[80%] min-w-0 rounded-md px-4 py-2.5 text-sm leading-relaxed break-words
                 ${streamingRole === 'user'
                   ? 'bg-primary text-primary-foreground'
                   : 'bg-card text-foreground border border-border'


### PR DESCRIPTION
## Why

Two visual artifacts appear above the composer (per the user's screenshot in the originating conversation): a horizontal dark bar at the bottom of the messages area, plus a small light box on the far right at the same vertical level. They are macOS Chromium's horizontal + vertical scrollbars on the messages container — the global `::-webkit-scrollbar` rule in `index.css` only sets `width: 6px`, so when a horizontal scrollbar gets triggered it falls back to default Chromium height (~15px), painting a dark gutter and thumb right above the composer.

The trigger: `<div className="flex-1 overflow-y-auto …">` on the messages list. Per CSS spec, when one axis is non-`visible`, the other axis's `visible` is computed as `auto`. Any horizontal overflow inside a message bubble (long unbreakable text, a pasted URL, a code-like string) pushes past `max-w-[80%]` and turns the implicit `overflow-x: auto` into a visible scrollbar.

Same family of bug as NAN-705 (textarea phantom gutter), different element.

## What changed

- `ChatPage.tsx` — messages container is now `overflow-y-auto overflow-x-hidden`, so any inner horizontal overflow is clipped instead of producing a Chromium scrollbar.
- `MessageBubble.tsx` + the streaming-bubble in `ChatPage.tsx` — added `min-w-0 break-words` so long URLs / unbreakable strings wrap inside the bubble rather than forcing the parent wider in the first place.

## Test plan

- [ ] Manually verify in Electron: open chat with the existing 1597-message conversation, scroll to bottom, confirm the dark horizontal gutter and the right-edge thumb above the composer are gone.
- [ ] Send a message with a long unbreakable URL (e.g. `https://example.com/very/long/path/that/has/no/breaking/points/at/all/and/keeps/going`) — confirm it wraps inside the bubble instead of overflowing.
- [ ] Vertical scrolling of the message list still works normally.

Note: I could not run the dev server to take a fresh "after" screenshot — `yarn dev` currently fails on `main` with a `mock-aws-s3` rolldown resolution error from `@mapbox/node-pre-gyp` (pre-existing on `main`, unrelated to this PR). Type-check + 124 desktop tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)