### PR TITLE
fix(desktop): align composer fields and dedupe burst timestamps

### DIFF
--- a/desktop/src/renderer/src/components/ChatComposer.tsx
+++ b/desktop/src/renderer/src/components/ChatComposer.tsx
@@ -83,7 +83,7 @@ export function ChatComposer({
             className="inline-flex"
           >
             <Button
-              variant="default"
+              variant="secondary"
               size="icon"
               onClick={onAttach}
               disabled={disabled || Boolean(attachDisabledReason)}
@@ -104,7 +104,7 @@ export function ChatComposer({
           placeholder={placeholder ?? 'Type a message — Enter sends, Shift+Enter for newline'}
           aria-label="Type a message"
           className="
-            flex-1 resize-none rounded-md border border-input bg-background px-3 py-2
+            flex-1 resize-none rounded-md border border-input bg-background px-3 py-2.5
             text-sm text-foreground placeholder:text-muted-foreground leading-5
             focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary/50
             disabled:opacity-50 disabled:cursor-not-allowed

--- a/desktop/src/renderer/src/lib/composer.ts
+++ b/desktop/src/renderer/src/lib/composer.ts
@@ -1,7 +1,7 @@
 const MIN_ROWS = 1
 const MAX_ROWS = 6
 const LINE_HEIGHT_PX = 20
-const VERTICAL_PADDING_PX = 16
+const VERTICAL_PADDING_PX = 20
 
 export function normalizeComposerText(value: string): string {
   return value.replace(/[ \t\r\n]+$/u, '')

--- a/desktop/src/renderer/src/lib/message-grouping.test.ts
+++ b/desktop/src/renderer/src/lib/message-grouping.test.ts
@@ -68,6 +68,31 @@ describe('groupMessages', () => {
     expect(messages[1]).toMatchObject({ isFirstInBurst: true, isLastInBurst: true })
   })
 
+  it('dedupes consecutive role-transition separators that share a label', () => {
+    const out = groupMessages(
+      [
+        msg(1, 'user', 0),
+        msg(2, 'assistant', 5_000),
+        msg(3, 'user', 10_000),
+        msg(4, 'assistant', 15_000),
+      ],
+      { now: BASE + 20_000 },
+    )
+    const seps = out.filter((i) => i.kind === 'separator') as Extract<
+      typeof out[number],
+      { kind: 'separator' }
+    >[]
+    // First separator is the day label for msg 1; the three subsequent
+    // role-transition separators all resolve to "just now" and collapse to one.
+    expect(seps).toHaveLength(2)
+    expect(seps[1].label).toBe('just now')
+    const messages = out.filter((i) => i.kind === 'message')
+    expect(messages).toHaveLength(4)
+    for (const m of messages) {
+      expect(m).toMatchObject({ isFirstInBurst: true, isLastInBurst: true })
+    }
+  })
+
   it('uses configurable burst threshold', () => {
     const out = groupMessages(
       [msg(1, 'user', 0), msg(2, 'user', 90_000)],

--- a/desktop/src/renderer/src/lib/message-grouping.test.ts
+++ b/desktop/src/renderer/src/lib/message-grouping.test.ts
@@ -82,8 +82,6 @@ describe('groupMessages', () => {
       typeof out[number],
       { kind: 'separator' }
     >[]
-    // First separator is the day label for msg 1; the three subsequent
-    // role-transition separators all resolve to "just now" and collapse to one.
     expect(seps).toHaveLength(2)
     expect(seps[1].label).toBe('just now')
     const messages = out.filter((i) => i.kind === 'message')

--- a/desktop/src/renderer/src/lib/message-grouping.ts
+++ b/desktop/src/renderer/src/lib/message-grouping.ts
@@ -30,6 +30,7 @@ export function groupMessages(
   const out: GroupedItem[] = []
 
   let burstStart = 0
+  let lastSeparatorLabel: string | null = null
   for (let i = 0; i < sorted.length; i++) {
     const msg = sorted[i]
     const prev = i > 0 ? sorted[i - 1] : null
@@ -42,18 +43,13 @@ export function groupMessages(
       msg.created_at - prev.created_at < burstThreshold
 
     if (!sameBurst) {
-      if (prev == null || !sameDay) {
-        out.push({
-          kind: 'separator',
-          label: formatDaySeparator(msg.created_at, now),
-          timestamp: msg.created_at,
-        })
-      } else {
-        out.push({
-          kind: 'separator',
-          label: formatBurstSeparator(msg.created_at, now),
-          timestamp: msg.created_at,
-        })
+      const label =
+        prev == null || !sameDay
+          ? formatDaySeparator(msg.created_at, now)
+          : formatBurstSeparator(msg.created_at, now)
+      if (label !== lastSeparatorLabel) {
+        out.push({ kind: 'separator', label, timestamp: msg.created_at })
+        lastSeparatorLabel = label
       }
       burstStart = i
     }

--- a/desktop/src/renderer/src/lib/message-grouping.ts
+++ b/desktop/src/renderer/src/lib/message-grouping.ts
@@ -43,10 +43,9 @@ export function groupMessages(
       msg.created_at - prev.created_at < burstThreshold
 
     if (!sameBurst) {
-      const label =
-        prev == null || !sameDay
-          ? formatDaySeparator(msg.created_at, now)
-          : formatBurstSeparator(msg.created_at, now)
+      const label = !sameDay
+        ? formatDaySeparator(msg.created_at, now)
+        : formatBurstSeparator(msg.created_at, now)
       if (label !== lastSeparatorLabel) {
         out.push({ kind: 'separator', label, timestamp: msg.created_at })
         lastSeparatorLabel = label


### PR DESCRIPTION
## Why

Composer button heights didn't match the textarea, and the paperclip rendered as a primary button — visually competing with send. Demote the paperclip to the secondary variant and pad the textarea to the same h-10 the icon buttons already use.

The chat transcript showed the same "36 MIN AGO" separator three times in a quick back-and-forth: every role transition opens a fresh burst, and inside the same minute every burst emits the same label. Dedupe consecutive separators with identical labels so each time bucket renders once.

## Screenshots

UI tweaks; this is an Electron app so screenshots aren't auto-captured. Test plan below covers visual verification.

<details><summary>Test plan</summary>

- [ ] Open the desktop chat. Confirm paperclip, textarea, and send button bottoms align at h-10.
- [ ] Confirm paperclip uses the secondary (muted) styling and send remains the primary (accent) styling.
- [ ] In a conversation with rapid back-and-forth (user → assistant → user → assistant within ~1 min), confirm the burst-timestamp separator (e.g. "just now" / "36 min ago") appears once per time bucket rather than between every role flip.
- [ ] Cross day boundaries: day separators ("Today …", "Yesterday …") still appear; they don't get deduped against burst labels because the labels differ.
- [ ] `yarn vitest run src/renderer/src/lib/message-grouping.test.ts src/renderer/src/lib/composer.test.ts` — green.

</details>

<details><summary>Implementation notes</summary>

- `VERTICAL_PADDING_PX` bumped 16 → 20 in `lib/composer.ts` so 1-row min-height matches the icon button (1 × 20px line + 20px padding = 40px). Textarea padding switches from `py-2` to `py-2.5` to match the new constant.
- `groupMessages` now tracks the last emitted separator label and skips the next push if the new label is identical. This catches both burst→burst (role transitions inside one time bucket) and burst→day separators only when they would actually collide — the formats differ enough in practice that day labels still render.
- New test covers the role-transition dedupe case end-to-end.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)