### PR TITLE
feat(website): add EmailOctopus join page and flip CTAs

### DIFF
--- a/website/.env.example
+++ b/website/.env.example
@@ -57,3 +57,11 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # no-ops when unset.
 NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# ---------------------------------------------------------------------------
+# EmailOctopus (newsletter signup)
+# ---------------------------------------------------------------------------
+# Create an API key at https://emailoctopus.com/api-keys and grab the list
+# ID from the list URL. /api/subscribe returns 501 until both are set.
+EMAIL_OCTOPUS_API_KEY=
+EMAIL_OCTOPUS_LIST_ID=

--- a/website/src/app/api/subscribe/route.ts
+++ b/website/src/app/api/subscribe/route.ts
@@ -1,0 +1,38 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { isEmailOctopusConfigured, subscribeToList } from "@/lib/email-octopus"
+import { withCapture } from "@/lib/telemetry/posthog-server"
+
+type Body = { email?: unknown }
+
+export const POST = withCapture(async (request: NextRequest) => {
+  if (!isEmailOctopusConfigured()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 501 })
+  }
+
+  let body: Body
+  try {
+    body = (await request.json()) as Body
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 })
+  }
+
+  if (typeof body.email !== "string") {
+    return NextResponse.json({ error: "missing_email" }, { status: 400 })
+  }
+
+  const result = await subscribeToList(body.email)
+  if (result.ok) {
+    return NextResponse.json({ ok: true })
+  }
+
+  switch (result.reason) {
+    case "invalid_email":
+      return NextResponse.json({ error: "invalid_email" }, { status: 400 })
+    case "already_subscribed":
+      return NextResponse.json({ ok: true, alreadySubscribed: true })
+    case "rate_limited":
+      return NextResponse.json({ error: "rate_limited" }, { status: 429 })
+    default:
+      return NextResponse.json({ error: "upstream_error" }, { status: 502 })
+  }
+}, "/api/subscribe")

