### PR TITLE
chore(dev-kill): add port 5173 to desktop dev port list

### DIFF
--- a/scripts/dev-kill.sh
+++ b/scripts/dev-kill.sh
@@ -10,7 +10,7 @@
 
 set -u
 
-PORTS=(8080 4318 4319 3000)
+PORTS=(8080 4318 4319 3000 5173)
 GRACE_SECONDS=2
 
 for port in "${PORTS[@]}"; do


### PR DESCRIPTION
## Summary
- Add port 5173 (desktop renderer dev server) to the kill list in `scripts/dev-kill.sh` so `yarn dev:kill` reclaims it.

## Test plan
- [ ] Run `scripts/dev-kill.sh` with a process bound to 5173 and confirm it is killed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)