### PR TITLE
docs: move site to docs.getvoiceclaw.com

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -3,8 +3,7 @@ import starlight from '@astrojs/starlight'
 import mermaid from 'astro-mermaid'
 
 export default defineConfig({
-  site: 'https://yagudaev.github.io',
-  base: '/voiceclaw',
+  site: 'https://docs.getvoiceclaw.com',
   integrations: [
     mermaid({
       theme: 'dark',

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+docs.getvoiceclaw.com

--- a/docs/src/content/docs/development/releasing.mdx
+++ b/docs/src/content/docs/development/releasing.mdx
@@ -7,7 +7,7 @@ import { Aside, Steps } from '@astrojs/starlight/components'
 
 VoiceClaw uses [release-please](https://github.com/googleapis/release-please) to version its packages and maintain a changelog. You never hand-bump a `version` field or hand-write a changelog entry — release-please does both, driven entirely by your PR titles.
 
-This page is the **contributor** view: how your PR title turns into a version bump. For the maintainer view — what happens after the tag fires, signing, notarizing, publishing the DMG — see [Releasing the desktop app](/voiceclaw/desktop/releasing/).
+This page is the **contributor** view: how your PR title turns into a version bump. For the maintainer view — what happens after the tag fires, signing, notarizing, publishing the DMG — see [Releasing the desktop app](/desktop/releasing/).
 
 ## The flow in one picture
 
@@ -82,7 +82,7 @@ fix(website): correct /download status code
    - Pushes a git tag per bumped package (see [tag scheme](#tag-scheme) below).
    - Creates a GitHub Release for each tag with the changelog body.
 
-5. For desktop releases: the `v*.*.*` tag push triggers [`release-desktop.yml`](https://github.com/yagudaev/voiceclaw/blob/main/.github/workflows/release-desktop.yml), which builds, signs, notarizes, and attaches the DMG to the same GitHub Release. See [Releasing the desktop app](/voiceclaw/desktop/releasing/) for that half of the story.
+5. For desktop releases: the `v*.*.*` tag push triggers [`release-desktop.yml`](https://github.com/yagudaev/voiceclaw/blob/main/.github/workflows/release-desktop.yml), which builds, signs, notarizes, and attaches the DMG to the same GitHub Release. See [Releasing the desktop app](/desktop/releasing/) for that half of the story.
 
 </Steps>
 

--- a/docs/src/content/docs/guides/web-search.mdx
+++ b/docs/src/content/docs/guides/web-search.mdx
@@ -17,7 +17,7 @@ the model only sees `ask_brain` and `echo_tool`, and behaviour is unchanged.
 
 `ask_brain` is powerful but heavy. Each call hits the brain gateway, which can
 spawn a multi-step agent run, hit local exec gates, and stream back tokens. Per
-the [Brain Agent](/voiceclaw/relay-server#brain-agent) section, a `searching`
+the [Brain Agent](/relay-server#brain-agent) section, a `searching`
 status comes back immediately so the model can verbally bridge ("Let me check
 on that..."), and the result is injected into the next turn. This is the right
 shape for things like "create a task" or "what did I decide about X" — but it's

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: Voice interface for any AI. Talk to Gemini, OpenAI, and more through a unified relay server -- on your phone, on your Mac, or from any WebSocket client.
   actions:
     - text: Get Started
-      link: /voiceclaw/architecture/
+      link: /architecture/
       icon: right-arrow
     - text: View on GitHub
       link: https://github.com/yagudaev/voiceclaw
@@ -50,17 +50,17 @@ import { Card, CardGrid, Steps, Tabs, TabItem } from '@astrojs/starlight/compone
     TypeScript / Node.js WebSocket relay that translates between clients and AI providers.
     Handles brain agent calls, session management, and observability via Langfuse.
 
-    [Read the docs](/voiceclaw/relay-server/)
+    [Read the docs](/relay-server/)
   </Card>
   <Card title="Desktop App" icon="laptop">
     Electron + React + Tailwind macOS voice assistant with screen sharing capabilities.
 
-    [Read the docs](/voiceclaw/desktop-app/)
+    [Read the docs](/desktop-app/)
   </Card>
   <Card title="Mobile App" icon="star">
     React Native / Expo iOS voice assistant with native audio I/O and conversation history.
 
-    [Read the docs](/voiceclaw/mobile-app/)
+    [Read the docs](/mobile-app/)
   </Card>
 </CardGrid>
 
@@ -157,8 +157,8 @@ The relay server sits between clients and AI providers. It normalizes the differ
 
 ## Learn More
 
-- [Architecture](/voiceclaw/architecture/) -- detailed system design, audio flow, and session lifecycle
-- [Relay Server](/voiceclaw/relay-server/) -- WebSocket protocol reference, configuration, and brain agent
-- [Desktop App](/voiceclaw/desktop-app/) -- building from source, screen sharing, and settings
-- [Mobile App](/voiceclaw/mobile-app/) -- Expo build setup and iOS-specific notes
-- [Contributing](/voiceclaw/contributing/) -- development setup, code style, and branch strategy
+- [Architecture](/architecture/) -- detailed system design, audio flow, and session lifecycle
+- [Relay Server](/relay-server/) -- WebSocket protocol reference, configuration, and brain agent
+- [Desktop App](/desktop-app/) -- building from source, screen sharing, and settings
+- [Mobile App](/mobile-app/) -- Expo build setup and iOS-specific notes
+- [Contributing](/contributing/) -- development setup, code style, and branch strategy

--- a/docs/src/content/docs/relay-server.mdx
+++ b/docs/src/content/docs/relay-server.mdx
@@ -404,7 +404,7 @@ These tools are handled server-side (never forwarded to the client):
 
 - `echo_tool` -- test tool that echoes back input (useful for verifying the tool pipeline)
 - `ask_brain` -- async brain agent call (described above)
-- `web_search` -- fast public-web lookup via [Tavily](https://tavily.com). Only registered when a Tavily API key is available (session config `tavilyApiKey` or `TAVILY_API_KEY` env). See the [Web Search](/voiceclaw/guides/web-search) guide.
+- `web_search` -- fast public-web lookup via [Tavily](https://tavily.com). Only registered when a Tavily API key is available (session config `tavilyApiKey` or `TAVILY_API_KEY` env). See the [Web Search](/guides/web-search) guide.
 
 ## Watchdog
 


### PR DESCRIPTION
## Why

Moves the docs from `yagudaev.github.io/voiceclaw` to its own subdomain so the URL is shorter, brand-aligned, and not tied to a personal GitHub account namespace.

## Changes

- `docs/astro.config.mjs` — drops `base: '/voiceclaw'`, points `site` at `https://docs.getvoiceclaw.com`.
- `docs/public/CNAME` — new file telling GitHub Pages to serve on `docs.getvoiceclaw.com`.
- Internal doc links in 4 MDX files — strips the now-stale `/voiceclaw` prefix so navigation works at root.

External GitHub URLs (`github.com/yagudaev/voiceclaw/...`) are left untouched.

## DNS — required before this works

Add this record at the `getvoiceclaw.com` DNS provider:

| Type  | Name | Value                  |
| ----- | ---- | ---------------------- |
| CNAME | docs | yagudaev.github.io.    |

Then in repo Settings → Pages → Custom domain, GitHub will re-check and provision HTTPS.

## Test plan

- [x] `yarn build:docs` — 34 pages, no errors
- [ ] DNS CNAME added
- [ ] GitHub Pages "DNS check" turns green
- [ ] `https://docs.getvoiceclaw.com` loads with valid cert
- [ ] Spot-check a few internal links (architecture, relay-server, mobile-app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)