### PR TITLE
docs: cross-link marketing site and docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -68,6 +68,7 @@ export default defineConfig({
         baseUrl: 'https://github.com/yagudaev/voiceclaw/edit/main/docs/',
       },
       sidebar: [
+        { label: '← VoiceClaw home', link: 'https://getvoiceclaw.com' },
         { label: 'Home', slug: 'index' },
         {
           label: 'Getting Started',

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/lib/downloads"
 
 const REPO_URL = "https://github.com/yagudaev/voiceclaw"
+const DOCS_URL = "https://docs.getvoiceclaw.com"
 const MAC_DOWNLOAD_URL = "/download"
 const TESTFLIGHT_SIGNUP_URL = ""
 const DEMO_EMBED_URL = "https://www.youtube.com/embed/iAS7vj2vRaA"
@@ -65,6 +66,9 @@ function Header({
           <Link className="hidden hover:text-[var(--brand-ink)] sm:inline" href="#work">
             How it works
           </Link>
+          <a className="hidden hover:text-[var(--brand-ink)] sm:inline" href={DOCS_URL}>
+            Docs
+          </a>
           <Link className="hidden hover:text-[var(--brand-ink)] sm:inline" href="/download">
             Download
           </Link>
@@ -417,6 +421,9 @@ function Footer() {
       <div className="mx-auto flex max-w-7xl flex-col justify-between gap-5 text-sm text-[var(--brand-muted)] sm:flex-row sm:items-center">
         <BrandWordmark />
         <div className="flex gap-5">
+          <a href={DOCS_URL} className="hover:text-[var(--brand-ink)]">
+            Docs
+          </a>
           <Link href="/brand" className="hover:text-[var(--brand-ink)]">
             Brand guidelines
           </Link>


### PR DESCRIPTION
## Why

Now that docs live at `docs.getvoiceclaw.com` (separate subdomain), there was no way to get from marketing → docs or back. Adds the missing links.

## Changes

- `website/src/app/page.tsx` — adds "Docs" to the header nav (between "How it works" and "Download") and to the footer (before "Brand guidelines").
- `docs/astro.config.mjs` — prepends a `← VoiceClaw home` entry at the top of the sidebar that links to `https://getvoiceclaw.com`.

## Test plan

- [x] `yarn build:docs` — clean, 34 pages, sidebar entry rendered
- [x] `cd website && yarn build` — clean Next.js production build
- [ ] Smoke-check the rendered marketing header on Vercel preview
- [ ] Smoke-check the docs sidebar after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)