--- a/website/src/app/join/page.tsx
+++ b/website/src/app/join/page.tsx
@@ -1,0 +1,145 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { ArrowLeft, Mic, RadioTower, ShieldCheck } from "lucide-react"
+import { BrandWordmark } from "@/components/brand/brand-system"
+import { ThemeSwitcher } from "@/components/theme-switcher"
+import { JoinForm } from "@/components/join/join-form"
+
+const REPO_URL = "https://github.com/yagudaev/voiceclaw"
+const RELEASES_URL = "https://github.com/yagudaev/voiceclaw/releases"
+
+export const metadata: Metadata = {
+  title: "Join VoiceClaw",
+  description:
+    "Get launch notes, TestFlight invites, and build updates for VoiceClaw — the open-source voice layer for your agent.",
+}
+
+export default function JoinPage() {
+  return (
+    <main className="min-h-screen bg-[var(--brand-paper)] text-[var(--brand-ink)]">
+      <Header />
+      <section className="border-b border-[var(--brand-line-strong)] px-5 py-20 sm:px-8">
+        <div className="mx-auto max-w-4xl">
+          <p className="font-mono text-xs uppercase tracking-[0.28em] text-[var(--brand-accent)]">
+            Join
+          </p>
+          <h1 className="mt-6 font-serif text-5xl leading-none sm:text-7xl">
+            Get on the list.
+          </h1>
+          <p className="mt-6 max-w-2xl text-lg leading-8 text-[var(--brand-muted)] sm:text-xl">
+            Drop your email and we&apos;ll send launch notes, TestFlight invites,
+            and the occasional build update. Voice for the agent you already
+            trust.
+          </p>
+
+          <div className="mt-10">
+            <JoinForm />
+          </div>
+
+          <div className="mt-10 grid gap-4 sm:grid-cols-3">
+            <InfoTile
+              icon={<Mic className="size-5" />}
+              title="Natural voice in front"
+              body="Low-latency voice sessions with transcript continuity and clear live state."
+            />
+            <InfoTile
+              icon={<RadioTower className="size-5" />}
+              title="iPhone TestFlight"
+              body="Members get TestFlight invites first while App Store review wraps up."
+            />
+            <InfoTile
+              icon={<ShieldCheck className="size-5" />}
+              title="Open source"
+              body="Run the relay yourself, inspect the code, and keep provider keys under your control."
+            />
+          </div>
+
+          <p className="mt-10 text-sm text-[var(--brand-muted)]">
+            Already have a Mac?{" "}
+            <Link
+              href="/download"
+              className="font-semibold text-[var(--brand-ink)] underline decoration-[var(--brand-accent)] underline-offset-4"
+            >
+              Download the macOS app
+            </Link>
+            .
+          </p>
+        </div>
+      </section>
+      <Footer />
+    </main>
+  )
+}
+
+function Header() {
+  return (
+    <header className="sticky top-0 z-50 border-b border-[var(--brand-line-strong)] bg-[var(--brand-paper)]/90 backdrop-blur-md">
+      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-5 sm:px-8">
+        <Link href="/" aria-label="VoiceClaw home">
+          <BrandWordmark />
+        </Link>
+        <nav className="flex items-center gap-2 text-sm text-[var(--brand-muted)] sm:gap-5">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 hover:text-[var(--brand-ink)]"
+          >
+            <ArrowLeft className="size-4" />
+            <span className="hidden sm:inline">Home</span>
+          </Link>
+          <ThemeSwitcher />
+        </nav>
+      </div>
+    </header>
+  )
+}
+
+function Footer() {
+  return (
+    <footer className="border-t border-[var(--brand-line-strong)] bg-[var(--brand-paper)] px-5 py-8 sm:px-8">
+      <div className="mx-auto flex max-w-7xl flex-col justify-between gap-5 text-sm text-[var(--brand-muted)] sm:flex-row sm:items-center">
+        <BrandWordmark />
+        <div className="flex flex-wrap gap-5">
+          <a
+            href={RELEASES_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-[var(--brand-ink)]"
+          >
+            Release notes
+          </a>
+          <Link href="/brand" className="hover:text-[var(--brand-ink)]">
+            Brand guidelines
+          </Link>
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-[var(--brand-ink)]"
+          >
+            GitHub
+          </a>
+        </div>
+      </div>
+    </footer>
+  )
+}
+
+function InfoTile({
+  icon,
+  title,
+  body,
+}: {
+  icon: React.ReactNode
+  title: string
+  body: string
+}) {
+  return (
+    <article className="rounded-md border border-[var(--brand-line-strong)] bg-[var(--brand-panel)] p-5 shadow-[var(--brand-shadow)]">
+      <div className="mb-4 flex size-10 items-center justify-center rounded-md bg-[var(--brand-accent-wash)] text-[var(--brand-accent)]">
+        {icon}
+      </div>
+      <h3 className="text-base font-semibold text-[var(--brand-ink)]">{title}</h3>
+      <p className="mt-2 text-sm leading-6 text-[var(--brand-muted)]">{body}</p>
+    </article>
+  )
+}

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import {
   ArrowRight,
   Download,
+  Mail,
   Mic,
   PlayCircle,
   RadioTower,
@@ -27,6 +28,7 @@ import {
 
 const REPO_URL = "https://github.com/yagudaev/voiceclaw"
 const MAC_DOWNLOAD_URL = "/download"
+const JOIN_URL = "/join"
 const TESTFLIGHT_SIGNUP_URL = ""
 const DEMO_EMBED_URL = "https://www.youtube.com/embed/iAS7vj2vRaA"
 const HERO_BARS = [26, 44, 58, 42, 24, 34, 52, 78, 50, 31, 66, 86, 60, 38, 54, 82, 48, 72]
@@ -71,14 +73,13 @@ function Header({
           <ThemeSwitcher />
           <TrackCtaLink
             ctaLocation="header"
-            ctaLabel="Download Mac"
-            href={MAC_DOWNLOAD_URL}
-            aria-label="Download for Mac"
-            title={downloadTitle(macRelease)}
-            className="inline-flex items-center gap-2 rounded-md border border-[var(--brand-line-strong)] bg-[var(--brand-panel)] px-3 py-2 text-[var(--brand-ink)] shadow-[var(--brand-shadow)] transition hover:border-[var(--brand-accent)]"
+            ctaLabel="Join"
+            href={JOIN_URL}
+            aria-label="Join the email list"
+            className="inline-flex items-center gap-2 rounded-md bg-[var(--brand-accent)] px-3 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-[var(--brand-accent-hover)]"
           >
-            <Download className="size-4" />
-            <span className="hidden sm:inline">Download Mac</span>
+            <Mail className="size-4" />
+            <span className="hidden sm:inline">Join</span>
           </TrackCtaLink>
         </nav>
       </div>
@@ -112,20 +113,29 @@ function HeroSection({
               OpenAI-compatible endpoint and it handles the mic, the route, and
               the transcript while your agent does the real work.
             </p>
-            <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+            <div className="mt-9 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+              <TrackCtaLink
+                ctaLocation="hero"
+                ctaLabel="Join"
+                href={JOIN_URL}
+                className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-[var(--brand-accent)] px-5 text-sm font-semibold text-primary-foreground transition hover:bg-[var(--brand-accent-hover)]"
+              >
+                <Mail className="size-4" />
+                Join
+              </TrackCtaLink>
               <TrackCtaLink
                 ctaLocation="hero"
                 ctaLabel="Download for Mac"
                 href={MAC_DOWNLOAD_URL}
                 title={downloadTitle(macRelease)}
-                className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-[var(--brand-accent)] px-5 text-sm font-semibold text-primary-foreground transition hover:bg-[var(--brand-accent-hover)]"
+                className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-[var(--brand-line-strong)] bg-[var(--brand-panel)] px-5 text-sm font-semibold text-[var(--brand-ink)] transition hover:border-[var(--brand-accent)]"
               >
                 <Download className="size-4" />
                 Download for Mac
               </TrackCtaLink>
               <Link
                 href="#demo"
-                className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-[var(--brand-line-strong)] bg-[var(--brand-panel)] px-5 text-sm font-semibold text-[var(--brand-ink)] transition hover:border-[var(--brand-accent)]"
+                className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-transparent px-2 text-sm font-semibold text-[var(--brand-muted)] transition hover:text-[var(--brand-ink)]"
               >
                 <PlayCircle className="size-4" />
                 Watch demo
@@ -377,20 +387,30 @@ function GetStartedSection({
             Get started
           </p>
           <h2 className="mt-4 max-w-3xl font-serif text-5xl leading-none sm:text-6xl">
-            Start with the Mac app.
+            Get on the list.
           </h2>
           <p className="mt-6 max-w-2xl text-lg leading-8 text-[var(--brand-contrast-muted)]">
-            Download VoiceClaw for macOS, connect your agent endpoint, and start
-            talking. <TestFlightSignupNotice contrast />
+            Drop your email for launch notes, TestFlight invites, and build
+            updates. Already on a Mac? Grab the desktop app below.{" "}
+            <TestFlightSignupNotice contrast />
           </p>
         </div>
         <div className="flex flex-col justify-end gap-3">
           <TrackCtaLink
             ctaLocation="get_started"
+            ctaLabel="Join"
+            href={JOIN_URL}
+            className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-[var(--brand-accent)] px-5 text-sm font-semibold text-primary-foreground transition hover:bg-[var(--brand-accent-hover)]"
+          >
+            <Mail className="size-4" />
+            Join
+          </TrackCtaLink>
+          <TrackCtaLink
+            ctaLocation="get_started"
             ctaLabel="Download for Mac"
             href={MAC_DOWNLOAD_URL}
             title={downloadTitle(macRelease)}
-            className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-[var(--brand-contrast-fg)] px-5 text-sm font-semibold text-[var(--brand-contrast-bg)] transition hover:bg-[var(--brand-contrast-fg-hover)]"
+            className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-[var(--brand-contrast-line)] px-5 text-sm font-semibold text-[var(--brand-contrast-fg)] transition hover:border-[var(--brand-contrast-fg)]"
           >
             <Download className="size-4" />
             Download for Mac
@@ -400,7 +420,7 @@ function GetStartedSection({
             href={REPO_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-[var(--brand-contrast-line)] px-5 text-sm font-semibold text-[var(--brand-contrast-fg)] transition hover:border-[var(--brand-contrast-fg)]"
+            className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-transparent px-5 text-sm font-semibold text-[var(--brand-contrast-muted)] transition hover:text-[var(--brand-contrast-fg)]"
           >
             View source
             <ArrowRight className="size-4" />

--- a/website/src/components/join/join-form.tsx
+++ b/website/src/components/join/join-form.tsx
@@ -1,0 +1,156 @@
+"use client"
+
+import { useState, type FormEvent } from "react"
+import { ArrowRight, CheckCircle2 } from "lucide-react"
+import { capture } from "@/lib/telemetry/posthog-client"
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "success"; alreadySubscribed: boolean }
+  | { kind: "error"; message: string }
+
+const ERROR_COPY: Record<string, string> = {
+  invalid_email: "That email doesn't look right. Try again.",
+  not_configured: "Signup isn't live yet. Check back soon.",
+  rate_limited: "Too many tries. Give it a minute and retry.",
+  upstream_error: "Something went wrong on our end. Try again.",
+  network_error: "Couldn't reach the server. Check your connection.",
+}
+
+export function JoinForm() {
+  const [email, setEmail] = useState("")
+  const [status, setStatus] = useState<Status>({ kind: "idle" })
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (status.kind === "submitting") return
+
+    setStatus({ kind: "submitting" })
+    capture("join_submitted", { location: "join_page" })
+
+    let response: Response
+    try {
+      response = await fetch("/api/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      })
+    } catch {
+      setStatus({ kind: "error", message: ERROR_COPY.network_error })
+      return
+    }
+
+    const payload = (await safeJson(response)) as
+      | { ok?: boolean; alreadySubscribed?: boolean; error?: string }
+      | null
+
+    if (response.ok && payload?.ok) {
+      capture("join_succeeded", {
+        location: "join_page",
+        already_subscribed: Boolean(payload.alreadySubscribed),
+      })
+      setStatus({
+        kind: "success",
+        alreadySubscribed: Boolean(payload.alreadySubscribed),
+      })
+      setEmail("")
+      return
+    }
+
+    const code = payload?.error ?? "upstream_error"
+    capture("join_failed", { location: "join_page", error: code })
+    setStatus({ kind: "error", message: ERROR_COPY[code] ?? ERROR_COPY.upstream_error })
+  }
+
+  if (status.kind === "success") {
+    return (
+      <div
+        role="status"
+        className="rounded-md border border-[var(--brand-line-strong)] bg-[var(--brand-panel)] p-6 shadow-[var(--brand-shadow)] sm:p-8"
+      >
+        <div className="flex items-start gap-4">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-md bg-[var(--brand-accent-wash)] text-[var(--brand-accent)]">
+            <CheckCircle2 className="size-5" />
+          </div>
+          <div>
+            <p className="font-mono text-xs uppercase tracking-[0.24em] text-[var(--brand-accent)]">
+              {status.alreadySubscribed ? "Already on the list" : "You're in"}
+            </p>
+            <h2 className="mt-3 font-serif text-2xl leading-tight text-[var(--brand-ink)] sm:text-3xl">
+              {status.alreadySubscribed
+                ? "We already have your email."
+                : "Welcome aboard."}
+            </h2>
+            <p className="mt-3 text-sm leading-7 text-[var(--brand-muted)]">
+              We&apos;ll send launch notes, TestFlight invites, and the occasional
+              build update. No noise.
+            </p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const submitting = status.kind === "submitting"
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      noValidate
+      className="rounded-md border border-[var(--brand-line-strong)] bg-[var(--brand-panel)] p-6 shadow-[var(--brand-shadow)] sm:p-8"
+    >
+      <label
+        htmlFor="join-email"
+        className="font-mono text-xs uppercase tracking-[0.24em] text-[var(--brand-muted)]"
+      >
+        Email
+      </label>
+      <div className="mt-3 flex flex-col gap-3 sm:flex-row">
+        <input
+          id="join-email"
+          name="email"
+          type="email"
+          required
+          autoComplete="email"
+          inputMode="email"
+          placeholder="you@domain.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          disabled={submitting}
+          aria-invalid={status.kind === "error" || undefined}
+          aria-describedby={status.kind === "error" ? "join-error" : undefined}
+          className="h-12 flex-1 rounded-md border border-[var(--brand-line-strong)] bg-[var(--brand-panel-strong)] px-4 text-base text-[var(--brand-ink)] placeholder:text-[var(--brand-muted)] focus:border-[var(--brand-accent)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent-wash)] disabled:opacity-60"
+        />
+        <button
+          type="submit"
+          disabled={submitting}
+          className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-[var(--brand-accent)] px-5 text-sm font-semibold text-primary-foreground transition hover:bg-[var(--brand-accent-hover)] disabled:cursor-not-allowed disabled:opacity-70"
+        >
+          {submitting ? "Joining..." : "Join"}
+          {!submitting && <ArrowRight className="size-4" />}
+        </button>
+      </div>
+      {status.kind === "error" && (
+        <p
+          id="join-error"
+          role="alert"
+          className="mt-4 text-sm text-destructive"
+        >
+          {status.message}
+        </p>
+      )}
+      <p className="mt-5 text-xs leading-6 text-[var(--brand-muted)]">
+        We use your email only to send VoiceClaw updates. Unsubscribe any time.
+      </p>
+    </form>
+  )
+}
+
+async function safeJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch {
+    return null
+  }
+}

--- a/website/src/lib/email-octopus.ts
+++ b/website/src/lib/email-octopus.ts
@@ -1,0 +1,82 @@
+const EMAIL_OCTOPUS_BASE = "https://api.emailoctopus.com"
+
+export type SubscribeResult =
+  | { ok: true }
+  | { ok: false; reason: "not_configured" | "invalid_email" | "already_subscribed" | "rate_limited" | "upstream_error"; status?: number; message?: string }
+
+export function isEmailOctopusConfigured(): boolean {
+  return Boolean(process.env.EMAIL_OCTOPUS_API_KEY && process.env.EMAIL_OCTOPUS_LIST_ID)
+}
+
+export async function subscribeToList(email: string): Promise<SubscribeResult> {
+  const apiKey = process.env.EMAIL_OCTOPUS_API_KEY
+  const listId = process.env.EMAIL_OCTOPUS_LIST_ID
+  if (!apiKey || !listId) {
+    return { ok: false, reason: "not_configured" }
+  }
+
+  const trimmed = email.trim().toLowerCase()
+  if (!isPlausibleEmail(trimmed)) {
+    return { ok: false, reason: "invalid_email" }
+  }
+
+  const url = `${EMAIL_OCTOPUS_BASE}/lists/${encodeURIComponent(listId)}/contacts`
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email_address: trimmed, status: "subscribed" }),
+      cache: "no-store",
+    })
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "upstream_error",
+      message: err instanceof Error ? err.message : "fetch_failed",
+    }
+  }
+
+  if (response.ok) {
+    return { ok: true }
+  }
+
+  const payload = (await safeJson(response)) as { error?: { code?: string; message?: string } } | null
+  const code = payload?.error?.code
+
+  if (response.status === 409 || code === "MEMBER_EXISTS_WITH_EMAIL_ADDRESS") {
+    return { ok: false, reason: "already_subscribed", status: response.status }
+  }
+  if (response.status === 429) {
+    return { ok: false, reason: "rate_limited", status: response.status }
+  }
+  if (response.status === 400 && code === "INVALID_PARAMETERS") {
+    return { ok: false, reason: "invalid_email", status: response.status }
+  }
+
+  return {
+    ok: false,
+    reason: "upstream_error",
+    status: response.status,
+    message: payload?.error?.message,
+  }
+}
+
+function isPlausibleEmail(value: string): boolean {
+  if (value.length < 3 || value.length > 254) return false
+  const at = value.indexOf("@")
+  if (at <= 0 || at !== value.lastIndexOf("@")) return false
+  const dot = value.lastIndexOf(".")
+  return dot > at + 1 && dot < value.length - 1
+}
+
+async function safeJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- New `/join` signup-style page with an inline email form that posts to a new `POST /api/subscribe` route, which subscribes the address to EmailOctopus via the v2 API.
- Homepage CTAs now lead with **Join** (primary) and keep **Download for Mac** as a secondary action across the header, hero, and "Get started" section.
- `/api/subscribe` returns `501 not_configured` until `EMAIL_OCTOPUS_API_KEY` and `EMAIL_OCTOPUS_LIST_ID` are set, matching the rest of the site's graceful-degrade pattern. `.env.example` documents both.

## Notes for review
- EmailOctopus credentials are pulled from env vars only — no list ID is hardcoded. Set `EMAIL_OCTOPUS_API_KEY` and `EMAIL_OCTOPUS_LIST_ID` in Vercel (and `.env.local` for dev) to turn it on.
- The form treats EmailOctopus' "already exists" response as a soft success so resubmissions don't look like errors.
- PostHog `cta_clicked`, `join_submitted`, `join_succeeded`, and `join_failed` events fire from the new flow so we can measure conversion.
- I couldn't run `yarn lint` in the sandbox (corepack can't reach `repo.yarnpkg.com` to fetch Yarn 4). Please run `yarn lint` and the dev server locally to confirm.

## Test plan
- [ ] `yarn lint` and `yarn build` pass in `website/`.
- [ ] Without env vars set: visit `/join`, submit a valid email, verify the inline error surfaces (501 → `upstream_error`-class message).
- [ ] With `EMAIL_OCTOPUS_API_KEY` and `EMAIL_OCTOPUS_LIST_ID` set: submit a real email, verify the contact lands on the EmailOctopus list and the success state renders.
- [ ] Submit the same email twice — second attempt should still show the success state (treated as already-subscribed).
- [ ] Submit an obviously invalid email (`foo`) — inline validation message appears and no network call is needed (but server still rejects).
- [ ] Homepage: header **Join** button, hero **Join** primary + **Download for Mac** secondary, and "Get started" section all link to `/join` and `/download` respectively.

https://claude.ai/code/session_01LtVvWyMttH3PPRARNbQae8

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtVvWyMttH3PPRARNbQae8)_